### PR TITLE
Added getDataPolarity to RawDataFile

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/RawDataFile.java
+++ b/src/main/java/io/github/mzmine/datamodel/RawDataFile.java
@@ -20,8 +20,8 @@ package io.github.mzmine.datamodel;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
 import com.google.common.collect.Range;
+import java.util.List;
 
 public interface RawDataFile {
 
@@ -106,6 +106,14 @@ public interface RawDataFile {
   public double getDataMaxBasePeakIntensity(int msLevel);
 
   public double getDataMaxTotalIonCurrent(int msLevel);
+
+  /**
+   * Returns a list of the different scan polarity types found in the raw data file.
+   * 
+   * @return Scan polarity types.
+   */
+  @Nonnull
+  public List<PolarityType> getDataPolarity();
 
   /**
    * Close the file in case it is removed from the project

--- a/src/main/java/io/github/mzmine/modules/io/rawdataimport/fileformats/MzMLReadTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/rawdataimport/fileformats/MzMLReadTask.java
@@ -36,6 +36,7 @@ import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.ExceptionUtils;
 import io.github.mzmine.util.scans.ScanUtils;
+import java.util.logging.Level;
 import uk.ac.ebi.jmzml.model.mzml.BinaryDataArray;
 import uk.ac.ebi.jmzml.model.mzml.BinaryDataArrayList;
 import uk.ac.ebi.jmzml.model.mzml.CVParam;
@@ -176,6 +177,12 @@ public class MzMLReadTask extends AbstractTask {
       }
 
       finalRawDataFile = newMZmineFile.finishWriting();
+
+      if (logger.isLoggable(Level.FINEST)) {
+        List<PolarityType> polarities = finalRawDataFile.getDataPolarity();
+        logger.finest("Scan polarities of file " + file + ": " + polarities);
+      }
+
       project.addFile(finalRawDataFile);
 
     } catch (Throwable e) {

--- a/src/main/java/io/github/mzmine/project/impl/RawDataFileImpl.java
+++ b/src/main/java/io/github/mzmine/project/impl/RawDataFileImpl.java
@@ -41,10 +41,13 @@ import com.google.common.collect.Range;
 import com.google.common.primitives.Ints;
 import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.MassList;
+import io.github.mzmine.datamodel.PolarityType;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.RawDataFileWriter;
 import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.impl.SimpleDataPoint;
+import java.util.EnumSet;
+import java.util.stream.Collectors;
 
 /**
  * RawDataFile implementation. It provides storage of data points for scans and mass lists using the
@@ -471,7 +474,7 @@ public class RawDataFileImpl implements RawDataFile, RawDataFileWriter {
       dataMZRange.put(msLevel, mzRange);
     else
       mzRange = Range.singleton(0.0);
-
+    
     return mzRange;
 
   }
@@ -544,6 +547,19 @@ public class RawDataFileImpl implements RawDataFile, RawDataFileWriter {
 
   public synchronized TreeMap<Integer, Integer> getDataPointsLengths() {
     return dataPointsLengths;
+  }
+
+  @Override
+  public List<PolarityType> getDataPolarity() {
+    Enumeration<StorableScan> scansEnum = scans.elements();
+    // create an enum set to store different polarity types encountered within the file
+    EnumSet<PolarityType> polarityTypes = EnumSet.noneOf(PolarityType.class);
+    while (scansEnum.hasMoreElements()) {
+      Scan scan = scansEnum.nextElement();
+      polarityTypes.add(scan.getPolarity());
+    }
+    // return as list
+    return polarityTypes.stream().collect(Collectors.toList());
   }
 
   @Override


### PR DESCRIPTION
To allow retrieval of overall scan polarities for mzTab-M export, e.g. POSITIVE, NEGATIVE, or a mix of both need to be available. This pull request adds this functionality.