### PR TITLE
fixed color palette implementation, changed xic colors

### DIFF
--- a/src/main/java/io/github/mzmine/gui/chartbasics/chartthemes/ChartThemeParameters.java
+++ b/src/main/java/io/github/mzmine/gui/chartbasics/chartthemes/ChartThemeParameters.java
@@ -172,12 +172,12 @@ public class ChartThemeParameters extends SimpleParameterSet {
     FontSpecs large = this.getParameter(ChartThemeParameters.titleFont).getValue();
     FontSpecs medium = this.getParameter(ChartThemeParameters.captionFont).getValue();
     FontSpecs small = this.getParameter(ChartThemeParameters.labelFont).getValue();
-    Color gbColor = this.getParameter(ChartThemeParameters.color).getValue();
+    Color bgColor = this.getParameter(ChartThemeParameters.color).getValue();
 
     theme.setShowTitle(showTitle);
     theme.getShowSubtitles(showLegends);
-    theme.setChartBackgroundPaint(FxColorUtil.fxColorToAWT(gbColor));
-    theme.setPlotBackgroundPaint(FxColorUtil.fxColorToAWT(gbColor));
+    theme.setChartBackgroundPaint(FxColorUtil.fxColorToAWT(bgColor));
+    theme.setPlotBackgroundPaint(FxColorUtil.fxColorToAWT(bgColor));
 
     theme.setMasterFont(FxFontUtil.fxFontToAWT(master.getFont()));
     theme.setExtraLargeFont(FxFontUtil.fxFontToAWT(large.getFont()));

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_manual/XICManualPickerDialog.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_manual/XICManualPickerDialog.java
@@ -105,8 +105,8 @@ public class XICManualPickerDialog extends ParameterSetupDialog {
   public XICManualPickerDialog(boolean valueCheckRequired, ParameterSet parameters) {
     super(valueCheckRequired, parameters);
 
-    Color l = Color.rgb(50, 255, 50, 0.6);
-    Color u = l;
+    Color l = MZmineCore.getConfiguration().getDefaultColorPalette().get(1);
+    Color u = MZmineCore.getConfiguration().getDefaultColorPalette().get(2);
     Stroke stroke = new BasicStroke(1.0f);
 
     // make new panel, put tic into the middle of a border layout.

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/colorpalette/ColorPaletteCell.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/colorpalette/ColorPaletteCell.java
@@ -60,7 +60,6 @@ public class ColorPaletteCell extends ListCell<SimpleColorPalette> {
 
   /**
    * 
-   * @param w The width of the combo box.
    * @param h The height of the combo box.
    */
   public ColorPaletteCell(double h) {
@@ -82,16 +81,15 @@ public class ColorPaletteCell extends ListCell<SimpleColorPalette> {
 
     // nasty way to align the palettes in the dropdown menu
     label.setMinWidth(80);
-    label.setMaxWidth(80);
-    label.setPrefWidth(80);
+    label.setMaxWidth(150);
+    label.setPrefWidth(150);
     label.setAlignment(Pos.CENTER_LEFT);
 
-    // TODO usually this should result in a two line layout with the name in the first and the
     // palette in the second row...
     pane = new GridPane();
     pane.setBorder(new Border(new BorderStroke(BORDER_CLR, BorderStrokeStyle.SOLID,
         new CornerRadii(2.0), new BorderWidths(1.0))));
-    pane.add(clrPane, 1, 0);
+    pane.add(clrPane, 0, 1);
     pane.add(label, 0, 0);
   }
 

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/colorpalette/ColorPaletteComponent.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/colorpalette/ColorPaletteComponent.java
@@ -1,16 +1,16 @@
 /*
  * Copyright 2006-2020 The MZmine Development Team
- * 
+ *
  * This file is part of MZmine.
- * 
+ *
  * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
  * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
  * Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
  * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
  * USA
@@ -18,13 +18,14 @@
 
 package io.github.mzmine.parameters.parametertypes.colorpalette;
 
-import java.util.List;
-import java.util.logging.Logger;
+import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.color.ColorsFX;
 import io.github.mzmine.util.color.SimpleColorPalette;
 import io.github.mzmine.util.color.Vision;
-import javafx.geometry.Pos;
+import java.util.List;
+import java.util.logging.Logger;
+import javafx.collections.ListChangeListener;
 import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
 import javafx.scene.layout.FlowPane;
@@ -32,9 +33,8 @@ import javafx.scene.layout.GridPane;
 
 /**
  * Gui component for a SimpleColorPalette. Allows editing and selection of different palettes.
- * 
- * @author SteffenHeu steffen.heuckeroth@gmx.de / s_heuc03@uni-muenster.de
  *
+ * @author SteffenHeu steffen.heuckeroth@gmx.de / s_heuc03@uni-muenster.de
  */
 public class ColorPaletteComponent extends GridPane {
 
@@ -44,6 +44,8 @@ public class ColorPaletteComponent extends GridPane {
   protected Button addPalette;
   protected Button editPalette;
   protected Button deletePalette;
+  protected Button duplicatePalette;
+  protected Button addDefault;
   protected FlowPane pnButtons;
 
   public ColorPaletteComponent() {
@@ -58,17 +60,34 @@ public class ColorPaletteComponent extends GridPane {
     box.setMinHeight(35);
     box.setMaxHeight(35);
 
-    addPalette = new Button("New palette");
+    box.getItems().addListener((ListChangeListener<? super SimpleColorPalette>) e ->
+        logger.info("Item added" + e.toString()));
+
+    addPalette = new Button("New");
     addPalette.setOnAction(e -> {
-      SimpleColorPalette pal;
-      if(!itemsContainDefaultPalette()) {
-        pal = new SimpleColorPalette(ColorsFX.getSevenColorPalette(Vision.DEUTERANOPIA, true));
-        pal.setName("Deuternopia");
-      }
-      else
-        pal = new SimpleColorPalette();
+      SimpleColorPalette pal = new SimpleColorPalette();
       box.getItems().add(pal);
-      box.getSelectionModel().select(box.getItems().indexOf(pal));
+//      box.getSelectionModel().select(box.getItems().indexOf(pal));
+//      box.setValue(pal);
+    });
+
+    duplicatePalette = new Button("Duplicate");
+    duplicatePalette.setOnAction(e -> {
+      SimpleColorPalette pal = box.getValue();
+      if (pal == null) {
+        logger.warning("No color palette selected. Cannot duplicate.");
+        return;
+      }
+
+      SimpleColorPalette newPal = pal.clone();
+      newPal.setName(pal.getName() + " (cpy)");
+      if (addPalette(newPal)) {
+        box.setValue(newPal);
+      }
+
+      logger.info("index of new value: " + box.getItems().indexOf(newPal));
+      logger.info("hash - old: " + pal.hashCode() + " new: " + newPal.hashCode());
+
     });
 
     editPalette = new Button("Edit");
@@ -78,9 +97,22 @@ public class ColorPaletteComponent extends GridPane {
 
       d.setOnHiding(f -> {
         if (d.getExitCode() == ExitCode.OK) {
-          box.getItems().remove(box.getValue());
+          // remove old
+          SimpleColorPalette oldVal = box.getValue();
+          box.getItems().remove(oldVal);
+
+          // check for existing duplicates, if present add old value again
           SimpleColorPalette newVal = d.getPalette();
-          box.getItems().add(newVal);
+          if (!addPalette(newVal)) {
+            addPalette(oldVal);
+            setValue(oldVal);
+            MZmineCore.getDesktop().displayErrorMessage(
+                "Cannot add duplicates. Palette with same name and colors already exists.");
+
+            d.show();
+//          return;
+          }
+
           setValue(newVal);
         }
       });
@@ -88,13 +120,27 @@ public class ColorPaletteComponent extends GridPane {
 
     deletePalette = new Button("Delete");
     deletePalette.setOnAction(e -> {
+      if (box.getItems().size() <= 1) {
+        logger.warning(
+            "Cannot remove palettes. Only 1 palette present. Please add a new palette first.");
+        return;
+      }
       box.getItems().remove(box.getValue());
       box.setValue(box.getItems().get(0));
     });
 
+    addDefault = new Button("Add default");
+    addDefault.setOnAction(e -> {
+      SimpleColorPalette pal;
+      pal = new SimpleColorPalette(ColorsFX.getSevenColorPalette(Vision.DEUTERANOPIA, true));
+      pal.setName("Deuternopia");
+      addPalette(pal);
+    });
+
     pnButtons = new FlowPane();
-    pnButtons.getChildren().addAll(addPalette, editPalette, deletePalette);
-    
+    pnButtons.getChildren()
+        .addAll(addPalette, duplicatePalette, editPalette, deletePalette, addDefault);
+
     add(box, 0, 0);
     add(pnButtons, 0, 1);
   }
@@ -104,9 +150,10 @@ public class ColorPaletteComponent extends GridPane {
   }
 
   public void setValue(SimpleColorPalette value) {
-    if (box.getItems().indexOf(value) == -1)
+    if (box.getItems().indexOf(value) == -1) {
       logger.warning("Value of ColorPaletteComponent was set to a value not contained "
           + "in the items. This might lead to unexpected behaviour.");
+    }
     box.setValue(value);
     box.autosize();
   }
@@ -116,23 +163,36 @@ public class ColorPaletteComponent extends GridPane {
   }
 
   public void setPalettes(List<SimpleColorPalette> list) {
-    if (list.isEmpty())
+    if (list.isEmpty()) {
       return;
+    }
 
     box.getItems().clear();
-    for (SimpleColorPalette p : list)
+    for (SimpleColorPalette p : list) {
       box.getItems().add(p);
+    }
   }
 
   protected boolean itemsContainDefaultPalette() {
     List<SimpleColorPalette> items = box.getItems();
     SimpleColorPalette def = new SimpleColorPalette(
         ColorsFX.getSevenColorPalette(Vision.DEUTERANOPIA, true));
-    for(SimpleColorPalette p : items)
-      if(p.equals(def))
+    for (SimpleColorPalette p : items) {
+      if (p.equals(def)) {
         return true;
-    
+      }
+    }
+
     return false;
+  }
+
+  public boolean addPalette(SimpleColorPalette pal) {
+    if (box.getItems().contains(pal)) {
+      logger.fine("Cannot add duplicates. A palette with same name and colors already exists.");
+      return false;
+    }
+
+    return box.getItems().add(pal);
   }
 }
 

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/colorpalette/ColorPaletteParameter.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/colorpalette/ColorPaletteParameter.java
@@ -71,7 +71,7 @@ public class ColorPaletteParameter
 
   @Override
   public boolean checkValue(Collection<String> errorMessages) {
-    if(!getValue().isValidPalette()) {
+    if(getValue() == null || !getValue().isValidPalette()) {
       errorMessages.add("Not enough colors in color palette " + getName());
       return false;
     }

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/colorpalette/ColorPalettePickerDialog.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/colorpalette/ColorPalettePickerDialog.java
@@ -94,7 +94,6 @@ public class ColorPalettePickerDialog extends Stage {
       if (colorPicker.getValue() != null) {
         int selected = pnPalette.getSelected();
         this.palette.set(selected, colorPicker.getValue());
-//        pnPalette.updatePreview();
       }
     });
 
@@ -122,7 +121,7 @@ public class ColorPalettePickerDialog extends Stage {
 
   private void hideWindow(ExitCode exitCode) {
     String name = txtName.getText();
-    if(name == null)
+    if(name == null || name == "")
       name = "unnamed";
     palette.setName(name);
     this.exitCode = exitCode;

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/colorpalette/ColorPalettePreviewField.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/colorpalette/ColorPalettePreviewField.java
@@ -55,12 +55,7 @@ public class ColorPalettePreviewField extends FlowPane {
     
     validDrag = false;
     
-    palette.addListener(new ListChangeListener<Color> () {
-      @Override
-      public void onChanged(Change<? extends Color> c) {
-        updatePreview();
-      }
-    });
+    palette.addListener((ListChangeListener<Color>) c -> updatePreview());
   }
 
   private void setRectangles() {


### PR DESCRIPTION
Hey Tomas,
this deals with duplication in the list of color palettes and adds a button to add the default palette.
Also, this sets the colors during manual integration to the second and third color in the palette. The lines have been set to the same color before, was that intentional? If yes, i'll remove that from here.

Best
Steffen