### PR TITLE
Modular annotation type, SpectralLibraryMatchType, Fix MS2 and feature conversion

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/features/Feature.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/Feature.java
@@ -63,7 +63,7 @@ public interface Feature {
   /**
    * Returns raw data file where this feature is present
    */
-  @Nonnull
+  @Nullable
   RawDataFile getRawDataFile();
 
   /**

--- a/src/main/java/io/github/mzmine/datamodel/features/FeatureListRow.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/FeatureListRow.java
@@ -23,6 +23,7 @@ import io.github.mzmine.datamodel.IsotopePattern;
 import io.github.mzmine.datamodel.FeatureInformation;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
 import javafx.collections.ObservableList;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -206,7 +207,6 @@ public interface FeatureListRow {
    */
   public IsotopePattern getBestIsotopePattern();
 
-  // DorresteinLaB edit
   /**
    * reset the rowID
    */
@@ -217,5 +217,8 @@ public interface FeatureListRow {
 
   void setFeatureList(@Nonnull FeatureList flist);
 
-  // End DorresteinLab edit
+  default void addSpectralLibraryMatch(SpectralDBFeatureIdentity id) {
+    addFeatureIdentity(id, false);
+  }
+
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularDataModel.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularDataModel.java
@@ -213,6 +213,8 @@ public interface ModularDataModel {
       property = realType.createProperty();
       setProperty(realType, property);
     }
+    if(value instanceof Property)
+      value = ((Property)value).getValue();
 
     // lists need to be ObservableList
     if (value instanceof List && !(value instanceof ObservableList))

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularDataModel.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularDataModel.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.datamodel.features;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.List;
 import java.util.Map;
@@ -98,7 +99,6 @@ public interface ModularDataModel {
   /**
    * Value for this datatype
    * 
-   * @param <T>
    * @param type
    * @return
    */
@@ -109,7 +109,6 @@ public interface ModularDataModel {
   /**
    * Value for this datatype
    * 
-   * @param <T>
    * @param tclass
    * @return
    */
@@ -169,7 +168,6 @@ public interface ModularDataModel {
    * FeatureList). To set the value of wrapping Property<?> call
    * {@link ModularDataModel#set(Class, Object)}
    * 
-   * @param <T>
    * @param type
    * @param value
    */
@@ -204,11 +202,18 @@ public interface ModularDataModel {
    */
   default <T extends Property<?>> void set(Class<? extends DataType<T>> tclass, Object value) {
     // type in defined columns?
-    if (!getTypes().containsKey(tclass))
+    if (!getTypes().containsKey(tclass)) {
       throw new TypeColumnUndefinedException(this, tclass);
+    }
 
     DataType realType = getTypeColumn(tclass);
     Property property = get(realType);
+    // TODO check if good - init property if not there
+    if(property == null) {
+      property = realType.createProperty();
+      setProperty(realType, property);
+    }
+
     // lists need to be ObservableList
     if (value instanceof List && !(value instanceof ObservableList))
       property.setValue(FXCollections.observableList((List) value));

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularDataModel.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularDataModel.java
@@ -228,8 +228,7 @@ public interface ModularDataModel {
   /**
    * Should only be called whenever a DataType column is removed from this model. To remove the
    * value of the underlying Property<?> call {@link ModularDataModel#set(DataType, Object)}
-   * 
-   * @param <T>
+   *  @param <T>
    * @param tclass
    */
   default <T extends Property<?>> void removeProperty(Class<? extends DataType<T>> tclass) {

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeature.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeature.java
@@ -72,13 +72,12 @@ public class ModularFeature implements Feature, ModularDataModel {
    * Initializes a new feature using given values
    *
    */
-  public ModularFeature(RawDataFile dataFile, double mz, float rt, float height, float area,
+  public ModularFeature(ModularFeatureList flist, RawDataFile dataFile, double mz, float rt, float height, float area,
       int[] scanNumbers, DataPoint[] dataPointsPerScan, FeatureStatus featureStatus,
       int representativeScan, int fragmentScanNumber, int[] allMS2FragmentScanNumbers,
       @Nonnull Range<Float> rtRange, @Nonnull Range<Double> mzRange,
       @Nonnull Range<Float> intensityRange) {
-
-    this(new ModularFeatureList("", dataFile));
+    this(flist);
 
     assert dataFile != null;
     assert scanNumbers != null;
@@ -127,25 +126,11 @@ public class ModularFeature implements Feature, ModularDataModel {
   }
 
   /**
-   * Initializes a new feature using given feature list and values
-   *
-   */
-  public ModularFeature(@Nonnull ModularFeatureList featureList, RawDataFile dataFile, double mz, float rt,
-      float height, float area, int[] scanNumbers, DataPoint[] dataPointsPerScan, FeatureStatus featureStatus,
-      int representativeScan, int fragmentScanNumber, int[] allMS2FragmentScanNumbers,
-      @Nonnull Range<Float> rtRange, @Nonnull Range<Double> mzRange,
-      @Nonnull Range<Float> intensityRange) {
-    this(dataFile, mz, rt, height, area, scanNumbers, dataPointsPerScan, featureStatus, representativeScan,
-        fragmentScanNumber, allMS2FragmentScanNumbers, rtRange, mzRange, intensityRange);
-    setFeatureList(featureList);
-  }
-
-  /**
    * Copy constructor
    */
-  public ModularFeature(@Nonnull Feature f) {
-    this((ModularFeatureList) Objects.requireNonNull(f.getFeatureList()), f);
-  }
+//  public ModularFeature(@Nonnull Feature f) {
+//    this((ModularFeatureList) Objects.requireNonNull(f.getFeatureList()), f);
+//  }
 
   /**
    * Copy constructor with custom feature list
@@ -396,10 +381,12 @@ public class ModularFeature implements Feature, ModularDataModel {
     return get(DataPointsType.class);
   }
 
-  @Nonnull
+  @Nullable
   @Override
   public RawDataFile getRawDataFile() {
     ObjectProperty<RawDataFile> raw = get(RawFileType.class);
+    if(raw==null)
+      return null;
     return raw.getValue();
   }
 

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeature.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeature.java
@@ -29,6 +29,7 @@ import io.github.mzmine.modules.tools.qualityparameters.QualityParameters;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -224,23 +225,31 @@ public class ModularFeature implements Feature, ModularDataModel {
   @Nonnull
   @Override
   public Range<Float> getRawDataPointsRTRange() {
+    if(!hasTypeColumn(RTRangeType.class))
+      return Range.singleton(0f);
     return get(RTRangeType.class).getValue();
   }
 
   @Nonnull
   @Override
   public Range<Double> getRawDataPointsMZRange() {
+    if(!hasTypeColumn(MZRangeType.class))
+      return Range.singleton(0d);
     return get(MZRangeType.class).getValue();
   }
 
   @Nonnull
   @Override
   public Range<Float> getRawDataPointsIntensityRange() {
+    if(!hasTypeColumn(IntensityRangeType.class))
+      return Range.singleton(0f);
     return get(IntensityRangeType.class).getValue();
   }
 
   @Override
   public int getMostIntenseFragmentScanNumber() {
+    if(!hasTypeColumn(BestFragmentScanNumberType.class))
+      return -1;
     return get(BestFragmentScanNumberType.class).getValue();
   }
 
@@ -251,6 +260,8 @@ public class ModularFeature implements Feature, ModularDataModel {
 
   @Override
   public ObservableList<Integer> getAllMS2FragmentScanNumbers() {
+    if(!hasTypeColumn(FragmentScanNumbersType.class))
+      return FXCollections.emptyObservableList();
     return get(FragmentScanNumbersType.class).getValue();
   }
 
@@ -262,6 +273,8 @@ public class ModularFeature implements Feature, ModularDataModel {
   @Nullable
   @Override
   public IsotopePattern getIsotopePattern() {
+    if(!hasTypeColumn(IsotopePatternType.class))
+      return null;
     return get(IsotopePatternType.class).getValue();
   }
 
@@ -352,6 +365,8 @@ public class ModularFeature implements Feature, ModularDataModel {
 
   @Override
   public SimpleFeatureInformation getFeatureInformation() {
+    if(!hasTypeColumn(FeatureInformationType.class))
+      return null;
     return get(FeatureInformationType.class).getValue();
   }
 
@@ -400,6 +415,8 @@ public class ModularFeature implements Feature, ModularDataModel {
   @Nonnull
   @Override
   public ObservableList<Integer> getScanNumbers() {
+    if(!hasTypeColumn(ScanNumbersType.class))
+      return FXCollections.emptyObservableList();
     return get(ScanNumbersType.class).getValue();
   }
 
@@ -410,33 +427,47 @@ public class ModularFeature implements Feature, ModularDataModel {
 
   @Override
   public int getRepresentativeScanNumber() {
+    if(!hasTypeColumn(BestScanNumberType.class))
+      return -1;
     return get(BestScanNumberType.class).getValue();
   }
 
   @Override
   public ObservableList<DataPoint> getDataPoints() {
+    if(!hasTypeColumn(DataPointsType.class))
+      return FXCollections.emptyObservableList();
     return get(DataPointsType.class).getValue();
   }
 
   public float getRT() {
+    if(!hasTypeColumn(RTType.class))
+      return Float.NaN;
     return get(RTType.class).getValue();
   }
 
   @Nonnull
   @Override
   public FeatureStatus getFeatureStatus() {
+    if(!hasTypeColumn(RTType.class))
+      return FeatureStatus.UNKNOWN;
     return get(DetectionType.class).getValue();
   }
 
   public double getMZ() {
+    if(!hasTypeColumn(MZType.class))
+      return Double.NaN;
     return get(MZType.class).getValue();
   }
 
   public float getHeight() {
+    if(!hasTypeColumn(HeightType.class))
+      return Float.NaN;
     return get(HeightType.class).getValue();
   }
 
   public float getArea() {
+    if(!hasTypeColumn(AreaType.class))
+      return Float.NaN;
     return get(AreaType.class).getValue();
   }
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeature.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeature.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import javafx.collections.MapChangeListener;
 import javafx.collections.ObservableList;
 import javax.annotation.Nonnull;
 import com.google.common.collect.Range;
@@ -65,6 +66,20 @@ public class ModularFeature implements Feature, ModularDataModel {
     flist.getFeatureTypes().values().forEach(type -> {
       this.setProperty(type, type.createProperty());
     });
+
+    // register listener to types map to automatically generate default properties for new DataTypes
+    flist.getFeatureTypes().addListener(
+        (MapChangeListener<? super Class<? extends DataType>, ? super DataType>) change -> {
+          if(change.wasAdded()) {
+            // add type columns to maps
+            DataType type = change.getValueAdded();
+            this.setProperty(type, type.createProperty());
+          } else if(change.wasRemoved()) {
+            // remove type columns to maps
+            DataType<Property<?>> type = change.getValueRemoved();
+            this.removeProperty((Class<DataType<Property<?>>>) type.getClass());
+          }
+        });
   }
 
   // NOT TESTED

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeature.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeature.java
@@ -152,36 +152,43 @@ public class ModularFeature implements Feature, ModularDataModel {
    */
   public ModularFeature(@Nonnull ModularFeatureList flist, Feature f) {
     this(flist);
-    // add values to feature
-    set(ScanNumbersType.class, f.getScanNumbers());
-    set(RawFileType.class, (f.getRawDataFile()));
-    set(DetectionType.class, (f.getFeatureStatus()));
-    set(MZType.class, (f.getMZ()));
-    set(RTType.class, (f.getRT()));
-    set(HeightType.class, (f.getHeight()));
-    set(AreaType.class, (f.getArea()));
-    set(BestScanNumberType.class, (f.getRepresentativeScanNumber()));
-
-    // datapoints of feature
-    set(DataPointsType.class, f.getDataPoints());
-
-    // ranges
-    set(MZRangeType.class, f.getRawDataPointsMZRange());
-    set(RTRangeType.class, f.getRawDataPointsRTRange());
-    set(IntensityRangeType.class, f.getRawDataPointsIntensityRange());
-
-    // quality parameters
-    float fwhm = f.getFWHM();
-    if(!Float.isNaN(fwhm)) {
-      set(FwhmType.class, fwhm);
+    if(f instanceof ModularFeature) {
+      ((ModularFeature) f).stream().forEach(entry -> this.set(entry.getKey(), entry.getValue()));
     }
-    float tf = f.getTailingFactor();
-    if(!Float.isNaN(tf)) {
-      set(TailingFactorType.class, tf);
-    }
-    float af = f.getAsymmetryFactor();
-    if(!Float.isNaN(af)) {
-      set(AsymmetryFactorType.class, af);
+    else {
+      // add values to feature
+      set(ScanNumbersType.class, f.getScanNumbers());
+      set(RawFileType.class, (f.getRawDataFile()));
+      set(DetectionType.class, (f.getFeatureStatus()));
+      set(MZType.class, (f.getMZ()));
+      set(RTType.class, (f.getRT()));
+      set(HeightType.class, (f.getHeight()));
+      set(AreaType.class, (f.getArea()));
+      set(BestScanNumberType.class, (f.getRepresentativeScanNumber()));
+      set(BestFragmentScanNumberType.class, (f.getMostIntenseFragmentScanNumber()));
+      set(FragmentScanNumbersType.class, (f.getAllMS2FragmentScanNumbers()));
+
+      // datapoints of feature
+      set(DataPointsType.class, f.getDataPoints());
+
+      // ranges
+      set(MZRangeType.class, f.getRawDataPointsMZRange());
+      set(RTRangeType.class, f.getRawDataPointsRTRange());
+      set(IntensityRangeType.class, f.getRawDataPointsIntensityRange());
+
+      // quality parameters
+      float fwhm = f.getFWHM();
+      if (!Float.isNaN(fwhm)) {
+        set(FwhmType.class, fwhm);
+      }
+      float tf = f.getTailingFactor();
+      if (!Float.isNaN(tf)) {
+        set(TailingFactorType.class, tf);
+      }
+      float af = f.getAsymmetryFactor();
+      if (!Float.isNaN(af)) {
+        set(AsymmetryFactorType.class, af);
+      }
     }
   }
 

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureList.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureList.java
@@ -3,13 +3,8 @@ package io.github.mzmine.datamodel.features;
 import io.github.mzmine.datamodel.features.types.AreaBarType;
 import io.github.mzmine.datamodel.features.types.AreaShareType;
 import io.github.mzmine.datamodel.features.types.FeatureShapeType;
-import io.github.mzmine.datamodel.features.types.numbers.AsymmetryFactorType;
-import io.github.mzmine.datamodel.features.types.numbers.FwhmType;
-import io.github.mzmine.datamodel.features.types.numbers.MZRangeType;
-import io.github.mzmine.datamodel.features.types.numbers.MZType;
-import io.github.mzmine.datamodel.features.types.numbers.RTRangeType;
-import io.github.mzmine.datamodel.features.types.numbers.RTType;
-import io.github.mzmine.datamodel.features.types.numbers.TailingFactorType;
+import io.github.mzmine.datamodel.features.types.modifiers.BindingsType;
+import io.github.mzmine.datamodel.features.types.numbers.*;
 import io.github.mzmine.util.DataTypeUtils;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -30,7 +25,6 @@ import io.github.mzmine.datamodel.features.types.CommentType;
 import io.github.mzmine.datamodel.features.types.DataType;
 import io.github.mzmine.datamodel.features.types.FeaturesType;
 import io.github.mzmine.datamodel.features.types.RawFileType;
-import io.github.mzmine.datamodel.features.types.numbers.IDType;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableMap;
 
@@ -98,6 +92,16 @@ public class ModularFeatureList implements FeatureList {
       addFeatureType(new AsymmetryFactorType());
     }
     addRowType(new CommentType());
+
+    // add standard row bindings even if data types are missing
+    addRowBinding(new RowBinding(new MZType(), BindingsType.AVERAGE));
+    addRowBinding(new RowBinding(new RTType(), BindingsType.AVERAGE));
+    addRowBinding(new RowBinding(new HeightType(), BindingsType.MAX));
+    addRowBinding(new RowBinding(new AreaType(), BindingsType.MAX));
+    addRowBinding(new RowBinding(new RTRangeType(), BindingsType.RANGE));
+    addRowBinding(new RowBinding(new MZRangeType(), BindingsType.RANGE));
+    addRowBinding(new RowBinding(new IntensityRangeType(), BindingsType.RANGE));
+    addRowBinding(new RowBinding(new ChargeType(), BindingsType.CONSENSUS));
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureList.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureList.java
@@ -463,6 +463,9 @@ public class ModularFeatureList implements FeatureList {
   //  a private variable during rows initialization
   @Override
   public Range<Double> getRowsMZRange() {
+    if(getRows().isEmpty())
+      return Range.singleton(0d);
+
     updateMaxIntensity(); // Update range before returning value
 
     DoubleSummaryStatistics mzStatistics = getRows().stream()
@@ -476,6 +479,9 @@ public class ModularFeatureList implements FeatureList {
   //  a private variable during rows initialization
   @Override
   public Range<Float> getRowsRTRange() {
+    if(getRows().isEmpty())
+      return Range.singleton(0f);
+
     updateMaxIntensity(); // Update range before returning value
 
     DoubleSummaryStatistics rtStatistics = getRows().stream()

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureList.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureList.java
@@ -72,27 +72,6 @@ public class ModularFeatureList implements FeatureList {
     descriptionOfAppliedTasks = FXCollections.observableArrayList();
     dateCreated = DATA_FORMAT.format(new Date());
 
-    // Type columns will be ordered in the order of types initialization
-    addRowType(new IDType());
-    addRowType(new MZType());
-    addRowType(new MZRangeType());
-    addRowType(new RTType());
-    addRowType(new RTRangeType());
-    DataTypeUtils.addDefaultChromatographicTypeColumns(this);
-
-    addRowType(new FeatureShapeType());
-    addRowType(new AreaBarType());
-    addRowType(new AreaShareType());
-    // has raw files - add column to row and feature
-    if (!dataFiles.isEmpty()) {
-      addRowType(new FeaturesType());
-      addFeatureType(new RawFileType());
-      addFeatureType(new FwhmType());
-      addFeatureType(new TailingFactorType());
-      addFeatureType(new AsymmetryFactorType());
-    }
-    addRowType(new CommentType());
-
     // add standard row bindings even if data types are missing
     addRowBinding(new RowBinding(new MZType(), BindingsType.AVERAGE));
     addRowBinding(new RowBinding(new RTType(), BindingsType.AVERAGE));

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureList.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureList.java
@@ -131,11 +131,8 @@ public class ModularFeatureList implements FeatureList {
   public void addFeatureType(@Nonnull List<DataType<?>> types) {
     for (DataType<?> type : types) {
       if (!featureTypes.containsKey(type.getClass())) {
+        // all {@link ModularFeature} will automatically add a default property to their data map
         featureTypes.put(type.getClass(), type);
-        // add to maps
-        modularStreamFeatures().forEach(f -> {
-          f.setProperty(type, type.createProperty());
-        });
       }
     }
   }
@@ -147,11 +144,9 @@ public class ModularFeatureList implements FeatureList {
   public void addRowType(@Nonnull List<DataType<?>> types) {
     for (DataType<?> type : types) {
       if (!rowTypes.containsKey(type.getClass())) {
+        // add row type - all rows will automatically generate a default property for this type in
+        // their data map
         rowTypes.put(type.getClass(), type);
-        // add type columns to maps
-        modularStream().forEach(row -> {
-          row.setProperty(type, type.createProperty());
-        });
       }
     }
   }

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureList.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureList.java
@@ -41,10 +41,12 @@ public class ModularFeatureList implements FeatureList {
   // using LinkedHashMaps to save columns order according to the constructor
   private final LinkedHashMap<Class<? extends DataType>, DataType> rowTypesLinkedMap =
       new LinkedHashMap<>();
+  // TODO do we need two maps? We could have ObservableMap of LinkedHashMap
   private ObservableMap<Class<? extends DataType>, DataType> rowTypes;
 
   private final LinkedHashMap<Class<? extends DataType>, DataType> featureTypesLinkedMap =
       new LinkedHashMap<>();
+  // TODO do we need two maps? We could have ObservableMap of LinkedHashMap
   private ObservableMap<Class<? extends DataType>, DataType> featureTypes;
 
   // bindings for values

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureListRow.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureListRow.java
@@ -19,14 +19,14 @@
 package io.github.mzmine.datamodel.features;
 
 import com.google.common.collect.Range;
+import com.microsoft.schemas.office.visio.x2012.main.RowType;
 import io.github.mzmine.datamodel.FeatureIdentity;
 import io.github.mzmine.datamodel.FeatureInformation;
 import io.github.mzmine.datamodel.IsotopePattern;
 import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.types.*;
 import io.github.mzmine.datamodel.features.types.exceptions.TypeColumnUndefinedException;
-import io.github.mzmine.datamodel.features.types.numbers.MZRangeType;
-import io.github.mzmine.datamodel.features.types.numbers.MZType;
+import io.github.mzmine.datamodel.features.types.numbers.*;
 import io.github.mzmine.util.FeatureSorter;
 import io.github.mzmine.util.SortingDirection;
 import io.github.mzmine.util.SortingProperty;
@@ -42,14 +42,11 @@ import java.util.Objects;
 import java.util.stream.Stream;
 
 import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
+import javafx.beans.property.ObjectProperty;
 import javafx.collections.ObservableList;
 import javax.annotation.Nonnull;
 import io.github.mzmine.datamodel.FeatureStatus;
 import io.github.mzmine.datamodel.RawDataFile;
-import io.github.mzmine.datamodel.features.types.numbers.AreaType;
-import io.github.mzmine.datamodel.features.types.numbers.HeightType;
-import io.github.mzmine.datamodel.features.types.numbers.IDType;
-import io.github.mzmine.datamodel.features.types.numbers.RTType;
 import javafx.beans.property.MapProperty;
 import javafx.beans.property.Property;
 import javafx.collections.FXCollections;
@@ -81,21 +78,6 @@ public class ModularFeatureListRow implements FeatureListRow, ModularDataModel {
 
   // buffert col charts and nodes
   private final Map<String, Node> buffertColCharts = new HashMap<>();
-
-  private ObservableList<FeatureIdentity> identities = FXCollections.observableArrayList();
-  private FeatureIdentity preferredIdentity;
-  private String comment;
-  private double maxDataPointIntensity;
-
-  /**
-   * These variables are used for caching the average values, so we don't need to calculate them
-   * again and again
-   */
-  private double averageMZ, averageHeight, averageArea;
-  private float averageRT;
-  private int rowCharge;
-
-  private FeatureInformation featureInformation;
 
   public ModularFeatureListRow(@Nonnull ModularFeatureList flist) {
     this.flist = flist;
@@ -262,11 +244,6 @@ public class ModularFeatureListRow implements FeatureListRow, ModularDataModel {
     }
 
     modularFeature.setFeatureList(flist);
-
-    if (modularFeature.getRawDataPointsIntensityRange().upperEndpoint() > maxDataPointIntensity)
-      maxDataPointIntensity = modularFeature.getRawDataPointsIntensityRange().upperEndpoint();
-
-    calculateAverageValues();
   }
 
   /**
@@ -288,32 +265,41 @@ public class ModularFeatureListRow implements FeatureListRow, ModularDataModel {
   @Override
   public void removeFeature(RawDataFile file) {
     this.features.remove(file);
-    calculateAverageValues();
   }
 
   @Override
   public double getAverageMZ() {
-    return averageMZ;
+    if(!hasTypeColumn(MZType.class))
+      return Double.NaN;
+    return get(MZType.class).getValue();
   }
 
   @Override
   public float getAverageRT() {
-    return averageRT;
+    if(!hasTypeColumn(RTType.class))
+      return Float.NaN;
+    return get(RTType.class).getValue();
   }
 
   @Override
   public double getAverageHeight() {
-    return averageHeight;
+    if(!hasTypeColumn(HeightType.class))
+      return Double.NaN;
+    return get(HeightType.class).getValue();
   }
 
   @Override
   public int getRowCharge() {
-    return rowCharge;
+    if(!hasTypeColumn(ChargeType.class))
+      return 0;
+    return get(ChargeType.class).getValue();
   }
 
   @Override
   public double getAverageArea() {
-    return averageArea;
+    if(!hasTypeColumn(AreaType.class))
+      return Double.NaN;
+    return get(AreaType.class).getValue();
   }
 
   @Override
@@ -374,44 +360,51 @@ public class ModularFeatureListRow implements FeatureListRow, ModularDataModel {
   }
 
   public String getComment() {
-    return comment;
+    if(!hasTypeColumn(CommentType.class))
+      return "";
+    return get(CommentType.class).getValue();
   }
 
   public void setComment(String comment) {
-    this.comment = comment;
+    set(CommentType.class, comment);
   }
 
   @Override
   public void setAverageMZ(double averageMZ) {
-    this.averageMZ = averageMZ;
+    // binding
   }
 
   @Override
   public void setAverageRT(float averageRT) {
-    this.averageRT = averageRT;
+    // binding
   }
 
   @Override
   public ObservableList<FeatureIdentity> getPeakIdentities() {
-    return identities;
+    if(!hasTypeColumn(IdentityType.class))
+      return FXCollections.emptyObservableList();
+    return get(IdentityType.class);
   }
 
   public void setPeakIdentities(ObservableList<FeatureIdentity> identities) {
-    this.identities = identities;
+    set(IdentityType.class, identities);
   }
 
   @Override
   public void addFeatureIdentity(FeatureIdentity identity, boolean preferred) {
     // Verify if exists already an identity with the same name
-    for (FeatureIdentity testId : identities) {
+    ObservableList<FeatureIdentity> peakIdentities = getPeakIdentities();
+    for (FeatureIdentity testId : peakIdentities) {
       if (testId.getName().equals(identity.getName())) {
         return;
       }
     }
 
-    identities.add(identity);
-    if ((preferredIdentity == null) || (preferred)) {
-      setPreferredFeatureIdentity(identity);
+    if (preferred) {
+      peakIdentities.add(0, identity);
+    }
+    else {
+      peakIdentities.add(identity);
     }
   }
 
@@ -423,37 +416,39 @@ public class ModularFeatureListRow implements FeatureListRow, ModularDataModel {
 
   @Override
   public void removeFeatureIdentity(FeatureIdentity identity) {
+    ObservableList<FeatureIdentity> identities = getPeakIdentities();
     identities.remove(identity);
-    if (preferredIdentity == identity) {
-      if (identities.size() > 0) {
-        FeatureIdentity[] identitiesArray = identities.toArray(new FeatureIdentity[0]);
-        setPreferredFeatureIdentity(identitiesArray[0]);
-      } else
-        preferredIdentity = null;
-    }
   }
 
   public FeatureIdentity getPreferredFeatureIdentity() {
-    return preferredIdentity;
+    return getPeakIdentities().stream().findFirst().orElse(null);
   }
 
   public void setPreferredFeatureIdentity(FeatureIdentity preferredIdentity) {
-    this.preferredIdentity = preferredIdentity;
+    ObservableList<FeatureIdentity> identities = getPeakIdentities();
+    identities.remove(preferredIdentity);
+    identities.add(0, preferredIdentity);
   }
 
   @Override
   public void setFeatureInformation(FeatureInformation featureInformation) {
-    this.featureInformation = featureInformation;
+    set(FeatureInformationType.class, featureInformation);
   }
 
   @Override
   public FeatureInformation getFeatureInformation() {
-    return featureInformation;
+    if(!hasTypeColumn(FeatureInformationType.class))
+      return null;
+    return (FeatureInformation) get(FeatureInformationType.class);
   }
 
   @Override
   public double getMaxDataPointIntensity() {
-    return maxDataPointIntensity;
+    if(!hasTypeColumn(IntensityRangeType.class))
+      return Double.NaN;
+    ObjectProperty<Range<Float>> rangeObjectProperty = get(IntensityRangeType.class);
+    return rangeObjectProperty.getValue()!=null?
+            rangeObjectProperty.getValue().upperEndpoint() : 0;
   }
 
   @Nullable
@@ -521,34 +516,4 @@ public class ModularFeatureListRow implements FeatureListRow, ModularDataModel {
     return null;
   }
 
-  // TODO: increase speed(enumeration through features)
-  private /*synchronized*/ void calculateAverageValues() {
-    double mzSum = 0;
-    float rtSum = 0, heightSum = 0, areaSum = 0;
-    int charge = 0;
-    HashSet<Integer> chargeArr = new HashSet<Integer>();
-    for (Feature feature : getFeatures()) {
-      // Alignned feature list rows can contain "empty" features
-      if(feature.getRawDataFile() == null) {
-        continue;
-      }
-      rtSum += feature.getRT();
-      mzSum += feature.getMZ();
-      heightSum += feature.getHeight();
-      areaSum += feature.getArea();
-      if (feature.getCharge() > 0) {
-        chargeArr.add(feature.getCharge());
-        charge = feature.getCharge();
-      }
-    }
-    averageRT = rtSum / features.size();
-    averageMZ = mzSum / features.size();
-    averageHeight = heightSum / features.size();
-    averageArea = areaSum / features.size();
-    if (chargeArr.size() < 2) {
-      rowCharge = charge;
-    } else {
-      rowCharge = 0;
-    }
-  }
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureListRow.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureListRow.java
@@ -23,9 +23,7 @@ import io.github.mzmine.datamodel.FeatureIdentity;
 import io.github.mzmine.datamodel.FeatureInformation;
 import io.github.mzmine.datamodel.IsotopePattern;
 import io.github.mzmine.datamodel.Scan;
-import io.github.mzmine.datamodel.features.types.AreaBarType;
-import io.github.mzmine.datamodel.features.types.AreaShareType;
-import io.github.mzmine.datamodel.features.types.FeatureShapeType;
+import io.github.mzmine.datamodel.features.types.*;
 import io.github.mzmine.datamodel.features.types.numbers.MZRangeType;
 import io.github.mzmine.datamodel.features.types.numbers.MZType;
 import io.github.mzmine.util.FeatureSorter;
@@ -39,13 +37,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
+
+import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
 import javafx.collections.ObservableList;
 import javax.annotation.Nonnull;
 import io.github.mzmine.datamodel.FeatureStatus;
 import io.github.mzmine.datamodel.RawDataFile;
-import io.github.mzmine.datamodel.features.types.DataType;
-import io.github.mzmine.datamodel.features.types.DetectionType;
-import io.github.mzmine.datamodel.features.types.FeaturesType;
 import io.github.mzmine.datamodel.features.types.numbers.AreaType;
 import io.github.mzmine.datamodel.features.types.numbers.HeightType;
 import io.github.mzmine.datamodel.features.types.numbers.IDType;
@@ -393,6 +390,12 @@ public class ModularFeatureListRow implements FeatureListRow, ModularDataModel {
     if ((preferredIdentity == null) || (preferred)) {
       setPreferredFeatureIdentity(identity);
     }
+  }
+
+  @Override
+  public void addSpectralLibraryMatch(SpectralDBFeatureIdentity id) {
+    // add column first if needed
+    get(SpectralLibraryMatchType.class).get(SpectralLibMatchSummaryType.class).add(id);
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureListRow.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureListRow.java
@@ -80,12 +80,21 @@ public class ModularFeatureListRow implements FeatureListRow, ModularDataModel {
   private final Map<String, Node> buffertColCharts = new HashMap<>();
 
   public ModularFeatureListRow(@Nonnull ModularFeatureList flist) {
+    this(flist, null, false);
+  }
+
+  public ModularFeatureListRow(@Nonnull ModularFeatureList flist, ModularFeatureListRow row, boolean copyFeatures) {
     this.flist = flist;
     // add type property columns to maps
     flist.getRowTypes().values().forEach(type -> {
       this.setProperty(type, type.createProperty());
     });
+    // copy all but features
+    if(row!=null)
+      row.stream().filter(e -> !(e.getKey() instanceof FeaturesType))
+              .forEach(entry -> this.set(entry.getKey(), entry.getValue()));
 
+    // features
     List<RawDataFile> raws = flist.getRawDataFiles();
     if (!raws.isEmpty()) {
       // init FeaturesType map (is final)
@@ -93,24 +102,19 @@ public class ModularFeatureListRow implements FeatureListRow, ModularDataModel {
       for (RawDataFile r : raws) {
         fmap.put(r, new ModularFeature(flist));
       }
-      features = FXCollections.observableMap(FXCollections.observableMap(fmap));
+      features = (FXCollections.observableMap(fmap));
       // set
       set(FeaturesType.class, features);
 
       // TODO: MapProperty/Map? change DataTypeCellValueFactory? Bind to features?
       //set(FeatureShapeType.class, getFeatures());
-      set(FeatureShapeType.class, getFeaturesProperty());
-      set(AreaBarType.class, getFeaturesProperty());
-      set(AreaShareType.class, getFeaturesProperty());
+//      set(FeatureShapeType.class, getFeaturesProperty());
+//      set(AreaBarType.class, getFeaturesProperty());
+//      set(AreaShareType.class, getFeaturesProperty());
     } else {
       features = Collections.emptyMap();
     }
-  }
 
-  public ModularFeatureListRow(@Nonnull ModularFeatureList flist, ModularFeatureListRow row, boolean copyFeatures) {
-    this(flist);
-    // copy all but features
-    row.stream().filter(e -> !(e.getKey() instanceof FeaturesType)).forEach(entry -> this.set(entry.getKey(), entry.getValue()));
     if(copyFeatures) {
       // Copy the features.
       for (final Feature feature : row.getFeatures()) {
@@ -235,28 +239,8 @@ public class ModularFeatureListRow implements FeatureListRow, ModularDataModel {
       throw new IllegalArgumentException("Cannot add non-modular feature to modular feature list row.");
     }
     ModularFeature modularFeature = (ModularFeature) feature;
-
-    /*
-    if (Objects.equals(modularFeature.getFeatureList(), getFeatureList())) {
-      // features are final - replace all values for all data types
-      // keep old feature
-      ModularFeature old = getFilesFeatures().get(raw);
-      for (DataType type : flist.getFeatureTypes().values()) {
-        old.set(type, modularFeature.get(type).getValue());
-      }
-    } else {
-      features.put(raw, modularFeature);
-    }
-    */
-    if(hasFeature(raw)) {
-      ModularFeature old = getFeature(raw);
-      for (DataType<?> type : flist.getFeatureTypes().values()) {
-        old.set(type, modularFeature.get(type).getValue());
-      }
-    } else {
-      features.put(raw, modularFeature);
-    }
-
+    features.put(raw, modularFeature);
+    // should already be set
     modularFeature.setFeatureList(flist);
   }
 

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureListRow.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureListRow.java
@@ -107,6 +107,18 @@ public class ModularFeatureListRow implements FeatureListRow, ModularDataModel {
     }
   }
 
+  public ModularFeatureListRow(@Nonnull ModularFeatureList flist, ModularFeatureListRow row, boolean copyFeatures) {
+    this(flist);
+    // copy all but features
+    row.stream().filter(e -> !(e.getKey() instanceof FeaturesType)).forEach(entry -> this.set(entry.getKey(), entry.getValue()));
+    if(copyFeatures) {
+      // Copy the features.
+      for (final Feature feature : row.getFeatures()) {
+        this.addFeature(feature.getRawDataFile(), new ModularFeature(flist, feature));
+      }
+    }
+  }
+
   /**
    * Constructor for row with only one raw data file.
    *
@@ -203,6 +215,8 @@ public class ModularFeatureListRow implements FeatureListRow, ModularDataModel {
   }
 
   public ObservableList<Feature> getFeatures() {
+    // TODO remove features object - not always do we have features
+    // FeaturesType creates an empty ListProperty for that
     //return FXCollections.observableArrayList(get(FeaturesType.class).getValue().values());
     return FXCollections.observableArrayList(features.values());
   }

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureListRow.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureListRow.java
@@ -181,7 +181,6 @@ public class ModularFeatureListRow implements FeatureListRow, ModularDataModel {
         DataType newType = tclass.getConstructor().newInstance();
         ModularFeatureList flist = (ModularFeatureList) getFeatureList();
         flist.addRowType(newType);
-        setProperty(newType, newType.createProperty());
       } catch (NullPointerException | InstantiationException | NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
         e.printStackTrace();
         return;

--- a/src/main/java/io/github/mzmine/datamodel/features/RowBinding.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/RowBinding.java
@@ -40,7 +40,9 @@ public class RowBinding {
   }
 
   public void apply(ModularFeatureListRow row) {
-    ObjectBinding<?> binding = featureType.createBinding(bindingType, row);
-    row.get(rowType).bind(binding);
+    if(row.get(rowType)!=null) {
+      ObjectBinding<?> binding = featureType.createBinding(bindingType, row);
+      row.get(rowType).bind(binding);
+    }
   }
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/CommentType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/CommentType.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.datamodel.features.types;
 
+import io.github.mzmine.datamodel.features.types.modifiers.AnnotationType;
 import io.github.mzmine.datamodel.features.types.modifiers.EditableColumnType;
 import io.github.mzmine.datamodel.features.types.modifiers.StringParser;
 import javafx.beans.property.SimpleStringProperty;
@@ -26,7 +27,7 @@ import javafx.util.StringConverter;
 import javafx.util.converter.DefaultStringConverter;
 
 public class CommentType extends DataType<StringProperty>
-    implements EditableColumnType, StringParser<String> {
+    implements EditableColumnType, StringParser<String>, AnnotationType {
 
   private StringConverter<String> converter = new DefaultStringConverter();
 

--- a/src/main/java/io/github/mzmine/datamodel/features/types/CompoundNameType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/CompoundNameType.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2006-2020 The MZmine Development Team
+ * 
+ * This file is part of MZmine.
+ * 
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package io.github.mzmine.datamodel.features.types;
+
+import io.github.mzmine.datamodel.features.types.modifiers.EditableColumnType;
+import io.github.mzmine.datamodel.features.types.modifiers.StringParser;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.util.StringConverter;
+import javafx.util.converter.DefaultStringConverter;
+
+public class CompoundNameType extends DataType<StringProperty>
+    implements EditableColumnType, StringParser<String> {
+
+  private StringConverter<String> converter = new DefaultStringConverter();
+
+  @Override
+  public String getHeaderString() {
+    return "Compound";
+  }
+
+  @Override
+  public String fromString(String s) {
+    return s;
+  }
+
+  @Override
+  public StringConverter<String> getStringConverter() {
+    return converter;
+  }
+
+  @Override
+  public StringProperty createProperty() {
+    return new SimpleStringProperty("");
+  }
+
+
+}

--- a/src/main/java/io/github/mzmine/datamodel/features/types/CompoundNameType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/CompoundNameType.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.datamodel.features.types;
 
+import io.github.mzmine.datamodel.features.types.modifiers.AnnotationType;
 import io.github.mzmine.datamodel.features.types.modifiers.EditableColumnType;
 import io.github.mzmine.datamodel.features.types.modifiers.StringParser;
 import javafx.beans.property.SimpleStringProperty;
@@ -26,7 +27,7 @@ import javafx.util.StringConverter;
 import javafx.util.converter.DefaultStringConverter;
 
 public class CompoundNameType extends DataType<StringProperty>
-    implements EditableColumnType, StringParser<String> {
+    implements EditableColumnType, StringParser<String>, AnnotationType {
 
   private StringConverter<String> converter = new DefaultStringConverter();
 

--- a/src/main/java/io/github/mzmine/datamodel/features/types/FeatureInformationType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/FeatureInformationType.java
@@ -33,7 +33,7 @@ public class FeatureInformationType extends DataType<ObjectProperty<SimpleFeatur
   @Override
   @Nonnull
   public String getHeaderString() {
-    return "Isotopes";
+    return "Feature information";
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/datamodel/features/types/FeatureInformationType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/FeatureInformationType.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2006-2020 The MZmine Development Team
+ * 
+ * This file is part of MZmine.
+ * 
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package io.github.mzmine.datamodel.features.types;
+
+import io.github.mzmine.datamodel.FeatureInformation;
+import io.github.mzmine.datamodel.IsotopePattern;
+import io.github.mzmine.datamodel.features.types.modifiers.NullColumnType;
+import io.github.mzmine.datamodel.impl.SimpleFeatureInformation;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+
+import javax.annotation.Nonnull;
+import java.util.stream.Collectors;
+
+public class FeatureInformationType extends DataType<ObjectProperty<SimpleFeatureInformation>> implements NullColumnType {
+
+  @Override
+  @Nonnull
+  public String getHeaderString() {
+    return "Isotopes";
+  }
+
+  @Override
+  @Nonnull
+  public String getFormattedString(@Nonnull ObjectProperty<SimpleFeatureInformation> property) {
+    return property.getValue() != null ? property.getValue().getAllProperties().entrySet().stream()
+            .map(e -> e.toString()).collect(Collectors.joining(";")) : "";
+  }
+
+  @Override
+  public ObjectProperty<SimpleFeatureInformation> createProperty() {
+    return new SimpleObjectProperty<>();
+  }
+
+}

--- a/src/main/java/io/github/mzmine/datamodel/features/types/FeaturesType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/FeaturesType.java
@@ -96,8 +96,6 @@ public class FeaturesType extends DataType<MapProperty<RawDataFile, ModularFeatu
   /**
    * Create bar chart of data
    * 
-   * @param cell
-   * @param coll
    * @return
    */
   public Node getBarChart(@Nonnull ModularFeatureListRow row, AtomicDouble progress) {
@@ -107,8 +105,6 @@ public class FeaturesType extends DataType<MapProperty<RawDataFile, ModularFeatu
   /**
    * Create bar chart of data
    * 
-   * @param cell
-   * @param coll
    * @return
    */
   public Node getAreaShareChart(@Nonnull ModularFeatureListRow row, AtomicDouble progress) {

--- a/src/main/java/io/github/mzmine/datamodel/features/types/FormulaType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/FormulaType.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2006-2020 The MZmine Development Team
+ * 
+ * This file is part of MZmine.
+ * 
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package io.github.mzmine.datamodel.features.types;
+
+import io.github.mzmine.datamodel.features.types.modifiers.EditableColumnType;
+import io.github.mzmine.datamodel.features.types.modifiers.StringParser;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.util.StringConverter;
+import javafx.util.converter.DefaultStringConverter;
+
+public class FormulaType extends DataType<StringProperty>
+    implements EditableColumnType, StringParser<String> {
+
+  private StringConverter<String> converter = new DefaultStringConverter();
+
+  @Override
+  public String getHeaderString() {
+    return "Formula";
+  }
+
+  @Override
+  public String fromString(String s) {
+    return s;
+  }
+
+  @Override
+  public StringConverter<String> getStringConverter() {
+    return converter;
+  }
+
+  @Override
+  public StringProperty createProperty() {
+    return new SimpleStringProperty("");
+  }
+
+
+}

--- a/src/main/java/io/github/mzmine/datamodel/features/types/FormulaType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/FormulaType.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.datamodel.features.types;
 
+import io.github.mzmine.datamodel.features.types.modifiers.AnnotationType;
 import io.github.mzmine.datamodel.features.types.modifiers.EditableColumnType;
 import io.github.mzmine.datamodel.features.types.modifiers.StringParser;
 import javafx.beans.property.SimpleStringProperty;
@@ -26,7 +27,7 @@ import javafx.util.StringConverter;
 import javafx.util.converter.DefaultStringConverter;
 
 public class FormulaType extends DataType<StringProperty>
-    implements EditableColumnType, StringParser<String> {
+    implements EditableColumnType, StringParser<String>, AnnotationType {
 
   private StringConverter<String> converter = new DefaultStringConverter();
 

--- a/src/main/java/io/github/mzmine/datamodel/features/types/IdentityType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/IdentityType.java
@@ -20,11 +20,12 @@ package io.github.mzmine.datamodel.features.types;
 
 import javax.annotation.Nonnull;
 import io.github.mzmine.datamodel.FeatureIdentity;
+import io.github.mzmine.datamodel.features.types.modifiers.AnnotationType;
 import io.github.mzmine.datamodel.features.types.numbers.abstr.ListDataType;
 import javafx.beans.property.ListProperty;
 import javafx.collections.ObservableList;
 
-public class IdentityType extends ListDataType<FeatureIdentity> {
+public class IdentityType extends ListDataType<FeatureIdentity> implements AnnotationType {
 
   @Override
   public String getHeaderString() {

--- a/src/main/java/io/github/mzmine/datamodel/features/types/InChIStructureType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/InChIStructureType.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2006-2020 The MZmine Development Team
+ * 
+ * This file is part of MZmine.
+ * 
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package io.github.mzmine.datamodel.features.types;
+
+import io.github.mzmine.datamodel.features.types.modifiers.AnnotationType;
+import io.github.mzmine.datamodel.features.types.modifiers.EditableColumnType;
+import io.github.mzmine.datamodel.features.types.modifiers.StringParser;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.util.StringConverter;
+import javafx.util.converter.DefaultStringConverter;
+
+public class InChIStructureType extends DataType<StringProperty>
+    implements EditableColumnType, StringParser<String>, AnnotationType {
+
+  private StringConverter<String> converter = new DefaultStringConverter();
+
+  @Override
+  public String getHeaderString() {
+    return "InChI";
+  }
+
+  @Override
+  public String fromString(String s) {
+    return s;
+  }
+
+  @Override
+  public StringConverter<String> getStringConverter() {
+    return converter;
+  }
+
+  @Override
+  public StringProperty createProperty() {
+    return new SimpleStringProperty("");
+  }
+
+
+}

--- a/src/main/java/io/github/mzmine/datamodel/features/types/IonAdductType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/IonAdductType.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2006-2020 The MZmine Development Team
+ * 
+ * This file is part of MZmine.
+ * 
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package io.github.mzmine.datamodel.features.types;
+
+import io.github.mzmine.datamodel.features.types.modifiers.EditableColumnType;
+import io.github.mzmine.datamodel.features.types.modifiers.StringParser;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.util.StringConverter;
+import javafx.util.converter.DefaultStringConverter;
+
+public class IonAdductType extends DataType<StringProperty>
+    implements EditableColumnType, StringParser<String> {
+
+  private StringConverter<String> converter = new DefaultStringConverter();
+
+  @Override
+  public String getHeaderString() {
+    return "Adduct";
+  }
+
+  @Override
+  public String fromString(String s) {
+    return s;
+  }
+
+  @Override
+  public StringConverter<String> getStringConverter() {
+    return converter;
+  }
+
+  @Override
+  public StringProperty createProperty() {
+    return new SimpleStringProperty("");
+  }
+
+
+}

--- a/src/main/java/io/github/mzmine/datamodel/features/types/IonAdductType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/IonAdductType.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.datamodel.features.types;
 
+import io.github.mzmine.datamodel.features.types.modifiers.AnnotationType;
 import io.github.mzmine.datamodel.features.types.modifiers.EditableColumnType;
 import io.github.mzmine.datamodel.features.types.modifiers.StringParser;
 import javafx.beans.property.SimpleStringProperty;
@@ -26,7 +27,7 @@ import javafx.util.StringConverter;
 import javafx.util.converter.DefaultStringConverter;
 
 public class IonAdductType extends DataType<StringProperty>
-    implements EditableColumnType, StringParser<String> {
+    implements EditableColumnType, StringParser<String>, AnnotationType {
 
   private StringConverter<String> converter = new DefaultStringConverter();
 

--- a/src/main/java/io/github/mzmine/datamodel/features/types/IsotopePatternType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/IsotopePatternType.java
@@ -19,6 +19,8 @@
 package io.github.mzmine.datamodel.features.types;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import io.github.mzmine.datamodel.IsotopePattern;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
@@ -34,7 +36,15 @@ public class IsotopePatternType extends DataType<ObjectProperty<IsotopePattern>>
   @Override
   @Nonnull
   public String getFormattedString(@Nonnull ObjectProperty<IsotopePattern> property) {
-    return property.getValue() != null ? "" + property.getValue().getNumberOfDataPoints() : "";
+    return property.getValue() != null ? String.valueOf(property.getValue().getNumberOfDataPoints()) : "";
+  }
+
+  @Nonnull
+  @Override
+  public String getFormattedString(@Nullable Object value) {
+    if(value==null || !(value instanceof IsotopePattern))
+      return "";
+    return String.valueOf(((IsotopePattern)value).getNumberOfDataPoints());
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/datamodel/features/types/ManualAnnotationType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/ManualAnnotationType.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2006-2020 The MZmine Development Team
+ * 
+ * This file is part of MZmine.
+ * 
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package io.github.mzmine.datamodel.features.types;
+
+import io.github.mzmine.datamodel.features.types.numbers.NeutralMassType;
+import javafx.collections.ObservableMap;
+
+import java.util.List;
+
+public class ManualAnnotationType extends ModularType {
+
+  // Unmodifiable list of all subtypes
+  private final List<DataType> subTypes = List.of(new CommentType(), new IonAdductType(), new FormulaType(),
+          new NeutralMassType(), new SmilesStructureType());
+
+  @Override
+  public List<DataType> getSubDataTypes() {
+    return subTypes;
+  }
+
+  @Override
+  public String getHeaderString() {
+    return "Manual Annotation";
+  }
+
+}

--- a/src/main/java/io/github/mzmine/datamodel/features/types/ManualAnnotationType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/ManualAnnotationType.java
@@ -26,8 +26,8 @@ import java.util.List;
 public class ManualAnnotationType extends ModularType {
 
   // Unmodifiable list of all subtypes
-  private final List<DataType> subTypes = List.of(new CommentType(), new IonAdductType(), new FormulaType(),
-          new NeutralMassType(), new SmilesStructureType());
+  private final List<DataType> subTypes = List.of(new CommentType(), new CompoundNameType(), new IonAdductType(),
+          new FormulaType(), new SmilesStructureType());
 
   @Override
   public List<DataType> getSubDataTypes() {

--- a/src/main/java/io/github/mzmine/datamodel/features/types/ManualAnnotationType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/ManualAnnotationType.java
@@ -18,12 +18,13 @@
 
 package io.github.mzmine.datamodel.features.types;
 
+import io.github.mzmine.datamodel.features.types.modifiers.AnnotationType;
 import io.github.mzmine.datamodel.features.types.numbers.NeutralMassType;
 import javafx.collections.ObservableMap;
 
 import java.util.List;
 
-public class ManualAnnotationType extends ModularType {
+public class ManualAnnotationType extends ModularType implements AnnotationType {
 
   // Unmodifiable list of all subtypes
   private final List<DataType> subTypes = List.of(new CommentType(), new CompoundNameType(), new IonAdductType(),

--- a/src/main/java/io/github/mzmine/datamodel/features/types/ManualAnnotationType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/ManualAnnotationType.java
@@ -37,7 +37,7 @@ public class ManualAnnotationType extends ModularType implements AnnotationType 
 
   @Override
   public String getHeaderString() {
-    return "Manual Annotation";
+    return "Manual annotation";
   }
 
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/ModularType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/ModularType.java
@@ -37,6 +37,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+/**
+ * ModularType offers a main column for multiple sub columns (DataTypes) that are stored in a {@link ModularTypeProperty}
+ * An example implementation is given by {@link SpectralLibraryMatchType}, which is extending the scope with one column
+ * (type) that defines all the other columns.
+ *
+ * @author Robin Schmid (https://github.com/robinschmid)
+ */
 public abstract class ModularType extends DataType<ModularTypeProperty>
         implements SubColumnsFactory<ModularTypeProperty> {
 
@@ -95,7 +102,12 @@ public abstract class ModularType extends DataType<ModularTypeProperty>
     return cols;
   }
 
-
+  /**
+   * Sub DataType is the sub column at index (see {@link #getSubDataTypes()#})
+   *
+   * @param index
+   * @return
+   */
   public DataType getSubTypeAt(int index) {
     return index>=0 && index<getSubDataTypes().size()? getSubDataTypes().get(index) : null;
   }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/ModularType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/ModularType.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2006-2020 The MZmine Development Team
+ * 
+ * This file is part of MZmine.
+ * 
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package io.github.mzmine.datamodel.features.types;
+
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.features.ModularFeatureListRow;
+import io.github.mzmine.datamodel.features.types.modifiers.GraphicalColumType;
+import io.github.mzmine.datamodel.features.types.modifiers.SubColumnsFactory;
+import javafx.beans.property.Property;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableMap;
+import javafx.scene.Node;
+import javafx.scene.control.TreeTableCell;
+import javafx.scene.control.TreeTableColumn;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public abstract class ModularType extends DataType<ModularTypeProperty>
+        implements SubColumnsFactory<ModularTypeProperty> {
+
+  private ObservableMap<Class<? extends DataType>, DataType> subTypeMap;
+
+  /**
+   * The unmodifiable list of sub data types. Order reflects the initial order of columns.
+   *
+   * @return
+   */
+  @Nonnull
+  public abstract List<DataType> getSubDataTypes();
+
+  /**
+   * The unmodifiable map as a reference for the ModularTypeProperty
+   * @return
+   */
+  @Nonnull
+  public ObservableMap<Class<? extends DataType>, DataType> getSubDataTypesMap() {
+    if(subTypeMap==null) {
+      LinkedHashMap<Class<? extends DataType>, DataType> map = new LinkedHashMap<>();
+      getSubDataTypes().forEach(type -> map.put(type.getClass(), type));
+      subTypeMap = FXCollections.unmodifiableObservableMap(FXCollections.observableMap(map));
+    }
+    return subTypeMap;
+  }
+
+  @Override
+  public ModularTypeProperty createProperty() {
+    // create map of datatype -> property for all sub types
+    LinkedHashMap<DataType, Property<?>> map = new LinkedHashMap<>();
+    getSubDataTypes().stream().forEach(t -> map.put(t, t.createProperty()));
+    return new ModularTypeProperty(FXCollections.unmodifiableObservableMap(FXCollections.observableMap(map)), this);
+  }
+
+  @Override
+  @Nonnull
+  public String getFormattedString(@Nonnull ModularTypeProperty value) {
+    ObservableMap<DataType, Property<?>> map = value.getValue();
+    return map == null || map.isEmpty() ? "" : map.entrySet().stream()
+            .map(e -> e.getKey().getFormattedString(e.getValue())).collect(Collectors.joining(";"));
+  }
+
+  @Override
+  @Nonnull
+  public List<TreeTableColumn<ModularFeatureListRow, Object>> createSubColumns(@Nullable RawDataFile raw) {
+    final ModularType thisType = this;
+    // add column for each sub data type
+    List<TreeTableColumn<ModularFeatureListRow, Object>> cols = new ArrayList<>();
+
+    for (DataType subType : getSubDataTypes()) {
+      // create column and replace value factory to access sub type
+      TreeTableColumn<ModularFeatureListRow, Object> col = subType.createColumn(raw, thisType);
+      cols.add(col);
+    }
+    return cols;
+  }
+
+
+  public DataType getSubTypeAt(int index) {
+    return index>=0 && index<getSubDataTypes().size()? getSubDataTypes().get(index) : null;
+  }
+
+  @Override
+  @Nullable
+  public String getFormattedSubColValue(int subcolumn,
+                                        TreeTableCell<ModularFeatureListRow, Object> cell,
+                                        TreeTableColumn<ModularFeatureListRow, Object> coll, Object value, RawDataFile raw) {
+    if (value == null)
+      return "";
+    DataType sub = getSubTypeAt(subcolumn);
+    if(sub==null)
+      return "";
+
+    Map<DataType, Property<?>> map = (Map<DataType, Property<?>>) value;
+    return sub.getFormattedString(map.get(sub));
+  }
+
+  @Nullable
+  @Override
+  public Node getSubColNode(int subcolumn, TreeTableCell<ModularFeatureListRow, Object> cell, TreeTableColumn<ModularFeatureListRow, Object> coll, Object cellData, RawDataFile raw) {
+    if (cellData == null)
+      return null;
+    DataType sub = getSubTypeAt(subcolumn);
+    if(sub==null || !(sub instanceof GraphicalColumType))
+      return null;
+
+    Map<DataType, Property<?>> map = (Map<DataType, Property<?>>) cellData;
+    return ((GraphicalColumType)sub).getCellNode(cell, coll, cellData, raw);
+  }
+
+}

--- a/src/main/java/io/github/mzmine/datamodel/features/types/ModularTypeProperty.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/ModularTypeProperty.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2006-2020 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package io.github.mzmine.datamodel.features.types;
+
+import io.github.mzmine.datamodel.features.ModularDataModel;
+import javafx.beans.property.MapProperty;
+import javafx.beans.property.Property;
+import javafx.beans.property.SimpleMapProperty;
+import javafx.collections.ObservableMap;
+
+public class ModularTypeProperty extends SimpleMapProperty<DataType, Property<?>> implements ModularDataModel {
+
+    private ModularType parentType;
+
+    public ModularTypeProperty(ObservableMap<DataType, Property<?>> map, ModularType parentType) {
+        super(map);
+        this.parentType = parentType;
+    }
+
+    public ModularType getParentType() {
+        return parentType;
+    }
+
+    @Override
+    public ObservableMap<Class<? extends DataType>, DataType> getTypes() {
+        return parentType.getSubDataTypesMap();
+    }
+
+    @Override
+    public ObservableMap<DataType, Property<?>> getMap() {
+        return this;
+    }
+}

--- a/src/main/java/io/github/mzmine/datamodel/features/types/ModularTypeProperty.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/ModularTypeProperty.java
@@ -18,14 +18,13 @@
 package io.github.mzmine.datamodel.features.types;
 
 import io.github.mzmine.datamodel.features.ModularDataModel;
-import javafx.beans.property.MapProperty;
 import javafx.beans.property.Property;
 import javafx.beans.property.SimpleMapProperty;
 import javafx.collections.ObservableMap;
 
 public class ModularTypeProperty extends SimpleMapProperty<DataType, Property<?>> implements ModularDataModel {
 
-    private ModularType parentType;
+    protected ModularType parentType;
 
     public ModularTypeProperty(ObservableMap<DataType, Property<?>> map, ModularType parentType) {
         super(map);

--- a/src/main/java/io/github/mzmine/datamodel/features/types/ModularTypeProperty.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/ModularTypeProperty.java
@@ -22,6 +22,12 @@ import javafx.beans.property.Property;
 import javafx.beans.property.SimpleMapProperty;
 import javafx.collections.ObservableMap;
 
+/**
+ * Used in {@link ModularType} as an observable property. The parentType is the main column and all DataTypes in this
+ * map are the sub columns
+ *
+ * @author Robin Schmid (https://github.com/robinschmid)
+ */
 public class ModularTypeProperty extends SimpleMapProperty<DataType, Property<?>> implements ModularDataModel {
 
     protected ModularType parentType;

--- a/src/main/java/io/github/mzmine/datamodel/features/types/SmilesStructureType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/SmilesStructureType.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.datamodel.features.types;
 
+import io.github.mzmine.datamodel.features.types.modifiers.AnnotationType;
 import io.github.mzmine.datamodel.features.types.modifiers.EditableColumnType;
 import io.github.mzmine.datamodel.features.types.modifiers.StringParser;
 import javafx.beans.property.SimpleStringProperty;
@@ -26,7 +27,7 @@ import javafx.util.StringConverter;
 import javafx.util.converter.DefaultStringConverter;
 
 public class SmilesStructureType extends DataType<StringProperty>
-    implements EditableColumnType, StringParser<String> {
+    implements EditableColumnType, StringParser<String>, AnnotationType {
 
   private StringConverter<String> converter = new DefaultStringConverter();
 

--- a/src/main/java/io/github/mzmine/datamodel/features/types/SmilesStructureType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/SmilesStructureType.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2006-2020 The MZmine Development Team
+ * 
+ * This file is part of MZmine.
+ * 
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package io.github.mzmine.datamodel.features.types;
+
+import io.github.mzmine.datamodel.features.types.modifiers.EditableColumnType;
+import io.github.mzmine.datamodel.features.types.modifiers.StringParser;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.util.StringConverter;
+import javafx.util.converter.DefaultStringConverter;
+
+public class SmilesStructureType extends DataType<StringProperty>
+    implements EditableColumnType, StringParser<String> {
+
+  private StringConverter<String> converter = new DefaultStringConverter();
+
+  @Override
+  public String getHeaderString() {
+    return "SMILES";
+  }
+
+  @Override
+  public String fromString(String s) {
+    return s;
+  }
+
+  @Override
+  public StringConverter<String> getStringConverter() {
+    return converter;
+  }
+
+  @Override
+  public StringProperty createProperty() {
+    return new SimpleStringProperty("");
+  }
+
+
+}

--- a/src/main/java/io/github/mzmine/datamodel/features/types/SpectralLibMatchSummaryType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/SpectralLibMatchSummaryType.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2006-2020 The MZmine Development Team
+ * 
+ * This file is part of MZmine.
+ * 
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package io.github.mzmine.datamodel.features.types;
+
+import io.github.mzmine.datamodel.features.types.modifiers.AnnotationType;
+import io.github.mzmine.datamodel.features.types.numbers.abstr.ListDataType;
+import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+
+public class SpectralLibMatchSummaryType extends ListDataType<SpectralDBFeatureIdentity>
+    implements AnnotationType {
+
+  @Override
+  public String getHeaderString() {
+    return "Summary";
+  }
+
+}

--- a/src/main/java/io/github/mzmine/datamodel/features/types/SpectralLibraryMatchType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/SpectralLibraryMatchType.java
@@ -25,6 +25,7 @@ import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.datamodel.features.types.fx.DataTypeCellFactory;
 import io.github.mzmine.datamodel.features.types.fx.DataTypeCellValueFactory;
+import io.github.mzmine.datamodel.features.types.modifiers.AnnotationType;
 import io.github.mzmine.datamodel.features.types.modifiers.SubColumnsFactory;
 import io.github.mzmine.datamodel.features.types.numbers.CosineScoreType;
 import io.github.mzmine.datamodel.features.types.numbers.NeutralMassType;
@@ -48,7 +49,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class SpectralLibraryMatchType extends ModularType {
+public class SpectralLibraryMatchType extends ModularType implements AnnotationType {
 
   // Unmodifiable list of all subtypes
   private final List<DataType> subTypes = List.of(new CompoundNameType(), new FormulaType(), new SmilesStructureType(),

--- a/src/main/java/io/github/mzmine/datamodel/features/types/SpectralLibraryMatchType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/SpectralLibraryMatchType.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2006-2020 The MZmine Development Team
+ * 
+ * This file is part of MZmine.
+ * 
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package io.github.mzmine.datamodel.features.types;
+
+import com.google.common.collect.Range;
+import io.github.mzmine.datamodel.FeatureIdentity;
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.features.ModularFeature;
+import io.github.mzmine.datamodel.features.ModularFeatureListRow;
+import io.github.mzmine.datamodel.features.types.fx.DataTypeCellFactory;
+import io.github.mzmine.datamodel.features.types.fx.DataTypeCellValueFactory;
+import io.github.mzmine.datamodel.features.types.modifiers.SubColumnsFactory;
+import io.github.mzmine.datamodel.features.types.numbers.CosineScoreType;
+import io.github.mzmine.datamodel.features.types.numbers.NeutralMassType;
+import io.github.mzmine.datamodel.features.types.numbers.abstr.ListDataType;
+import javafx.beans.property.ListProperty;
+import javafx.beans.property.MapProperty;
+import javafx.beans.property.Property;
+import javafx.beans.property.SimpleMapProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.collections.ObservableMap;
+import javafx.scene.Node;
+import javafx.scene.control.TreeTableCell;
+import javafx.scene.control.TreeTableColumn;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class SpectralLibraryMatchType extends ModularType {
+
+  // Unmodifiable list of all subtypes
+  private final List<DataType> subTypes = List.of(new CompoundNameType(), new FormulaType(), new SmilesStructureType(),
+          new NeutralMassType(), new CosineScoreType());
+
+  @Override
+  public List<DataType> getSubDataTypes() {
+    return subTypes;
+  }
+
+  @Override
+  public String getHeaderString() {
+    return "Spectral Library Match";
+  }
+
+}

--- a/src/main/java/io/github/mzmine/datamodel/features/types/SpectralLibraryMatchType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/SpectralLibraryMatchType.java
@@ -56,6 +56,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * This type has multiple sub columns. The first is a list of complex objects
+ * ({@link SpectralLibMatchSummaryType}). The first object in this list defines all the other sub
+ * columns.
+ *
+ * @author Robin Schmid (https://github.com/robinschmid)
+ */
 public class SpectralLibraryMatchType extends ModularType implements AnnotationType {
 
   // Unmodifiable list of all subtypes
@@ -94,7 +101,11 @@ public class SpectralLibraryMatchType extends ModularType implements AnnotationT
     return property;
   }
 
-
+  /**
+   * On change of the first list element, change all the other sub types.
+   * @param data
+   * @param match
+   */
   private void setCurrentElement(ModularTypeProperty data, SpectralDBFeatureIdentity match) {
     if(match==null) {
       for (DataType type : this.getSubDataTypes()) {

--- a/src/main/java/io/github/mzmine/datamodel/features/types/SpectralLibraryMatchType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/SpectralLibraryMatchType.java
@@ -79,15 +79,15 @@ public class SpectralLibraryMatchType extends ModularType implements AnnotationT
     ModularTypeProperty property = super.createProperty();
 
     // add bindings: If first element in summary column changes - update all other columns based on this object
-    ListProperty<SpectralDBFeatureIdentity> summaryProperty = property.get(SpectralLibMatchSummaryType.class);
-    summaryProperty.addListener((ListChangeListener<SpectralDBFeatureIdentity>) change -> {
+    property.get(SpectralLibMatchSummaryType.class).addListener((ListChangeListener<SpectralDBFeatureIdentity>) change -> {
+      ObservableList<? extends SpectralDBFeatureIdentity> summaryProperty = change.getList();
       boolean firstElementChanged = false;
       while (change.next()) {
         firstElementChanged = firstElementChanged || change.getFrom() == 0;
       }
       if(firstElementChanged) {
         // first list elements has changed - set all other fields
-        setCurrentElement(property, !summaryProperty.isEmpty()? null : summaryProperty.get(0));
+        setCurrentElement(property, summaryProperty.isEmpty()? null : summaryProperty.get(0));
       }
     });
 
@@ -108,15 +108,17 @@ public class SpectralLibraryMatchType extends ModularType implements AnnotationT
       SpectralSimilarity score = match.getSimilarity();
 
       // update selected values
-      data.set(CompoundNameType.class, entry.getField(DBEntryField.NAME));
-      data.set(FormulaType.class, entry.getField(DBEntryField.FORMULA));
-      data.set(IonAdductType.class, entry.getField(DBEntryField.ION_TYPE));
-      data.set(SmilesStructureType.class, entry.getField(DBEntryField.SMILES));
-      data.set(InChIStructureType.class, entry.getField(DBEntryField.INCHI));
+      data.set(CompoundNameType.class, entry.getField(DBEntryField.NAME).orElse(""));
+      data.set(FormulaType.class, entry.getField(DBEntryField.FORMULA).orElse(""));
+      data.set(IonAdductType.class, entry.getField(DBEntryField.ION_TYPE).orElse(""));
+      data.set(SmilesStructureType.class, entry.getField(DBEntryField.SMILES).orElse(""));
+      data.set(InChIStructureType.class, entry.getField(DBEntryField.INCHI).orElse(""));
       data.set(CosineScoreType.class, score.getScore());
       data.set(MatchingSignalsType.class, score.getOverlap());
-      data.set(PrecursorMZType.class, entry.getField(DBEntryField.MZ));
-      data.set(NeutralMassType.class, entry.getField(DBEntryField.EXACT_MASS));
+      if(entry.getField(DBEntryField.MZ).isPresent())
+        data.set(PrecursorMZType.class, entry.getField(DBEntryField.MZ).get());
+      if(entry.getField(DBEntryField.EXACT_MASS).isPresent())
+        data.set(NeutralMassType.class, entry.getField(DBEntryField.EXACT_MASS).get());
     }
   }
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/SpectralLibraryMatchType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/SpectralLibraryMatchType.java
@@ -78,7 +78,7 @@ public class SpectralLibraryMatchType extends ModularType implements AnnotationT
 
   @Override
   public String getHeaderString() {
-    return "Spectral Library Match";
+    return "Spectral library match";
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/datamodel/features/types/fx/DataTypeCellFactory.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/fx/DataTypeCellFactory.java
@@ -36,7 +36,6 @@ import javafx.util.Callback;
  * 
  * @author Robin Schmid (robinschmid@uni-muenster.de)
  *
- * @param <T>
  */
 public class DataTypeCellFactory implements
     Callback<TreeTableColumn<ModularFeatureListRow, Object>, TreeTableCell<ModularFeatureListRow, Object>> {

--- a/src/main/java/io/github/mzmine/datamodel/features/types/fx/ModularDataTypeCellValueFactory.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/fx/ModularDataTypeCellValueFactory.java
@@ -77,7 +77,7 @@ public class ModularDataTypeCellValueFactory implements
       MapProperty<DataType, Property<?>> parentMap = map.get(modularParentType);
       return (ObservableValue<Object>) parentMap.get(subType);
     }catch (Exception ex) {
-      logger.warning("Cannot get sub type of ModularType");
+      logger.log(Level.WARNING, "Cannot get sub type of ModularType", ex);
       return null;
     }
   }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/modifiers/AnnotationType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/modifiers/AnnotationType.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2006-2020 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package io.github.mzmine.datamodel.features.types.modifiers;
+
+/**
+ * Tag types as annotation type (for later combination of annotation results)
+ */
+public interface AnnotationType {
+
+}

--- a/src/main/java/io/github/mzmine/datamodel/features/types/modifiers/BindingsFactoryType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/modifiers/BindingsFactoryType.java
@@ -12,8 +12,7 @@
  * Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
- * USA
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 package io.github.mzmine.datamodel.features.types.modifiers;

--- a/src/main/java/io/github/mzmine/datamodel/features/types/modifiers/BindingsType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/modifiers/BindingsType.java
@@ -2,6 +2,6 @@ package io.github.mzmine.datamodel.features.types.modifiers;
 
 public enum BindingsType {
 
-  AVERAGE, SUM, MIN, MAX, COUNT, RANGE;
+  AVERAGE, SUM, MIN, MAX, COUNT, RANGE, CONSENSUS;
 
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/modifiers/BindingsType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/modifiers/BindingsType.java
@@ -12,8 +12,7 @@
  * Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
- * USA
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 package io.github.mzmine.datamodel.features.types.modifiers;

--- a/src/main/java/io/github/mzmine/datamodel/features/types/modifiers/EditableColumnType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/modifiers/EditableColumnType.java
@@ -1,19 +1,18 @@
 /*
  * Copyright 2006-2020 The MZmine Development Team
- * 
+ *
  * This file is part of MZmine.
- * 
+ *
  * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
  * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
  * Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
- * USA
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 package io.github.mzmine.datamodel.features.types.modifiers;

--- a/src/main/java/io/github/mzmine/datamodel/features/types/modifiers/ExpandableType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/modifiers/ExpandableType.java
@@ -12,8 +12,7 @@
  * Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
- * USA
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 package io.github.mzmine.datamodel.features.types.modifiers;

--- a/src/main/java/io/github/mzmine/datamodel/features/types/modifiers/GraphicalColumType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/modifiers/GraphicalColumType.java
@@ -1,19 +1,18 @@
 /*
  * Copyright 2006-2020 The MZmine Development Team
- * 
+ *
  * This file is part of MZmine.
- * 
+ *
  * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
  * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
  * Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
- * USA
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 package io.github.mzmine.datamodel.features.types.modifiers;

--- a/src/main/java/io/github/mzmine/datamodel/features/types/modifiers/NullColumnType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/modifiers/NullColumnType.java
@@ -1,19 +1,18 @@
 /*
  * Copyright 2006-2020 The MZmine Development Team
- * 
+ *
  * This file is part of MZmine.
- * 
+ *
  * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
  * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
  * Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
- * USA
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 package io.github.mzmine.datamodel.features.types.modifiers;

--- a/src/main/java/io/github/mzmine/datamodel/features/types/modifiers/StringParser.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/modifiers/StringParser.java
@@ -1,19 +1,18 @@
 /*
  * Copyright 2006-2020 The MZmine Development Team
- * 
+ *
  * This file is part of MZmine.
- * 
+ *
  * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
  * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
  * Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
- * USA
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 package io.github.mzmine.datamodel.features.types.modifiers;

--- a/src/main/java/io/github/mzmine/datamodel/features/types/modifiers/SubColumnsFactory.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/modifiers/SubColumnsFactory.java
@@ -1,19 +1,18 @@
 /*
  * Copyright 2006-2020 The MZmine Development Team
- * 
+ *
  * This file is part of MZmine.
- * 
+ *
  * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
  * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
  * Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
- * USA
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 package io.github.mzmine.datamodel.features.types.modifiers;

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/ChargeType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/ChargeType.java
@@ -18,12 +18,49 @@
 
 package io.github.mzmine.datamodel.features.types.numbers;
 
+import com.google.common.collect.Range;
+import io.github.mzmine.datamodel.features.ModularFeature;
+import io.github.mzmine.datamodel.features.ModularFeatureListRow;
+import io.github.mzmine.datamodel.features.types.exceptions.UndefinedRowBindingException;
+import io.github.mzmine.datamodel.features.types.modifiers.BindingsType;
 import io.github.mzmine.datamodel.features.types.numbers.abstr.IntegerType;
+import javafx.beans.binding.Bindings;
+import javafx.beans.binding.ObjectBinding;
+import javafx.beans.property.Property;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
 
 public class ChargeType extends IntegerType {
 
   @Override
   public String getHeaderString() {
     return "Charge";
+  }
+
+
+  @Override
+  public ObjectBinding<?> createBinding(BindingsType bind, ModularFeatureListRow row) {
+    // get all properties of all features
+    @SuppressWarnings("unchecked")
+    Property<Integer>[] prop = row.streamFeatures().map(f -> (ModularFeature) f).map(f -> f.get(this)).toArray(Property[]::new);
+    switch (bind) {
+      case CONSENSUS:
+        return Bindings.createObjectBinding(() -> {
+          Map<Integer, Integer> count = new HashMap<>();
+          for (Property<Integer> p : prop) {
+            if (p.getValue() != null) {
+              Integer charge = p.getValue();
+              Integer n = count.get(charge);
+              count.put(charge, n==null? 1 : n+1);
+            }
+          }
+          return count.entrySet().stream().max(Comparator.comparingInt(Map.Entry::getValue)).map(Map.Entry::getValue)
+                  .orElse(0);
+        }, prop);
+    }
+    return super.createBinding(bind, row);
   }
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/CosineScoreType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/CosineScoreType.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2006-2020 The MZmine Development Team
+ * 
+ * This file is part of MZmine.
+ * 
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package io.github.mzmine.datamodel.features.types.numbers;
+
+import io.github.mzmine.datamodel.features.types.DataType;
+import io.github.mzmine.datamodel.features.types.modifiers.ExpandableType;
+import io.github.mzmine.datamodel.features.types.numbers.abstr.FloatType;
+import io.github.mzmine.main.MZmineCore;
+
+import javax.annotation.Nonnull;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+
+public class CosineScoreType extends FloatType {
+
+  public CosineScoreType() {
+    super(new DecimalFormat("0.000"));
+  }
+
+  @Override
+  public NumberFormat getFormatter() {
+    return DEFAULT_FORMAT;
+  }
+
+  @Override
+  public String getHeaderString() {
+    return "Cosine similarity";
+  }
+
+}

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/FragmentScanNumbersType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/FragmentScanNumbersType.java
@@ -18,13 +18,11 @@
 
 package io.github.mzmine.datamodel.features.types.numbers;
 
-import io.github.mzmine.datamodel.features.types.modifiers.NullColumnType;
-
-public class FragmentScanNumbersType extends ScanNumbersType implements NullColumnType {
+public class FragmentScanNumbersType extends ScanNumbersType {
 
   @Override
   public String getHeaderString() {
-    return "Fragment Scans";
+    return "Fragment scans";
   }
 
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/IntensityRangeType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/IntensityRangeType.java
@@ -43,7 +43,7 @@ public class IntensityRangeType extends FloatRangeType {
   @Override
   @Nonnull
   public String getHeaderString() {
-    return "Intensity Range";
+    return "Intensity range";
   }
 
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/MZRangeType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/MZRangeType.java
@@ -45,7 +45,7 @@ public class MZRangeType extends DoubleRangeType implements ExpandableType {
   @Override
   @Nonnull
   public String getHeaderString() {
-    return "m/z Range";
+    return "m/z range";
   }
 
   @Nonnull

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/MatchingSignalsType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/MatchingSignalsType.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2006-2020 The MZmine Development Team
+ * 
+ * This file is part of MZmine.
+ * 
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package io.github.mzmine.datamodel.features.types.numbers;
+
+import io.github.mzmine.datamodel.features.types.numbers.abstr.FloatType;
+import io.github.mzmine.datamodel.features.types.numbers.abstr.IntegerType;
+
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+
+public class MatchingSignalsType extends IntegerType {
+
+  public MatchingSignalsType() {
+    super();
+  }
+
+  @Override
+  public String getHeaderString() {
+    return "Matched signals";
+  }
+
+}

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/NeutralMassType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/NeutralMassType.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2006-2020 The MZmine Development Team
+ * 
+ * This file is part of MZmine.
+ * 
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package io.github.mzmine.datamodel.features.types.numbers;
+
+import io.github.mzmine.datamodel.features.types.DataType;
+import io.github.mzmine.datamodel.features.types.modifiers.ExpandableType;
+import io.github.mzmine.datamodel.features.types.numbers.abstr.DoubleType;
+import io.github.mzmine.main.MZmineCore;
+
+import javax.annotation.Nonnull;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+
+public class NeutralMassType extends DoubleType implements ExpandableType {
+
+  public NeutralMassType() {
+    super(new DecimalFormat("0.0000"));
+  }
+
+  @Override
+  public NumberFormat getFormatter() {
+    try {
+      return MZmineCore.getConfiguration().getMZFormat();
+    } catch (NullPointerException e) {
+      // only happens if types are used without initializing the MZmineCore
+      return DEFAULT_FORMAT;
+    }
+  }
+
+  @Override
+  public String getHeaderString() {
+    return "Neutral mass";
+  }
+
+  @Nonnull
+  @Override
+  public Class<? extends DataType<?>> getExpandedTypeClass() {
+    return MZRangeType.class;
+  }
+
+  @Nonnull
+  @Override
+  public Class<? extends DataType<?>> getHiddenTypeClass() {
+    return getClass();
+  }
+}

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/PrecursorMZType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/PrecursorMZType.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2006-2020 The MZmine Development Team
+ * 
+ * This file is part of MZmine.
+ * 
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ * 
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package io.github.mzmine.datamodel.features.types.numbers;
+
+import io.github.mzmine.datamodel.features.types.DataType;
+import io.github.mzmine.datamodel.features.types.modifiers.ExpandableType;
+import io.github.mzmine.datamodel.features.types.numbers.abstr.DoubleType;
+import io.github.mzmine.main.MZmineCore;
+
+import javax.annotation.Nonnull;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+
+public class PrecursorMZType extends DoubleType {
+
+  public PrecursorMZType() {
+    super(new DecimalFormat("0.0000"));
+  }
+
+  @Override
+  public NumberFormat getFormatter() {
+    try {
+      return MZmineCore.getConfiguration().getMZFormat();
+    } catch (NullPointerException e) {
+      // only happens if types are used without initializing the MZmineCore
+      return DEFAULT_FORMAT;
+    }
+  }
+
+  @Override
+  public String getHeaderString() {
+    return "Precursor m/z";
+  }
+
+}

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/RTRangeType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/RTRangeType.java
@@ -45,7 +45,7 @@ public class RTRangeType extends FloatRangeType implements ExpandableType {
   @Override
   @Nonnull
   public String getHeaderString() {
-    return "RT Range";
+    return "RT range";
   }
 
   @Nonnull

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/ScanNumbersType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/ScanNumbersType.java
@@ -20,12 +20,31 @@ package io.github.mzmine.datamodel.features.types.numbers;
 
 import io.github.mzmine.datamodel.features.types.modifiers.NullColumnType;
 import io.github.mzmine.datamodel.features.types.numbers.abstr.ListDataType;
+import javafx.beans.property.ListProperty;
 
-public class ScanNumbersType extends ListDataType<Integer> implements NullColumnType {
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+
+public class ScanNumbersType extends ListDataType<Integer> {
 
   @Override
   public String getHeaderString() {
     return "Scans";
   }
 
+
+  @Nonnull
+  @Override
+  public String getFormattedString(@Nonnull ListProperty<Integer> property) {
+    return property.getValue() != null ? String.valueOf(property.getValue().size()) : "";
+  }
+
+  @Nonnull
+  @Override
+  public String getFormattedString(@Nullable Object value) {
+    if(value==null || !(value instanceof List))
+      return "";
+    return String.valueOf(((List)value).size());
+  }
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/abstr/ListDataType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/abstr/ListDataType.java
@@ -52,6 +52,6 @@ public abstract class ListDataType<T> extends DataType<ListProperty<T>> {
   @Nonnull
   @Override
   public String getFormattedString(@Nonnull ListProperty<T> property) {
-    return property.stream().map(Object::toString).findFirst().orElse(null);
+    return property.stream().map(Object::toString).findFirst().orElse("");
   }
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/abstr/ListDataType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/abstr/ListDataType.java
@@ -19,15 +19,39 @@
 package io.github.mzmine.datamodel.features.types.numbers.abstr;
 
 import java.util.ArrayList;
+import java.util.List;
+
 import io.github.mzmine.datamodel.features.types.DataType;
 import javafx.beans.property.ListProperty;
+import javafx.beans.property.Property;
 import javafx.beans.property.SimpleListProperty;
 import javafx.collections.FXCollections;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public abstract class ListDataType<T> extends DataType<ListProperty<T>> {
 
   @Override
   public ListProperty<T> createProperty() {
     return new SimpleListProperty<T>(FXCollections.observableList(new ArrayList<T>()));
+  }
+
+  @Nonnull
+  @Override
+  public String getFormattedString(@Nullable Object value) {
+    if(value==null)
+      return "";
+    if(value instanceof List)
+      return (String) ((List)value).stream().map(Object::toString).findFirst().orElse("");
+    if(value instanceof ListProperty)
+      return (String) ((ListProperty)value).stream().map(Object::toString).findFirst().orElse("");
+    return value.toString();
+  }
+
+  @Nonnull
+  @Override
+  public String getFormattedString(@Nonnull ListProperty<T> property) {
+    return property.stream().map(Object::toString).findFirst().orElse(null);
   }
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/adap_hierarchicalclustering/ADAP3DecompositionV1_5Task.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/adap_hierarchicalclustering/ADAP3DecompositionV1_5Task.java
@@ -187,14 +187,14 @@ public class ADAP3DecompositionV1_5Task extends AbstractTask {
       if (component.getSpectrum().isEmpty())
         continue;
 
-      FeatureListRow row = new ModularFeatureListRow(resolvedPeakList, ++rowID);
+      ModularFeatureListRow row = new ModularFeatureListRow(resolvedPeakList, ++rowID);
 
       // Add the reference peak
       FeatureListRow refPeakRow = originalPeakList.getRow(component.getBestPeak().getInfo().peakID);
       // ?
       refPeakRow.setFeatureList(resolvedPeakList);
       // ?
-      Feature refPeak = new ModularFeature(refPeakRow.getBestFeature());
+      Feature refPeak = new ModularFeature(resolvedPeakList, refPeakRow.getBestFeature());
 
       // Add spectrum
       List<DataPoint> dataPoints = new ArrayList<>();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/adap_mcr/ADAP3DecompositionV2Task.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/adap_mcr/ADAP3DecompositionV2Task.java
@@ -58,7 +58,7 @@ public class ADAP3DecompositionV2Task extends AbstractTask {
   // Feature lists.
   private final MZmineProject project;
   private final ChromatogramPeakPair originalLists;
-  private FeatureList newPeakList;
+  private ModularFeatureList newPeakList;
   private final Decomposition decomposition;
 
   // User parameters
@@ -145,11 +145,11 @@ public class ADAP3DecompositionV2Task extends AbstractTask {
     }
   }
 
-  private FeatureList decomposePeaks(@Nonnull ChromatogramPeakPair lists) {
+  private ModularFeatureList decomposePeaks(@Nonnull ChromatogramPeakPair lists) {
     RawDataFile dataFile = lists.chromatograms.getRawDataFile(0);
 
     // Create new feature list.
-    final FeatureList resolvedPeakList = new ModularFeatureList(lists.peaks + " "
+    final ModularFeatureList resolvedPeakList = new ModularFeatureList(lists.peaks + " "
         + parameters.getParameter(ADAP3DecompositionV2Parameters.SUFFIX).getValue(), dataFile);
 
     // Load previous applied methods.
@@ -196,7 +196,7 @@ public class ADAP3DecompositionV2Task extends AbstractTask {
           new SimpleIsotopePattern(dataPoints.toArray(new DataPoint[dataPoints.size()]),
               IsotopePattern.IsotopePatternStatus.PREDICTED, "Spectrum"));
 
-      FeatureListRow row = new ModularFeatureListRow((ModularFeatureList) resolvedPeakList, ++rowID);
+      ModularFeatureListRow row = new ModularFeatureListRow((ModularFeatureList) resolvedPeakList, ++rowID);
 
       row.addFeature(dataFile, refPeak);
 
@@ -224,7 +224,7 @@ public class ADAP3DecompositionV2Task extends AbstractTask {
    * Performs ADAP Peak Decomposition
    *
    * @param chromatograms list of {@link BetterPeak} representing chromatograms
-   * @param ranges arrays of {@link RetTimeClusterer.Item} containing ranges of detected peaks
+   * @param peaks containing ranges of detected peaks
    * @return Collection of dulab.adap.Component objects
    */
 
@@ -279,12 +279,11 @@ public class ADAP3DecompositionV2Task extends AbstractTask {
     for (double intensity : chromatogram.ys)
       dataPoints[count++] = new SimpleDataPoint(peak.getMZ(), intensity);
 
-    ModularFeature newFeature = new ModularFeature(file, peak.getMZ(), (float) peak.getRetTime(),
+    ModularFeature newFeature = new ModularFeature(newPeakList, file, peak.getMZ(), (float) peak.getRetTime(),
         (float) peak.getIntensity(), (float) area, scanNumbers, dataPoints, FeatureStatus.MANUAL,
         representativeScan, representativeScan, new int[] {}, Range.closed((float) peak.getFirstRetTime(),
         (float) peak.getLastRetTime()), Range.closed(peak.getMZ() - 0.01, peak.getMZ() + 0.01),
         Range.closed(0f, (float) peak.getIntensity()));
-    newFeature.setFeatureList(newPeakList);
     return newFeature;
   }
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_adap3/ADAP3AlignerTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_adap3/ADAP3AlignerTask.java
@@ -171,7 +171,7 @@ public class ADAP3AlignerTask extends AbstractTask {
     process();
 
     // Create new feature list
-    final FeatureList alignedPeakList =
+    final ModularFeatureList alignedPeakList =
         new ModularFeatureList(peakListName, allDataFiles.toArray(new RawDataFile[0]));
 
     int rowID = 0;
@@ -182,7 +182,7 @@ public class ADAP3AlignerTask extends AbstractTask {
 
     for (final ReferenceComponent referenceComponent : alignedComponents) {
 
-      ModularFeatureListRow newRow = new ModularFeatureListRow((ModularFeatureList) alignedPeakList, ++rowID);
+      ModularFeatureListRow newRow = new ModularFeatureListRow(alignedPeakList, ++rowID);
       for (int i = 0; i < referenceComponent.size(); ++i) {
 
         Component component = referenceComponent.getComponent(i);
@@ -199,7 +199,7 @@ public class ADAP3AlignerTask extends AbstractTask {
         RawDataFile file = row.getRawDataFiles().get(0);
 
         // Create a new MZmine feature
-        Feature feature = ADAPInterface.peakToFeature(file, peak);
+        Feature feature = ADAPInterface.peakToFeature(alignedPeakList, file, peak);
 
         // Add spectrum as an isotopic pattern
         DataPoint[] spectrum = component.getSpectrum().entrySet().stream()
@@ -226,9 +226,9 @@ public class ADAP3AlignerTask extends AbstractTask {
   }
 
   /**
-   * Convert a {@link PeakListRow} with one {@link Feature} into {@link Component}.
+   * Convert a {@link FeatureListRow} with one {@link Feature} into {@link Component}.
    *
-   * @param row an instance of {@link PeakListRow}. This parameter cannot be null.
+   * @param row an instance of {@link FeatureListRow}. This parameter cannot be null.
    * @return an instance of {@link Component} or null if the row doesn't contain any peaks or
    *         isotope patterns.
    */
@@ -270,7 +270,6 @@ public class ADAP3AlignerTask extends AbstractTask {
   /**
    * Call the alignment from the ADAP package.
    *
-   * @param alignment an instance of {@link Project} containing all samples and peaks to be aligned.
    */
   private void process() {
     AlignmentParameters params = new AlignmentParameters()
@@ -292,12 +291,12 @@ public class ADAP3AlignerTask extends AbstractTask {
   }
 
   /**
-   * Find the existing {@link PeakListRow} for a given feature list ID and row ID.
+   * Find the existing {@link FeatureListRow} for a given feature list ID and row ID.
    *
-   * @param peakListID number of a feature list in the array of {@link PeakList}. The numeration
+   * @param peakListID number of a feature list in the array of {@link FeatureList}. The numeration
    *        starts with 0.
-   * @param rowID integer that is returned by method getId() of {@link PeakListRow}.
-   * @return an instance of {@link PeakListRow} if an existing row is found. Otherwise it returns
+   * @param rowID integer that is returned by method getId() of {@link FeatureListRow}.
+   * @return an instance of {@link FeatureListRow} if an existing row is found. Otherwise it returns
    *         null.
    */
   @Nullable
@@ -320,11 +319,11 @@ public class ADAP3AlignerTask extends AbstractTask {
   }
 
   /**
-   * Find the existing {@link PeakList} for a given feature list ID.
+   * Find the existing {@link FeatureList} for a given feature list ID.
    *
-   * @param peakListId number of a feature list in the array of {@link PeakList}. The numeration
+   * @param peakListId number of a feature list in the array of {@link FeatureList}. The numeration
    *        starts with 0.
-   * @return an instance of {@link PeakList} if a feature list is found, or null.
+   * @return an instance of {@link FeatureList} if a feature list is found, or null.
    */
   @Nullable
   private FeatureList findPeakList(int peakListId) {

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_join/JoinAlignerTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_join/JoinAlignerTask.java
@@ -313,14 +313,8 @@ public class JoinAlignerTask extends AbstractTask {
           targetRow.addFeature(file, row.getFeature(file));
         }
 
-        // Add all non-existing identities from the original row to the
-        // aligned row
-        FeatureUtils.copyFeatureListRowProperties(row, targetRow);
-
         processedRows++;
-
       }
-
     } // Next feature list
 
     // Add new aligned feature list to the project

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_ransac/RansacAlignerTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_ransac/RansacAlignerTask.java
@@ -166,12 +166,7 @@ class RansacAlignerTask extends AbstractTask {
           targetRow.addFeature(file, row.getFeature(file));
         }
 
-        // Add all non-existing identities from the original row to the
-        // aligned row
-        FeatureUtils.copyFeatureListRowProperties(row, targetRow);
-
         processedRows++;
-
       }
 
     } // Next feature list

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ModularADAPChromatogramBuilderTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ModularADAPChromatogramBuilderTask.java
@@ -21,6 +21,7 @@
 package io.github.mzmine.modules.dataprocessing.featdet_adapchromatogrambuilder;
 
 
+import io.github.mzmine.datamodel.features.types.FeatureShapeType;
 import io.github.mzmine.util.FeatureConvertors;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -394,6 +395,7 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
       ModularFeature modular = FeatureConvertors.ADAPChromatogramToModularFeature(finishedFeature);
       ModularFeatureListRow newRow =
           new ModularFeatureListRow(newFeatureList, newFeatureID, dataFile, modular);
+      newRow.set(FeatureShapeType.class, newRow.getFeaturesProperty());
       newFeatureList.addRow(newRow);
       newFeatureID++;
     }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/DeconvolutionTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/DeconvolutionTask.java
@@ -31,6 +31,7 @@ import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
+import io.github.mzmine.util.DataTypeUtils;
 import io.github.mzmine.util.FeatureConvertors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -205,7 +206,6 @@ public class DeconvolutionTask extends AbstractTask {
    * Deconvolve a chromatogram into separate peaks.
    *
    * @param peakList holds the chromatogram to deconvolve.
-   * @param mzCenterFunction2
    * @return a new feature list holding the resolved peaks.
    * @throws RSessionWrapperException
    */
@@ -233,8 +233,9 @@ public class DeconvolutionTask extends AbstractTask {
       this.RTRangeMSMS = 0;
 
     // Create new feature list.
-    final FeatureList resolvedPeaks =
+    final ModularFeatureList resolvedPeaks =
         new ModularFeatureList(peakList + " " + parameters.getParameter(SUFFIX).getValue(), dataFile);
+    DataTypeUtils.addDefaultChromatographicTypeColumns(resolvedPeaks);
 
     // Load previous applied methods.
     for (final FeatureListAppliedMethod method : peakList.getAppliedMethods()) {
@@ -267,7 +268,6 @@ public class DeconvolutionTask extends AbstractTask {
 
       // Add peaks to the new feature list.
       for (final ResolvedPeak peak : peaks) {
-
         peak.setParentChromatogramRowID(currentRow.getID());
 
         final FeatureListRow newRow = new ModularFeatureListRow((ModularFeatureList) resolvedPeaks, peakId++);

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_msn/MsnPeakPickingTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_msn/MsnPeakPickingTask.java
@@ -199,7 +199,10 @@ public class MsnPeakPickingTask extends AbstractTask {
       return null;
     }
 
-    int[] fragmentScanNumbers = scan.getFragmentScanNumbers();
+    // int[] fragmentScanNumbers = scan.getFragmentScanNumbers();
+    int[] fragmentScanNumbers = new int[0];
+    if(fragmentScanNumbers==null || fragmentScanNumbers.length==0)
+      return new int[0];
 
     // Recursively search fragment scans for all scan numbers at MS level.
     if (fragmentScanNumbers != null) {

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_smoothing/SmoothingTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_smoothing/SmoothingTask.java
@@ -193,12 +193,11 @@ public class SmoothingTask extends AbstractTask {
 
                 // Create a new peak.
                 ModularFeature newFeature
-                    = new ModularFeature(dataFile, maxDataPoint.getMZ(), peak.getRT(), maxIntensity,
+                    = new ModularFeature(newPeakList, dataFile, maxDataPoint.getMZ(), peak.getRT(), maxIntensity,
                     area, scanNumbers, newDataPoints, peak.getFeatureStatus(), maxScanNumber,
                     peak.getMostIntenseFragmentScanNumber(),
                     peak.getAllMS2FragmentScanNumbers().stream().mapToInt(i -> i).toArray(), peak.getRawDataPointsRTRange(),
                     peak.getRawDataPointsMZRange(), RangeUtils.toFloatRange(intensityRange));
-                newFeature.setFeatureList(newPeakList);
                 newRow.addFeature(dataFile, newFeature);
               }
             }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_targeted/Gap.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_targeted/Gap.java
@@ -27,6 +27,7 @@ import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.FeatureStatus;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.datamodel.impl.SimpleDataPoint;
 import io.github.mzmine.util.scans.ScanUtils;
 
@@ -46,8 +47,8 @@ class Gap {
   /**
    * Constructor: Initializes an empty gap
    *
-   * @param mz M/Z coordinate of this empty gap
-   * @param rt RT coordinate of this empty gap
+   * @param mzRange M/Z coordinate of this empty gap
+   * @param rtRange RT coordinate of this empty gap
    */
   Gap(FeatureListRow peakListRow, RawDataFile rawDataFile, Range<Double> mzRange,
       Range<Float> rtRange, double intTolerance, double noiseLevel) {
@@ -190,10 +191,9 @@ class Gap {
 
       // Is intensity above the noise level?
       if (height >= noiseLevel) {
-        ModularFeature newPeak = new ModularFeature(rawDataFile, mz, rt, height, area, scanNumbers,
+        ModularFeature newPeak = new ModularFeature((ModularFeatureList) peakListRow.getFeatureList(), rawDataFile, mz, rt, height, area, scanNumbers,
             finalDataPoint, FeatureStatus.ESTIMATED, representativeScan, fragmentScan,
             allMS2fragmentScanNumbers, finalRTRange, finalMZRange, finalIntensityRange);
-        newPeak.setFeatureList(peakListRow.getFeatureList());
 
         // Fill the gap
         peakListRow.addFeature(rawDataFile, newPeak);

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_blanksubtraction/PeakListBlankSubtractionMasterTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_blanksubtraction/PeakListBlankSubtractionMasterTask.java
@@ -18,10 +18,7 @@
 
 package io.github.mzmine.modules.dataprocessing.filter_blanksubtraction;
 
-import io.github.mzmine.datamodel.features.FeatureList;
-import io.github.mzmine.datamodel.features.FeatureListRow;
-import io.github.mzmine.datamodel.features.ModularFeatureList;
-import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
+import io.github.mzmine.datamodel.features.*;
 import io.github.mzmine.util.FeatureListUtils;
 import io.github.mzmine.util.FeatureUtils;
 import java.text.NumberFormat;
@@ -115,7 +112,7 @@ public class PeakListBlankSubtractionMasterTask extends AbstractTask {
     // minBlankDetections);
 
     FeatureListRow[] rows =
-        FeatureUtils.copyFeatureRows(alignedFeatureList.getRows().toArray(FeatureListRow[]::new));
+        FeatureUtils.copyFeatureRows(alignedFeatureList.getRows().toArray(ModularFeatureListRow[]::new));
     rows = FeatureUtils.sortRowsMzAsc(rows);
 
     for (RawDataFile raw : alignedFeatureList.getRawDataFiles()) {

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_isotopegrouper/IsotopeGrouperTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_isotopegrouper/IsotopeGrouperTask.java
@@ -216,7 +216,6 @@ class IsotopeGrouperTask extends AbstractTask {
       newPeak.setCharge(bestFitCharge);
 
       FeatureListRow newRow = new ModularFeatureListRow((ModularFeatureList) deisotopedFeatureList, oldRow.getID(), newPeak);
-      FeatureUtils.copyFeatureListRowProperties(oldRow, newRow);
       newRow.addFeature(dataFile, newPeak);
       deisotopedFeatureList.addRow(newRow);
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_neutralloss/NeutralLossFilterTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_neutralloss/NeutralLossFilterTask.java
@@ -68,7 +68,7 @@ public class NeutralLossFilterTask extends AbstractTask {
   private double minHeight;
   private int totalRows, finishedRows;
   private String molecule;
-  private FeatureList resultPeakList;
+  private ModularFeatureList resultPeakList;
   private MZmineProject project;
   private FeatureList peakList;
   private boolean checkRT;
@@ -253,12 +253,12 @@ public class NeutralLossFilterTask extends AbstractTask {
 
       String comParent = "", comChild = "";
 
-      FeatureListRow originalChild = getRowFromCandidate(candidates, 0, plh);
+      ModularFeatureListRow originalChild = getRowFromCandidate(candidates, 0, plh);
       if (originalChild == null) {
         finishedRows++;
         continue;
       }
-      FeatureListRow child = copyPeakRow(originalChild);
+      FeatureListRow child = new ModularFeatureListRow(resultPeakList, originalChild, true);
 
       if (resultMap.containsID(child.getID()))
         comChild += resultMap.getRowByID(child.getID()).getComment();
@@ -276,14 +276,14 @@ public class NeutralLossFilterTask extends AbstractTask {
                                                   // which we
                                                   // added before
       {
-        FeatureListRow originalParent = getRowFromCandidate(candidates, 1, plh);
+        ModularFeatureListRow originalParent = getRowFromCandidate(candidates, 1, plh);
 
         if (originalParent == null) {
           allPeaksAddable = false;
           continue;
         }
 
-        FeatureListRow parent = copyPeakRow(originalParent);
+        FeatureListRow parent = new ModularFeatureListRow(resultPeakList, originalParent, true);
 
         if (resultMap.containsID(parent.getID()))
           comParent += resultMap.getRowByID(parent.getID()).getComment();
@@ -352,7 +352,6 @@ public class NeutralLossFilterTask extends AbstractTask {
    *
    * @param pL
    * @param parentIndex index of possible parent peak
-   * @param maxMass
    * @return will return ArrayList<PeakListRow> of all peaks within the range of pL[parentIndex].mz
    *         -> pL[parentIndex].mz+maxMass
    */
@@ -388,28 +387,6 @@ public class NeutralLossFilterTask extends AbstractTask {
         return buf;
     }
     return buf;
-  }
-
-  /**
-   * Create a copy of a feature list row.
-   *
-   * @param row the row to copy.
-   * @return the newly created copy.
-   */
-  private static FeatureListRow copyPeakRow(final FeatureListRow row) {
-    // Copy the feature list row.
-    final FeatureListRow newRow = new ModularFeatureListRow(
-        (ModularFeatureList) row.getFeatureList(), row.getID());
-    FeatureUtils.copyFeatureListRowProperties(row, newRow);
-
-    // Copy the peaks.
-    for (final Feature peak : row.getFeatures()) {
-      final Feature newPeak = new ModularFeature(peak);
-      FeatureUtils.copyFeatureProperties(peak, newPeak);
-      newRow.addFeature(peak.getRawDataFile(), newPeak);
-    }
-
-    return newRow;
   }
 
   public static double round(double value, int places) { // https://stackoverflow.com/questions/2808535/round-a-double-to-2-decimal-places
@@ -466,7 +443,7 @@ public class NeutralLossFilterTask extends AbstractTask {
    * @return null if no peak with the given parameters exists, the specified feature list row
    *         otherwise.
    */
-  private @Nullable FeatureListRow getRowFromCandidate(@Nonnull Candidates candidates, int peakIndex,
+  private @Nullable ModularFeatureListRow getRowFromCandidate(@Nonnull Candidates candidates, int peakIndex,
       @Nonnull PeakListHandler plh) {
 
     if (peakIndex >= candidates.size())
@@ -477,7 +454,7 @@ public class NeutralLossFilterTask extends AbstractTask {
     if (cand != null) {
       int id = cand.getCandID();
       FeatureListRow original = plh.getRowByID(id);
-      return original;
+      return (ModularFeatureListRow) original;
     }
     return null;
   }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_peakcomparisonrowfilter/PeakComparisonRowFilterTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_peakcomparisonrowfilter/PeakComparisonRowFilterTask.java
@@ -128,7 +128,7 @@ public class PeakComparisonRowFilterTask extends AbstractTask {
   private FeatureList filterPeakListRows(final FeatureList peakList) {
 
     // Create new feature list.
-    final FeatureList newPeakList = new ModularFeatureList(
+    final ModularFeatureList newPeakList = new ModularFeatureList(
         peakList.getName() + ' '
             + parameters.getParameter(PeakComparisonRowFilterParameters.SUFFIX).getValue(),
         peakList.getRawDataFiles());
@@ -165,7 +165,7 @@ public class PeakComparisonRowFilterTask extends AbstractTask {
             .getEmbeddedParameter().getValue();
 
     // Setup variables
-    final FeatureListRow[] rows = peakList.getRows().toArray(FeatureListRow[]::new);
+    final ModularFeatureListRow[] rows = peakList.getRows().toArray(ModularFeatureListRow[]::new);
     RawDataFile rawDataFile1;
     RawDataFile rawDataFile2;
     Feature peak1;
@@ -205,7 +205,7 @@ public class PeakComparisonRowFilterTask extends AbstractTask {
       double foldChange = 0.0;
       double ppmDiff = 0.0;
       double rtDiff = 0.0;
-      final FeatureListRow row = rows[processedRows];
+      final ModularFeatureListRow row = rows[processedRows];
       rawDataFile1 = rawDataFiles[columnIndex1];
       rawDataFile2 = rawDataFiles[columnIndex2];
 
@@ -248,34 +248,11 @@ public class PeakComparisonRowFilterTask extends AbstractTask {
 
       // Good row?
       if (allCriteriaMatched)
-        newPeakList.addRow(copyPeakRow(row));
+        newPeakList.addRow(new ModularFeatureListRow(newPeakList, row, true));
 
     }
 
     return newPeakList;
-  }
-
-  /**
-   * Create a copy of a feature list row.
-   *
-   * @param row the row to copy.
-   * @return the newly created copy.
-   */
-  private FeatureListRow copyPeakRow(final FeatureListRow row) {
-
-    // Copy the feature list row.
-    final FeatureListRow newRow = new ModularFeatureListRow((ModularFeatureList) filteredPeakList, row.getID());
-    FeatureUtils.copyFeatureListRowProperties(row, newRow);
-
-    // Copy the peaks.
-    for (final Feature peak : row.getFeatures()) {
-
-      final Feature newPeak = new ModularFeature(peak);
-      FeatureUtils.copyFeatureProperties(peak, newPeak);
-      newRow.addFeature(peak.getRawDataFile(), newPeak);
-    }
-
-    return newRow;
   }
 
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_rowsfilter/RowsFilterTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_rowsfilter/RowsFilterTask.java
@@ -198,13 +198,13 @@ public class RowsFilterTask extends AbstractTask {
     int intMinCount = minCount.intValue();
 
     // Filter rows.
-    final FeatureListRow[] rows = featureList.getRows().toArray(FeatureListRow[]::new);
+    final ModularFeatureListRow[] rows = featureList.getRows().toArray(ModularFeatureListRow[]::new);
     totalRows = rows.length;
     for (processedRows = 0; !isCanceled() && processedRows < totalRows; processedRows++) {
 
       filterRowCriteriaFailed = false;
 
-      final FeatureListRow row = rows[processedRows];
+      final ModularFeatureListRow row = rows[processedRows];
 
       final int featureCount = getFeatureCount(row, groupingParameter);
 
@@ -415,7 +415,7 @@ public class RowsFilterTask extends AbstractTask {
       if (!filterRowCriteriaFailed && !removeRow) {
         // Only add the row if none of the criteria have failed.
         rowsCount++;
-        FeatureListRow resetRow = copyFeatureRow(newFeatureList,row);
+        FeatureListRow resetRow = new ModularFeatureListRow(newFeatureList, row, true);
         if (renumber) {
           resetRow.setID(rowsCount);
         }
@@ -426,7 +426,7 @@ public class RowsFilterTask extends AbstractTask {
         // Only remove rows that match *all* of the criteria, so add
         // rows that fail any of the criteria.
         rowsCount++;
-        FeatureListRow resetRow = copyFeatureRow(newFeatureList, row);
+        FeatureListRow resetRow = new ModularFeatureListRow(newFeatureList, row, true);
         if (renumber) {
           resetRow.setID(rowsCount);
         }
@@ -436,37 +436,6 @@ public class RowsFilterTask extends AbstractTask {
     }
 
     return newFeatureList;
-  }
-
-  /**
-   * Create a copy of a feature list row.
-   *
-   *
-   * @param newFeatureList
-   * @param row the row to copy.
-   * @return the newly created copy.
-   */
-  private static FeatureListRow copyFeatureRow(ModularFeatureList newFeatureList, final FeatureListRow row) {
-
-    // Copy the feature list row.
-    final FeatureListRow newRow = new ModularFeatureListRow(newFeatureList, row.getID());
-    FeatureUtils.copyFeatureListRowProperties(row, newRow);
-
-    // Copy the features.
-    for (final Feature feature : row.getFeatures()) {
-      final Feature newFeature = new ModularFeature(newFeatureList,feature);
-      FeatureUtils.copyFeatureProperties(feature, newFeature);
-      newRow.addFeature(feature.getRawDataFile(), newFeature);
-    }
-
-    // Add FeatureInformation
-    if (row.getFeatureInformation() != null) {
-      SimpleFeatureInformation information =
-          new SimpleFeatureInformation(new HashMap<>(row.getFeatureInformation().getAllProperties()));
-      newRow.setFeatureInformation(information);
-    }
-
-    return newRow;
   }
 
   private int getFeatureCount(FeatureListRow row, String groupingParameter) {

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_rowsfilter/RowsFilterTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_rowsfilter/RowsFilterTask.java
@@ -136,7 +136,7 @@ public class RowsFilterTask extends AbstractTask {
 
     // Create new feature list.
 
-    final FeatureList newFeatureList = new ModularFeatureList(
+    final ModularFeatureList newFeatureList = new ModularFeatureList(
         featureList.getName() + ' ' + parameters.getParameter(RowsFilterParameters.SUFFIX).getValue(),
         featureList.getRawDataFiles());
 
@@ -415,7 +415,7 @@ public class RowsFilterTask extends AbstractTask {
       if (!filterRowCriteriaFailed && !removeRow) {
         // Only add the row if none of the criteria have failed.
         rowsCount++;
-        FeatureListRow resetRow = copyFeatureRow(row);
+        FeatureListRow resetRow = copyFeatureRow(newFeatureList,row);
         if (renumber) {
           resetRow.setID(rowsCount);
         }
@@ -426,7 +426,7 @@ public class RowsFilterTask extends AbstractTask {
         // Only remove rows that match *all* of the criteria, so add
         // rows that fail any of the criteria.
         rowsCount++;
-        FeatureListRow resetRow = copyFeatureRow(row);
+        FeatureListRow resetRow = copyFeatureRow(newFeatureList, row);
         if (renumber) {
           resetRow.setID(rowsCount);
         }
@@ -441,20 +441,20 @@ public class RowsFilterTask extends AbstractTask {
   /**
    * Create a copy of a feature list row.
    *
+   *
+   * @param newFeatureList
    * @param row the row to copy.
    * @return the newly created copy.
    */
-  private static FeatureListRow copyFeatureRow(final FeatureListRow row) {
+  private static FeatureListRow copyFeatureRow(ModularFeatureList newFeatureList, final FeatureListRow row) {
 
     // Copy the feature list row.
-    final FeatureListRow newRow = new ModularFeatureListRow(
-        (ModularFeatureList) row.getFeatureList(), row.getID());
+    final FeatureListRow newRow = new ModularFeatureListRow(newFeatureList, row.getID());
     FeatureUtils.copyFeatureListRowProperties(row, newRow);
 
     // Copy the features.
     for (final Feature feature : row.getFeatures()) {
-
-      final Feature newFeature = new ModularFeature(feature);
+      final Feature newFeature = new ModularFeature(newFeatureList,feature);
       FeatureUtils.copyFeatureProperties(feature, newFeature);
       newRow.addFeature(feature.getRawDataFile(), newFeature);
     }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/Gap.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/Gap.java
@@ -27,6 +27,7 @@ import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.FeatureStatus;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.datamodel.impl.SimpleDataPoint;
 import io.github.mzmine.util.RangeUtils;
 import io.github.mzmine.util.scans.ScanUtils;
@@ -48,8 +49,8 @@ public class Gap {
   /**
    * Constructor: Initializes an empty gap
    * 
-   * @param mz M/Z coordinate of this empty gap
-   * @param rt RT coordinate of this empty gap
+   * @param mzRange M/Z coordinate of this empty gap
+   * @param rtRange RT coordinate of this empty gap
    */
   public Gap(FeatureListRow peakListRow, RawDataFile rawDataFile, Range<Double> mzRange,
       Range<Float> rtRange, double intTolerance) {
@@ -114,7 +115,6 @@ public class Gap {
   /**
    * Finalizes the gap, adds a peak
    * 
-   * @param lock A lock for multi threading purpose. null if single threaded
    */
   public void noMoreOffers() {
 
@@ -189,7 +189,7 @@ public class Gap {
       int[] allMS2FragmentScanNumbers =
           ScanUtils.findAllMS2FragmentScans(rawDataFile, finalRTRange, finalMZRange);
 
-      ModularFeature newPeak = new ModularFeature(rawDataFile, mz, rt, height, area, scanNumbers,
+      ModularFeature newPeak = new ModularFeature((ModularFeatureList) peakListRow.getFeatureList(), rawDataFile, mz, rt, height, area, scanNumbers,
           finalDataPoint, FeatureStatus.ESTIMATED, representativeScan, fragmentScan,
           allMS2FragmentScanNumbers, finalRTRange, finalMZRange, finalIntensityRange);
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/PeakFinderTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/PeakFinderTask.java
@@ -47,7 +47,7 @@ class PeakFinderTask extends AbstractTask {
   private Logger logger = Logger.getLogger(this.getClass().getName());
 
   private final MZmineProject project;
-  private FeatureList peakList, processedPeakList;
+  private ModularFeatureList peakList, processedPeakList;
   private String suffix;
   private double intTolerance;
   private MZTolerance mzTolerance;
@@ -63,7 +63,7 @@ class PeakFinderTask extends AbstractTask {
   PeakFinderTask(MZmineProject project, FeatureList peakList, ParameterSet parameters) {
 
     this.project = project;
-    this.peakList = peakList;
+    this.peakList = (ModularFeatureList) peakList;
     this.parameters = parameters;
 
     suffix = parameters.getParameter(PeakFinderParameters.suffix).getValue();
@@ -87,28 +87,15 @@ class PeakFinderTask extends AbstractTask {
     processedScans = new AtomicInteger();
 
     // Create new feature list
-    processedPeakList = new ModularFeatureList(peakList + " " + suffix, peakList.getRawDataFiles());
-
-    // Fill new feature list with empty rows
-    for (int row = 0; row < peakList.getNumberOfRows(); row++) {
-      FeatureListRow sourceRow = peakList.getRow(row);
-      FeatureListRow newRow = new ModularFeatureListRow((ModularFeatureList) processedPeakList, sourceRow.getID());
-      newRow.setComment(sourceRow.getComment());
-      for (FeatureIdentity ident : sourceRow.getPeakIdentities()) {
-        newRow.addFeatureIdentity(ident, false);
-      }
-      if (sourceRow.getPreferredFeatureIdentity() != null) {
-        newRow.setPreferredFeatureIdentity(sourceRow.getPreferredFeatureIdentity());
-      }
-      processedPeakList.addRow(newRow);
-    }
+    processedPeakList = peakList.createCopy(peakList + " " + suffix);
+//            new ModularFeatureList(peakList + " " + suffix, peakList.getRawDataFiles());
 
     if (rtCorrection) {
       totalScans *= 2;
       // Fill the gaps of a random sample using all the other samples and
       // take it as master list
       // to fill the gaps of the other samples
-      masterSample = (int) Math.floor(Math.random() * peakList.getNumberOfRawDataFiles());
+      masterSample = (int) Math.floor(Math.random() * processedPeakList.getNumberOfRawDataFiles());
       fillList(MASTERLIST);
 
       // Process all raw data files
@@ -117,7 +104,7 @@ class PeakFinderTask extends AbstractTask {
     } else {
 
       // Process all raw data files
-      IntStream rawStream = IntStream.range(0, peakList.getNumberOfRawDataFiles());
+      IntStream rawStream = IntStream.range(0, processedPeakList.getNumberOfRawDataFiles());
       if (useParallelStream)
         rawStream = rawStream.parallel();
 
@@ -127,38 +114,35 @@ class PeakFinderTask extends AbstractTask {
           // inside stream - only skips this element
           return;
         }
-        RawDataFile dataFile = peakList.getRawDataFile(i);
+        RawDataFile dataFile = processedPeakList.getRawDataFile(i);
 
         List<Gap> gaps = new ArrayList<Gap>();
 
         // Fill each row of this raw data file column, create new empty
         // gaps
         // if necessary
-        for (int row = 0; row < peakList.getNumberOfRows(); row++) {
+        for (int row = 0; row < processedPeakList.getNumberOfRows(); row++) {
           // Canceled?
           if (isCanceled()) {
             // inside stream - only skips this element
             return;
           }
 
-          FeatureListRow sourceRow = peakList.getRow(row);
           FeatureListRow newRow = processedPeakList.getRow(row);
 
-          Feature sourcePeak = sourceRow.getFeature(dataFile);
+          Feature sourcePeak = newRow.getFeature(dataFile);
 
           if (sourcePeak == null) {
 
             // Create a new gap
 
-            Range<Double> mzRange = mzTolerance.getToleranceRange(sourceRow.getAverageMZ());
-            Range<Float> rtRange = rtTolerance.getToleranceRange(sourceRow.getAverageRT());
+            Range<Double> mzRange = mzTolerance.getToleranceRange(newRow.getAverageMZ());
+            Range<Float> rtRange = rtTolerance.getToleranceRange(newRow.getAverageRT());
 
             Gap newGap = new Gap(newRow, dataFile, mzRange, rtRange, intTolerance);
 
             gaps.add(newGap);
 
-          } else {
-            newRow.addFeature(dataFile, sourcePeak);
           }
         }
 
@@ -203,9 +187,6 @@ class PeakFinderTask extends AbstractTask {
     // Append processed feature list to the project
     project.addFeatureList(processedPeakList);
 
-    // Add quality parameters to peaks
-    //QualityParameters.calculateQualityParameters(processedPeakList);
-
     // Add task description to peakList
     processedPeakList
         .addDescriptionOfAppliedTask(new SimpleFeatureListAppliedMethod("Gap filling ", parameters));
@@ -220,22 +201,22 @@ class PeakFinderTask extends AbstractTask {
   }
 
   public void fillList(boolean masterList) {
-    for (int i = 0; i < peakList.getNumberOfRawDataFiles(); i++) {
+    for (int i = 0; i < processedPeakList.getNumberOfRawDataFiles(); i++) {
       if (i != masterSample) {
 
         RawDataFile datafile1;
         RawDataFile datafile2;
 
         if (masterList) {
-          datafile1 = peakList.getRawDataFile(masterSample);
-          datafile2 = peakList.getRawDataFile(i);
+          datafile1 = processedPeakList.getRawDataFile(masterSample);
+          datafile2 = processedPeakList.getRawDataFile(i);
         } else {
-          datafile1 = peakList.getRawDataFile(i);
-          datafile2 = peakList.getRawDataFile(masterSample);
+          datafile1 = processedPeakList.getRawDataFile(i);
+          datafile2 = processedPeakList.getRawDataFile(masterSample);
         }
         RegressionInfo info = new RegressionInfo();
 
-        for (FeatureListRow row : peakList.getRows()) {
+        for (FeatureListRow row : processedPeakList.getRows()) {
           Feature peaki = row.getFeature(datafile1);
           Feature peake = row.getFeature(datafile2);
           if (peaki != null && peake != null) {
@@ -255,7 +236,7 @@ class PeakFinderTask extends AbstractTask {
         // Fill each row of this raw data file column, create new empty
         // gaps
         // if necessary
-        for (int row = 0; row < peakList.getNumberOfRows(); row++) {
+        for (int row = 0; row < processedPeakList.getNumberOfRows(); row++) {
           FeatureListRow sourceRow = peakList.getRow(row);
           FeatureListRow newRow = processedPeakList.getRow(row);
 
@@ -268,8 +249,8 @@ class PeakFinderTask extends AbstractTask {
             double mz = sourceRow.getAverageMZ();
             double rt2 = -1;
             if (!masterList) {
-              if (processedPeakList.getRow(row).getFeature(datafile2) != null) {
-                rt2 = processedPeakList.getRow(row).getFeature(datafile2).getRT();
+              if (peakList.getRow(row).getFeature(datafile2) != null) {
+                rt2 = peakList.getRow(row).getFeature(datafile2).getRT();
               }
             } else {
               if (peakList.getRow(row).getFeature(datafile2) != null) {
@@ -342,10 +323,6 @@ class PeakFinderTask extends AbstractTask {
 
   public String getTaskDescription() {
     return "Gap filling " + peakList;
-  }
-
-  FeatureList getPeakList() {
-    return peakList;
   }
 
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/multithreaded/SubTaskFinishListener.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/multithreaded/SubTaskFinishListener.java
@@ -19,6 +19,7 @@
 package io.github.mzmine.modules.dataprocessing.gapfill_peakfinder.multithreaded;
 
 import io.github.mzmine.datamodel.features.FeatureList;
+import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
@@ -31,12 +32,12 @@ public class SubTaskFinishListener implements Consumer<FeatureList> {
 
   private final MZmineProject project;
   private ParameterSet parameters;
-  private FeatureList peakList;
+  private ModularFeatureList peakList;
   private int tasks;
   private int finished = 0;
   private boolean removeOriginal;
 
-  public SubTaskFinishListener(MZmineProject project, ParameterSet parameters, FeatureList peakList,
+  public SubTaskFinishListener(MZmineProject project, ParameterSet parameters, ModularFeatureList peakList,
       boolean removeOriginal, int tasks) {
     super();
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_spectraldbsearch/RowsSpectralMatchTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_spectraldbsearch/RowsSpectralMatchTask.java
@@ -19,10 +19,15 @@
 package io.github.mzmine.modules.dataprocessing.id_spectraldbsearch;
 
 import io.github.mzmine.datamodel.features.FeatureListRow;
+import io.github.mzmine.datamodel.features.ModularDataModel;
+import io.github.mzmine.datamodel.features.ModularFeatureList;
+import io.github.mzmine.datamodel.features.ModularFeatureListRow;
+import io.github.mzmine.datamodel.features.types.SpectralLibraryMatchType;
 import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
 import java.io.File;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.logging.Level;
@@ -176,6 +181,8 @@ public class RowsSpectralMatchTask extends AbstractTask {
   @Override
   public void run() {
     setStatus(TaskStatus.PROCESSING);
+    addRowTypes();
+
     for (FeatureListRow row : rows) {
       if (isCanceled()) {
         logger.info("Added " + count + " spectral library matches (before being cancelled)");
@@ -240,6 +247,15 @@ public class RowsSpectralMatchTask extends AbstractTask {
     setStatus(TaskStatus.FINISHED);
   }
 
+  private void addRowTypes() {
+    // modular feature list?
+    Arrays.stream(rows).filter(row -> row.getFeatureList() instanceof ModularFeatureList)
+            .map(row -> (ModularFeatureList) row.getFeatureList()).findFirst()
+            .ifPresent(featureList -> {
+              featureList.addRowType(new SpectralLibraryMatchType());
+            });
+  }
+
   /**
    * Remove 13C isotopes from masslist
    * 
@@ -287,8 +303,6 @@ public class RowsSpectralMatchTask extends AbstractTask {
   /**
    * Uses the similarity function and filter to create similarity.
    * 
-   * @param a
-   * @param b
    * @return positive match with similarity or null if criteria was not met
    */
   private SpectralSimilarity createSimilarity(DataPoint[] library, DataPoint[] query) {
@@ -311,7 +325,6 @@ public class RowsSpectralMatchTask extends AbstractTask {
   /**
    * Thresholded masslist
    * 
-   * @param row
    * @return
    * @throws MissingMassListException
    */
@@ -349,7 +362,7 @@ public class RowsSpectralMatchTask extends AbstractTask {
 
   private void addIdentity(FeatureListRow row, SpectralDBFeatureIdentity pid) {
     // add new identity to the row
-    row.addFeatureIdentity(pid, false);
+    row.addSpectralLibraryMatch(pid);
 
     if (matchListener != null)
       matchListener.accept(pid);

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_spectraldbsearch/RowsSpectralMatchTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_spectraldbsearch/RowsSpectralMatchTask.java
@@ -318,8 +318,10 @@ public class RowsSpectralMatchTask extends AbstractTask {
   }
 
   private boolean checkRT(FeatureListRow row, SpectralDBEntry ident) {
+    if(!useRT)
+      return true;
     Float rt = (Float) ident.getField(DBEntryField.RT).orElse(null);
-    return (!useRT || rt == null || rtTolerance.checkWithinTolerance(rt, row.getAverageRT()));
+    return (rt == null || rtTolerance.checkWithinTolerance(rt, row.getAverageRT()));
   }
 
   /**

--- a/src/main/java/io/github/mzmine/modules/example/FeatureLearnerTask.java
+++ b/src/main/java/io/github/mzmine/modules/example/FeatureLearnerTask.java
@@ -45,8 +45,8 @@ class FeatureLearnerTask extends AbstractTask {
   private Logger logger = Logger.getLogger(this.getClass().getName());
 
   private final MZmineProject project;
-  private FeatureList featureList;
-  private FeatureList resultFeatureList;
+  private ModularFeatureList featureList;
+  private ModularFeatureList resultFeatureList;
 
   // features counter
   private int processedFeatures;
@@ -62,12 +62,11 @@ class FeatureLearnerTask extends AbstractTask {
   /**
    * Constructor to set all parameters and the project
    *
-   * @param rawDataFile
    * @param parameters
    */
   public FeatureLearnerTask(MZmineProject project, FeatureList featureList, ParameterSet parameters) {
     this.project = project;
-    this.featureList = featureList;
+    this.featureList = (ModularFeatureList) featureList;
     this.parameters = parameters;
     // Get parameter values for easier use
     suffix = parameters.getParameter(LearnerParameters.suffix).getValue();
@@ -136,8 +135,8 @@ class FeatureLearnerTask extends AbstractTask {
       // ...
 
       // add row to result feature list
-      FeatureListRow row = featureList.getFeatureRow(aFeature);
-      row = copyFeatureRow(row);
+      ModularFeatureListRow row = (ModularFeatureListRow) featureList.getFeatureRow(aFeature);
+      row = new ModularFeatureListRow(resultFeatureList, row, true);
       resultFeatureList.addRow(row);
 
       // Update completion rate
@@ -149,28 +148,6 @@ class FeatureLearnerTask extends AbstractTask {
 
     logger.info("Finished on " + featureList);
     setStatus(TaskStatus.FINISHED);
-  }
-
-  /**
-   * Create a copy of a feature list row.
-   *
-   * @param row the row to copy.
-   * @return the newly created copy.
-   */
-  private static FeatureListRow copyFeatureRow(final FeatureListRow row) {
-    // Copy the feature list row.
-    final FeatureListRow newRow = new ModularFeatureListRow(
-        (ModularFeatureList) row.getFeatureList(), row.getID());
-    FeatureUtils.copyFeatureListRowProperties(row, newRow);
-
-    // Copy the features.
-    for (final Feature feature : row.getFeatures()) {
-      final Feature newFeature = new ModularFeature(feature);
-      FeatureUtils.copyFeatureProperties(feature, newFeature);
-      newRow.addFeature(feature.getRawDataFile(), newFeature);
-    }
-
-    return newRow;
   }
 
   /**

--- a/src/main/java/io/github/mzmine/modules/example/FeatureListRowLearnerTask.java
+++ b/src/main/java/io/github/mzmine/modules/example/FeatureListRowLearnerTask.java
@@ -45,7 +45,7 @@ class FeatureListRowLearnerTask extends AbstractTask {
 
   private final MZmineProject project;
   private FeatureList featureList;
-  private FeatureList resultFeatureList;
+  private ModularFeatureList resultFeatureList;
 
   // features counter
   private int processedFeatures;
@@ -61,8 +61,6 @@ class FeatureListRowLearnerTask extends AbstractTask {
   /**
    * Constructor to set all parameters and the project
    *
-   * @param rawDataFile
-   * @param parameters
    */
   public FeatureListRowLearnerTask(MZmineProject project, FeatureList featureList, ParameterSet parameters) {
     this.project = project;
@@ -110,7 +108,7 @@ class FeatureListRowLearnerTask extends AbstractTask {
      * ---- access mean retention time, mean m/z, maximum intensity, ...<br>
      */
     // get all rows and sort by m/z
-    FeatureListRow[] rows = featureList.getRows().toArray(FeatureListRow[]::new);
+    ModularFeatureListRow[] rows = featureList.getRows().toArray(ModularFeatureListRow[]::new);
     Arrays.sort(rows, new FeatureListRowSorter(SortingProperty.MZ, SortingDirection.Ascending));
 
     totalRows = rows.length;
@@ -119,7 +117,7 @@ class FeatureListRowLearnerTask extends AbstractTask {
       if (isCanceled())
         return;
 
-      FeatureListRow row = rows[i];
+      ModularFeatureListRow row = rows[i];
       // access details
       double mz = row.getAverageMZ();
       double intensity = row.getAverageHeight();
@@ -129,7 +127,7 @@ class FeatureListRowLearnerTask extends AbstractTask {
       // ...
 
       // add row to feature list result
-      FeatureListRow copy = copyFeatureRow(row);
+      ModularFeatureListRow copy = new ModularFeatureListRow(resultFeatureList, row, true);
       resultFeatureList.addRow(copy);
 
       // Update completion rate
@@ -141,28 +139,6 @@ class FeatureListRowLearnerTask extends AbstractTask {
 
     logger.info("Finished on " + featureList);
     setStatus(TaskStatus.FINISHED);
-  }
-
-  /**
-   * Create a copy of a feature list row.
-   *
-   * @param row the row to copy.
-   * @return the newly created copy.
-   */
-  private static FeatureListRow copyFeatureRow(final FeatureListRow row) {
-    // Copy the feature list row.
-    final FeatureListRow newRow = new ModularFeatureListRow(
-        (ModularFeatureList) row.getFeatureList(), row.getID());
-    FeatureUtils.copyFeatureListRowProperties(row, newRow);
-
-    // Copy the features.
-    for (final Feature feature : row.getFeatures()) {
-      final Feature newFeature = new ModularFeature(feature);
-      FeatureUtils.copyFeatureProperties(feature, newFeature);
-      newRow.addFeature(feature.getRawDataFile(), newFeature);
-    }
-
-    return newRow;
   }
 
   /**

--- a/src/main/java/io/github/mzmine/modules/io/csvimport/CsvImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/csvimport/CsvImportTask.java
@@ -68,7 +68,7 @@ public class CsvImportTask extends AbstractTask {
     try{
       FileReader fileReader = new FileReader(fileName);
       CSVReader csvReader = new CSVReader(fileReader);
-      FeatureList newFeatureList = new ModularFeatureList( fileName.getName(), rawDataFile);
+      ModularFeatureList newFeatureList = new ModularFeatureList( fileName.getName(), rawDataFile);
       String[] dataLine;
       int counter = 0;
       while((dataLine = csvReader.readNext()) != null){
@@ -135,7 +135,7 @@ public class CsvImportTask extends AbstractTask {
         int fragmentScan = -1;
         int[] allFragmentScans = new int[]{0};
 
-        Feature feature = new ModularFeature(rawDataFile, feature_mz, feature_rt, feature_height, abundance,
+        Feature feature = new ModularFeature(newFeatureList, rawDataFile, feature_mz, feature_rt, feature_height, abundance,
             scanNumbers, finalDataPoint, status, representativeScan, fragmentScan, allFragmentScans,
             finalRTRange, finalMZRange, finalIntensityRange);
         newRow.addFeature(rawDataFile,feature);

--- a/src/main/java/io/github/mzmine/modules/io/gnpsexport/fbmn/GnpsFbmnMgfExportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/gnpsexport/fbmn/GnpsFbmnMgfExportTask.java
@@ -197,7 +197,8 @@ public class GnpsFbmnMgfExportTask extends AbstractTask {
         continue;
       int msmsScanNumber = bestFeature.getMostIntenseFragmentScanNumber();
       if (rowID != null) {
-        FeatureListRow copyRow = copyFeatureRow(row);
+        // TODO why
+        FeatureListRow copyRow = new ModularFeatureListRow((ModularFeatureList)row.getFeatureList(), (ModularFeatureListRow)row, true);
         // Best feature always exists, because feature list row has at
         // least one feature
         bestFeature = copyRow.getBestFeature();
@@ -303,27 +304,6 @@ public class GnpsFbmnMgfExportTask extends AbstractTask {
   @Override
   public String getTaskDescription() {
     return "Exporting GNPS of feature list(s) " + Arrays.toString(featureLists) + " to MGF file(s)";
-  }
-
-  /**
-   * Create a copy of a feature list row.
-   */
-  private static FeatureListRow copyFeatureRow(final FeatureListRow row) {
-    // Copy the feature list row.
-    final FeatureListRow newRow = new ModularFeatureListRow(
-        (ModularFeatureList) row.getFeatureList(), row.getID());
-    FeatureUtils.copyFeatureListRowProperties(row, newRow);
-
-    // Copy the features.
-    for (final Feature feature : row.getFeatures()) {
-
-      final Feature newFeature = new ModularFeature(feature);
-      FeatureUtils.copyFeatureProperties(feature, newFeature);
-      newRow.addFeature(feature.getRawDataFile(), newFeature);
-
-    }
-
-    return newRow;
   }
 
 }

--- a/src/main/java/io/github/mzmine/modules/io/mztabimport/MzTabImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/mztabimport/MzTabImportTask.java
@@ -145,7 +145,7 @@ class MzTabImportTask extends AbstractTask {
       // Create a new feature list
       String featureListName = inputFile.getName().replace(".mzTab", "");
       RawDataFile rawDataArray[] = rawDataFiles.values().toArray(new RawDataFile[0]);
-      FeatureList newFeatureList = new ModularFeatureList(featureListName, rawDataArray);
+      ModularFeatureList newFeatureList = new ModularFeatureList(featureListName, rawDataArray);
 
       // Check if not canceled
       if (isCanceled())
@@ -338,7 +338,7 @@ class MzTabImportTask extends AbstractTask {
 
   }
 
-  private void importSmallMolecules(FeatureList newFeatureList, MZTabFile mzTabFile,
+  private void importSmallMolecules(ModularFeatureList newFeatureList, MZTabFile mzTabFile,
       Map<Integer, RawDataFile> rawDataFiles) {
     SortedMap<Integer, Assay> assayMap = mzTabFile.getMetadata().getAssayMap();
     Collection<SmallMolecule> smallMolecules = mzTabFile.getSmallMolecules();
@@ -397,7 +397,7 @@ class MzTabImportTask extends AbstractTask {
       }
 
       // Add shared information to row
-      FeatureListRow newRow = new ModularFeatureListRow((ModularFeatureList) newFeatureList, rowCounter);
+      ModularFeatureListRow newRow = new ModularFeatureListRow((ModularFeatureList) newFeatureList, rowCounter);
       newRow.setAverageMZ(mzExp);
       newRow.setAverageRT(rtValue);
       if (description != null) {
@@ -453,7 +453,7 @@ class MzTabImportTask extends AbstractTask {
         Range<Float> finalIntensityRange = Range.singleton(feature_height);
         FeatureStatus status = FeatureStatus.DETECTED;
 
-        Feature peak = new ModularFeature(rawData, feature_mz, feature_rt, feature_height, abundance,
+        Feature peak = new ModularFeature(newFeatureList, rawData, feature_mz, feature_rt, feature_height, abundance,
             scanNumbers, finalDataPoint, status, representativeScan, fragmentScan, allFragmentScans,
             finalRTRange, finalMZRange, finalIntensityRange);
 

--- a/src/main/java/io/github/mzmine/modules/io/mztabmimport/MzTabmImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/mztabmimport/MzTabmImportTask.java
@@ -137,7 +137,7 @@ public class MzTabmImportTask extends AbstractTask {
       //Create new feature list
       String featureListName = inputFile.getName().replace(".mzTab", "");
       RawDataFile rawDataArray[] = rawDataFiles.toArray(new RawDataFile[0]);
-      FeatureList newFeatureList = new ModularFeatureList(featureListName, rawDataArray);
+      ModularFeatureList newFeatureList = new ModularFeatureList(featureListName, rawDataArray);
 
       // Check if not canceled
         if (isCanceled()) {
@@ -307,7 +307,7 @@ public class MzTabmImportTask extends AbstractTask {
     }
   }
 
-  private void importTablesData(FeatureList newFeatureList, MzTab mzTabmFile,
+  private void importTablesData(ModularFeatureList newFeatureList, MzTab mzTabmFile,
       List<RawDataFile> rawDataFiles) {
     List<Assay> assayList = mzTabmFile.getMetadata().getAssay();
     List<SmallMoleculeSummary> smallMoleculeSummaryList = mzTabmFile.getSmallMoleculeSummary();
@@ -422,7 +422,7 @@ public class MzTabmImportTask extends AbstractTask {
           status = FeatureStatus.UNKNOWN;
         }
 
-        Feature feature = new ModularFeature(rawData, feature_mz, feature_rt, feature_height,
+        Feature feature = new ModularFeature(newFeatureList, rawData, feature_mz, feature_rt, feature_height,
             (float) abundance,
             scanNumbers, finalDataPoint, status, representativeScan, fragmentScan, allFragmentScans,
             finalRTRange, finalMZRange, finalIntensityRange);

--- a/src/main/java/io/github/mzmine/modules/io/projectload/version_2_5/PeakListOpenHandler_2_5.java
+++ b/src/main/java/io/github/mzmine/modules/io/projectload/version_2_5/PeakListOpenHandler_2_5.java
@@ -38,6 +38,8 @@ import java.util.logging.Logger;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
+
+import io.github.mzmine.util.DataTypeUtils;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
@@ -499,6 +501,9 @@ public class PeakListOpenHandler_2_5 extends DefaultHandler implements PeakListO
     RawDataFile[] dataFiles = currentPeakListDataFiles.toArray(new RawDataFile[0]);
 
     buildingPeakList = new ModularFeatureList(peakListName, dataFiles);
+    // just add all columns that we used in MZmine 2
+    // TODO create new method to save and load projects with modular data model
+    DataTypeUtils.addDefaultChromatographicTypeColumns(buildingPeakList);
 
     for (int i = 0; i < appliedMethods.size(); i++) {
       String methodName = appliedMethods.elementAt(i);

--- a/src/main/java/io/github/mzmine/modules/io/projectload/version_2_5/PeakListOpenHandler_2_5.java
+++ b/src/main/java/io/github/mzmine/modules/io/projectload/version_2_5/PeakListOpenHandler_2_5.java
@@ -393,7 +393,7 @@ public class PeakListOpenHandler_2_5 extends DefaultHandler implements PeakListO
       if (peakRTRange == null)
         peakRTRange = Range.singleton(rt);
 
-      ModularFeature peak = new ModularFeature(dataFile, mass, rt, height, area, scanNumbers, mzPeaks,
+      ModularFeature peak = new ModularFeature(buildingPeakList, dataFile, mass, rt, height, area, scanNumbers, mzPeaks,
           status, representativeScan, fragmentScan, allMS2FragmentScanNumbers, peakRTRange,
           peakMZRange, peakIntensityRange);
       //SimpleFeatureOld peak = new SimpleFeatureOld(dataFile, mass, rt, height, area, scanNumbers, mzPeaks,

--- a/src/main/java/io/github/mzmine/modules/io/projectload/version_3_0/PeakListOpenHandler_3_0.java
+++ b/src/main/java/io/github/mzmine/modules/io/projectload/version_3_0/PeakListOpenHandler_3_0.java
@@ -38,6 +38,8 @@ import java.util.logging.Logger;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
+
+import io.github.mzmine.util.DataTypeUtils;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
@@ -168,7 +170,8 @@ public class PeakListOpenHandler_3_0 extends DefaultHandler implements PeakListO
       int rowID = Integer.parseInt(attrs.getValue(PeakListElementName_3_0.ID.getElementName()));
       buildingRow = new ModularFeatureListRow(buildingPeakList, rowID);
       String comment = attrs.getValue(PeakListElementName_3_0.COMMENT.getElementName());
-      buildingRow.setComment(comment);
+      if(comment!=null && !comment.isEmpty())
+        buildingRow.setComment(comment);
     }
 
     // <PEAK_IDENTITY>
@@ -499,6 +502,10 @@ public class PeakListOpenHandler_3_0 extends DefaultHandler implements PeakListO
     RawDataFile[] dataFiles = currentPeakListDataFiles.toArray(new RawDataFile[0]);
 
     buildingPeakList = new ModularFeatureList(peakListName, dataFiles);
+
+    // just add all columns that we used in MZmine 2
+    // TODO create new method to save and load projects with modular data model
+    DataTypeUtils.addDefaultChromatographicTypeColumns(buildingPeakList);
 
     for (int i = 0; i < appliedMethods.size(); i++) {
       String methodName = appliedMethods.elementAt(i);

--- a/src/main/java/io/github/mzmine/modules/io/projectload/version_3_0/PeakListOpenHandler_3_0.java
+++ b/src/main/java/io/github/mzmine/modules/io/projectload/version_3_0/PeakListOpenHandler_3_0.java
@@ -393,7 +393,7 @@ public class PeakListOpenHandler_3_0 extends DefaultHandler implements PeakListO
       if (peakRTRange == null)
         peakRTRange = Range.singleton(rt);
 
-      ModularFeature peak = new ModularFeature(dataFile, mass, rt, height, area, scanNumbers, mzPeaks,
+      ModularFeature peak = new ModularFeature(buildingPeakList, dataFile, mass, rt, height, area, scanNumbers, mzPeaks,
           status, representativeScan, fragmentScan, allMS2FragmentScanNumbers, peakRTRange,
           peakMZRange, peakIntensityRange);
       //SimpleFeatureOld peak = new SimpleFeatureOld(dataFile, mass, rt, height, area, scanNumbers, mzPeaks,

--- a/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFX.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFX.java
@@ -218,7 +218,7 @@ public class FeatureTableFX extends TreeTableView<FeatureListRow> {
     if (dataType.getClass().equals(FeaturesType.class)) {
       addFeaturesColumns();
     } else {
-      TreeTableColumn<FeatureListRow, ? extends DataType> col = dataType.createColumn(null);
+      TreeTableColumn<FeatureListRow, ? extends DataType> col = dataType.createColumn(null, null);
       if (col == null) {
         return;
       }
@@ -453,7 +453,7 @@ public class FeatureTableFX extends TreeTableView<FeatureListRow> {
 
       // Add sub columns of feature
       for (DataType ftype : ((ModularFeatureList) flist).getFeatureTypes().values()) {
-        TreeTableColumn<FeatureListRow, ?> subCol = ftype.createColumn(dataFile);
+        TreeTableColumn<FeatureListRow, ?> subCol = ftype.createColumn(dataFile, null);
         if (subCol != null) {
           if(ftype instanceof ExpandableType) {
             setupExpandableColumn(ftype, subCol, ColumnType.FEATURE_TYPE, dataFile);

--- a/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFX.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFX.java
@@ -205,7 +205,13 @@ public class FeatureTableFX extends TreeTableView<FeatureListRow> {
 //    logger.info("Adding columns to table");
     // for all data columns available in "data"
     assert flist instanceof ModularFeatureList : "Feature list is not modular";
-    ((ModularFeatureList) flist).getRowTypes().values().forEach(this::addColumn);
+    ModularFeatureList featureList = (ModularFeatureList) flist;
+    // add row types
+    featureList.getRowTypes().values().stream()
+        .filter(t -> !(t instanceof FeaturesType)).forEach(this::addColumn);
+    // add features
+    if(featureList.getRowTypes().containsKey(FeaturesType.class))
+      addColumn(featureList.getRowTypes().get(FeaturesType.class));
   }
 
   /**

--- a/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFXMLTabAnchorPaneController.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFXMLTabAnchorPaneController.java
@@ -27,6 +27,7 @@ import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.RangeUtils;
 import io.github.mzmine.util.javafx.FxIconUtil;
 import java.text.NumberFormat;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.application.Platform;
 import javafx.event.ActionEvent;
@@ -176,21 +177,25 @@ public class FeatureTableFXMLTabAnchorPaneController {
     if(featureList==null) {
       return;
     }
+    try {
+      // Fill filters text fields with a prompt values
+      NumberFormat mzFormat = MZmineCore.getConfiguration().getMZFormat();
+      Range<Double> mzRange = featureList.getRowsMZRange();
+      if(mzRange!=null)
+        mzSearchField.setPromptText(mzFormat.format(mzRange.lowerEndpoint()) + " - "
+                + mzFormat.format(mzRange.upperEndpoint()));
+      mzSearchField.setStyle("-fx-prompt-text-fill: derive(-fx-control-inner-background, -30%);");
 
-    // Fill filters text fields with a prompt values
-    NumberFormat mzFormat = MZmineCore.getConfiguration().getMZFormat();
-    Range<Double> mzRange = featureList.getRowsMZRange();
-    if(mzRange!=null)
-      mzSearchField.setPromptText(mzFormat.format(mzRange.lowerEndpoint()) + " - "
-        + mzFormat.format(mzRange.upperEndpoint()));
-    mzSearchField.setStyle("-fx-prompt-text-fill: derive(-fx-control-inner-background, -30%);");
-
-    NumberFormat rtFormat = MZmineCore.getConfiguration().getRTFormat();
-    Range<Float> rtRange = featureTable.getFeatureList().getRowsRTRange();
-    if(rtRange!=null)
-      rtSearchField.setPromptText(rtFormat.format(rtRange.lowerEndpoint()) + " - "
-        + rtFormat.format(rtRange.upperEndpoint()));
-    rtSearchField.setStyle("-fx-prompt-text-fill: derive(-fx-control-inner-background, -30%);");
+      NumberFormat rtFormat = MZmineCore.getConfiguration().getRTFormat();
+      Range<Float> rtRange = featureList.getRowsRTRange();
+      if(rtRange!=null) {
+        rtSearchField.setPromptText(rtFormat.format(rtRange.lowerEndpoint()) + " - "
+                + rtFormat.format(rtRange.upperEndpoint()));
+      }
+      rtSearchField.setStyle("-fx-prompt-text-fill: derive(-fx-control-inner-background, -30%);");
+    } catch (Exception ex) {
+      logger.log(Level.WARNING, "Error in table visualization", ex);
+    }
   }
 
   void selectedRowChanged() {

--- a/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFXMLTabAnchorPaneController.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFXMLTabAnchorPaneController.java
@@ -173,16 +173,22 @@ public class FeatureTableFXMLTabAnchorPaneController {
   public void setFeatureList(FeatureList featureList) {
     featureTable.addData(featureList);
 
+    if(featureList==null) {
+      return;
+    }
+
     // Fill filters text fields with a prompt values
     NumberFormat mzFormat = MZmineCore.getConfiguration().getMZFormat();
-    Range<Double> mzRange = featureTable.getFeatureList().getRowsMZRange();
-    mzSearchField.setPromptText(mzFormat.format(mzRange.lowerEndpoint()) + " - "
+    Range<Double> mzRange = featureList.getRowsMZRange();
+    if(mzRange!=null)
+      mzSearchField.setPromptText(mzFormat.format(mzRange.lowerEndpoint()) + " - "
         + mzFormat.format(mzRange.upperEndpoint()));
     mzSearchField.setStyle("-fx-prompt-text-fill: derive(-fx-control-inner-background, -30%);");
 
     NumberFormat rtFormat = MZmineCore.getConfiguration().getRTFormat();
     Range<Float> rtRange = featureTable.getFeatureList().getRowsRTRange();
-    rtSearchField.setPromptText(rtFormat.format(rtRange.lowerEndpoint()) + " - "
+    if(rtRange!=null)
+      rtSearchField.setPromptText(rtFormat.format(rtRange.lowerEndpoint()) + " - "
         + rtFormat.format(rtRange.upperEndpoint()));
     rtSearchField.setStyle("-fx-prompt-text-fill: derive(-fx-control-inner-background, -30%);");
   }

--- a/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFXTab.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFXTab.java
@@ -81,7 +81,7 @@ public class FeatureTableFXTab extends MZmineTab {
   @Nonnull
   @Override
   public Collection<? extends RawDataFile> getRawDataFiles() {
-    return getFeatureList().getRawDataFiles();
+    return getFeatureList()==null? Collections.emptyList() : getFeatureList().getRawDataFiles();
   }
 
   @Nonnull

--- a/src/main/java/io/github/mzmine/util/DataTypeUtils.java
+++ b/src/main/java/io/github/mzmine/util/DataTypeUtils.java
@@ -24,21 +24,9 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.datamodel.features.RowBinding;
-import io.github.mzmine.datamodel.features.types.DataType;
-import io.github.mzmine.datamodel.features.types.DetectionType;
-import io.github.mzmine.datamodel.features.types.ManualAnnotationType;
-import io.github.mzmine.datamodel.features.types.RawFileType;
+import io.github.mzmine.datamodel.features.types.*;
 import io.github.mzmine.datamodel.features.types.modifiers.BindingsType;
-import io.github.mzmine.datamodel.features.types.numbers.AreaType;
-import io.github.mzmine.datamodel.features.types.numbers.BestScanNumberType;
-import io.github.mzmine.datamodel.features.types.numbers.DataPointsType;
-import io.github.mzmine.datamodel.features.types.numbers.HeightType;
-import io.github.mzmine.datamodel.features.types.numbers.IntensityRangeType;
-import io.github.mzmine.datamodel.features.types.numbers.MZRangeType;
-import io.github.mzmine.datamodel.features.types.numbers.MZType;
-import io.github.mzmine.datamodel.features.types.numbers.RTRangeType;
-import io.github.mzmine.datamodel.features.types.numbers.RTType;
-import io.github.mzmine.datamodel.features.types.numbers.ScanNumbersType;
+import io.github.mzmine.datamodel.features.types.numbers.*;
 
 @SuppressWarnings("null")
 public class DataTypeUtils {
@@ -50,14 +38,16 @@ public class DataTypeUtils {
           new RowBinding(new AreaType(), BindingsType.MAX)*/,
           new RowBinding(new RTRangeType(), BindingsType.RANGE),
           new RowBinding(new MZRangeType(), BindingsType.RANGE));
-  public static final @Nonnull List<DataType<?>> DEFAULT_CHROMATOGRAPHIC_ROW = List.of(new ManualAnnotationType()
-          /*new RTType(),
-      new MZType(),*/ /*new HeightType(), new AreaType()*//*, new RTRangeType(), new MZRangeType()*/);
+
+  public static final @Nonnull List<DataType<?>> DEFAULT_CHROMATOGRAPHIC_ROW = List.of(new RTType(), new MZType(),
+          new HeightType(), new AreaType(), new RTRangeType(), new MZRangeType(), new ManualAnnotationType(),
+          new FeatureShapeType(), new FeaturesType());
+
   public static final @Nonnull List<DataType<?>> DEFAULT_CHROMATOGRAPHIC_FEATURE =
       List.of(new ScanNumbersType(), new RawFileType(), new DetectionType(), new MZType(),
           new MZRangeType(), new RTType(), new RTRangeType(), new HeightType(), new AreaType(),
-          new BestScanNumberType(), new DataPointsType(), new IntensityRangeType());
-
+          new BestScanNumberType(), new DataPointsType(), new IntensityRangeType(), new FwhmType(),
+              new TailingFactorType(), new AsymmetryFactorType());
 
   /**
    * Adds the default chromatogram DataType columns to a feature list
@@ -67,7 +57,8 @@ public class DataTypeUtils {
   public static void addDefaultChromatographicTypeColumns(ModularFeatureList flist) {
     flist.addRowType(DEFAULT_CHROMATOGRAPHIC_ROW);
     flist.addFeatureType(DEFAULT_CHROMATOGRAPHIC_FEATURE);
-    flist.addRowBinding(DEFAULT_CHROMATOGRAPHIC_ROWBINDING);
+    // row bindigns are now added in the table
+    // flist.addRowBinding(DEFAULT_CHROMATOGRAPHIC_ROWBINDING);
   }
 
 }

--- a/src/main/java/io/github/mzmine/util/DataTypeUtils.java
+++ b/src/main/java/io/github/mzmine/util/DataTypeUtils.java
@@ -26,6 +26,7 @@ import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.datamodel.features.RowBinding;
 import io.github.mzmine.datamodel.features.types.DataType;
 import io.github.mzmine.datamodel.features.types.DetectionType;
+import io.github.mzmine.datamodel.features.types.ManualAnnotationType;
 import io.github.mzmine.datamodel.features.types.RawFileType;
 import io.github.mzmine.datamodel.features.types.modifiers.BindingsType;
 import io.github.mzmine.datamodel.features.types.numbers.AreaType;
@@ -49,7 +50,8 @@ public class DataTypeUtils {
           new RowBinding(new AreaType(), BindingsType.MAX)*/,
           new RowBinding(new RTRangeType(), BindingsType.RANGE),
           new RowBinding(new MZRangeType(), BindingsType.RANGE));
-  public static final @Nonnull List<DataType<?>> DEFAULT_CHROMATOGRAPHIC_ROW = List.of(/*new RTType(),
+  public static final @Nonnull List<DataType<?>> DEFAULT_CHROMATOGRAPHIC_ROW = List.of(new ManualAnnotationType()
+          /*new RTType(),
       new MZType(),*/ /*new HeightType(), new AreaType()*//*, new RTRangeType(), new MZRangeType()*/);
   public static final @Nonnull List<DataType<?>> DEFAULT_CHROMATOGRAPHIC_FEATURE =
       List.of(new ScanNumbersType(), new RawFileType(), new DetectionType(), new MZType(),

--- a/src/main/java/io/github/mzmine/util/DataTypeUtils.java
+++ b/src/main/java/io/github/mzmine/util/DataTypeUtils.java
@@ -39,8 +39,10 @@ public class DataTypeUtils {
           new RowBinding(new RTRangeType(), BindingsType.RANGE),
           new RowBinding(new MZRangeType(), BindingsType.RANGE));
 
-  public static final @Nonnull List<DataType<?>> DEFAULT_CHROMATOGRAPHIC_ROW = List.of(new RTType(), new MZType(),
-          new HeightType(), new AreaType(), new RTRangeType(), new MZRangeType(), new ManualAnnotationType(),
+  public static final @Nonnull List<DataType<?>> DEFAULT_CHROMATOGRAPHIC_ROW = List.of(
+          new RTType(), new RTRangeType(), // needed next to each other for switching between RTType and RTRangeType
+          new MZType(), new MZRangeType(), //
+          new HeightType(), new AreaType(), new ManualAnnotationType(),
           new FeatureShapeType(), new FeaturesType());
 
   public static final @Nonnull List<DataType<?>> DEFAULT_CHROMATOGRAPHIC_FEATURE =

--- a/src/main/java/io/github/mzmine/util/FeatureConvertors.java
+++ b/src/main/java/io/github/mzmine/util/FeatureConvertors.java
@@ -36,6 +36,7 @@ import io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution
 import io.github.mzmine.modules.dataprocessing.featdet_manual.ManualFeature;
 import io.github.mzmine.modules.dataprocessing.gapfill_samerange.SameRangePeak;
 import io.github.mzmine.modules.dataprocessing.featdet_adapchromatogrambuilder.ADAPChromatogram;
+import io.github.mzmine.modules.io.rawdataexport.RawDataFileType;
 import io.github.mzmine.modules.tools.qualityparameters.QualityParameters;
 import io.github.mzmine.util.scans.ScanUtils;
 import java.util.ArrayList;
@@ -394,7 +395,6 @@ public class FeatureConvertors {
     modularFeature.set(HeightType.class, (float) resolvedPeak.getHeight());
     modularFeature.set(AreaType.class, (float) resolvedPeak.getArea());
     modularFeature.set(BestScanNumberType.class, resolvedPeak.getRepresentativeScanNumber());
-
 
     // Data points of feature
     List<DataPoint> dps = new ArrayList<>();

--- a/src/main/java/io/github/mzmine/util/FeatureConvertors.java
+++ b/src/main/java/io/github/mzmine/util/FeatureConvertors.java
@@ -43,6 +43,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
 import javax.annotation.Nonnull;
 
 public class FeatureConvertors {
@@ -74,7 +76,8 @@ public class FeatureConvertors {
 
     modularFeature.set(BestFragmentScanNumberType.class, chromatogram.getMostIntenseFragmentScanNumber());
     modularFeature.set(BestScanNumberType.class, chromatogram.getRepresentativeScanNumber());
-    modularFeature.set(IsotopePatternType.class, chromatogram.getIsotopePattern());
+    if(chromatogram.getIsotopePattern()!=null)
+      modularFeature.set(IsotopePatternType.class, chromatogram.getIsotopePattern());
     modularFeature.set(ChargeType.class, chromatogram.getCharge());
 
     modularFeature.set(RawFileType.class, chromatogram.getDataFile());
@@ -104,9 +107,10 @@ public class FeatureConvertors {
     modularFeature.set(RTRangeType.class, rtRange);
     modularFeature.set(IntensityRangeType.class, intensityRange);
 
-    modularFeature.setAllMS2FragmentScanNumbers(IntStream.of(ScanUtils
-        .findAllMS2FragmentScans(chromatogram.getDataFile(), rtRange, mzRange)).boxed()
-        .collect(Collectors.toCollection(FXCollections::observableArrayList)));
+    ObservableList<Integer> allMS2 = IntStream.of(ScanUtils
+            .findAllMS2FragmentScans(chromatogram.getDataFile(), rtRange, mzRange)).boxed()
+            .collect(Collectors.toCollection(FXCollections::observableArrayList));
+    modularFeature.setAllMS2FragmentScanNumbers(allMS2);
 
     // Quality parameters
     float fwhm = QualityParameters.calculateFWHM(modularFeature);

--- a/src/main/java/io/github/mzmine/util/adap/ADAPInterface.java
+++ b/src/main/java/io/github/mzmine/util/adap/ADAPInterface.java
@@ -32,6 +32,7 @@ import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.FeatureStatus;
 import io.github.mzmine.datamodel.IsotopePattern;
 import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.datamodel.impl.SimpleDataPoint;
 
 /**
@@ -71,7 +72,7 @@ public class ADAPInterface {
   }
 
   @Nonnull
-  public static ModularFeature peakToFeature(@Nonnull RawDataFile file, @Nonnull BetterPeak peak) {
+  public static ModularFeature peakToFeature(@Nonnull ModularFeatureList featureList, @Nonnull RawDataFile file, @Nonnull BetterPeak peak) {
 
     Chromatogram chromatogram = peak.chromatogram;
 
@@ -102,7 +103,7 @@ public class ADAPInterface {
     for (double intensity : chromatogram.ys)
       dataPoints[count++] = new SimpleDataPoint(peak.getMZ(), intensity);
 
-    return new ModularFeature(file, peak.getMZ(), (float) peak.getRetTime(), (float) peak.getIntensity(),
+    return new ModularFeature(featureList, file, peak.getMZ(), (float) peak.getRetTime(), (float) peak.getIntensity(),
         (float) area, scanNumbers, dataPoints, FeatureStatus.ESTIMATED, representativeScan, representativeScan,
         new int[] {}, Range.closed((float) peak.getFirstRetTime(), (float) peak.getLastRetTime()),
         Range.closed(peak.getMZ() - 0.01, peak.getMZ() + 0.01),
@@ -110,7 +111,7 @@ public class ADAPInterface {
   }
 
   @Nonnull
-  public static Feature peakToFeature(@Nonnull RawDataFile file, @Nonnull Peak peak) {
+  public static Feature peakToFeature(@Nonnull ModularFeatureList featureList, @Nonnull RawDataFile file, @Nonnull Peak peak) {
 
     NavigableMap<Double, Double> chromatogram = peak.getChromatogram();
 
@@ -126,6 +127,6 @@ public class ADAPInterface {
     BetterPeak betterPeak = new BetterPeak(peak.getInfo().peakID,
         new Chromatogram(retTimes, intensities), peak.getInfo());
 
-    return peakToFeature(file, betterPeak);
+    return peakToFeature(featureList, file, betterPeak);
   }
 }

--- a/src/main/java/io/github/mzmine/util/scans/ScanUtils.java
+++ b/src/main/java/io/github/mzmine/util/scans/ScanUtils.java
@@ -120,8 +120,7 @@ public class ScanUtils {
    * @param mzRange mz range to search in
    * @return double[2] containing base peak m/z and intensity
    */
-  public static @Nonnull
-  DataPoint findBasePeak(@Nonnull Scan scan,
+  public static @Nullable DataPoint findBasePeak(@Nonnull Scan scan,
       @Nonnull Range<Double> mzRange) {
 
     DataPoint dataPoints[] = scan.getDataPointsByMass(mzRange);
@@ -580,8 +579,7 @@ public class ScanUtils {
    * Finds all MS/MS scans on MS2 level within given retention time range and with precursor m/z
    * within given m/z range
    */
-  public static int[] findAllMS2FragmentScans(RawDataFile dataFile, Range<Float> rtRange,
-      Range<Double> mzRange) {
+  public static int[] findAllMS2FragmentScans(RawDataFile dataFile, Range<Float> rtRange, Range<Double> mzRange) {
 
     assert dataFile != null;
     assert rtRange != null;

--- a/src/main/java/io/github/mzmine/util/spectraldb/entry/DBEntryField.java
+++ b/src/main/java/io/github/mzmine/util/spectraldb/entry/DBEntryField.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 
 public enum DBEntryField {
 
-  ENTRY_ID, NAME, SYNONYM, COMMENT, ION_TYPE, RT(Double.class), MZ(Double.class), CHARGE(
+  ENTRY_ID, NAME, SYNONYM, COMMENT, ION_TYPE, RT(Float.class), MZ(Double.class), CHARGE(
       Integer.class), ION_MODE, COLLISION_ENERGY, FORMULA, MOLWEIGHT(Double.class), EXACT_MASS(
           Double.class), INCHI, INCHIKEY, SMILES, CAS, PUBMED, PUBCHEM, MONA_ID, CHEMSPIDER, INSTRUMENT_TYPE, INSTRUMENT, ION_SOURCE, NUM_PEAKS(
               Integer.class), ACQUISITION, PRINCIPAL_INVESTIGATOR, DATA_COLLECTOR, SOFTWARE, MS_LEVEL, RESOLUTION;

--- a/src/main/java/io/github/mzmine/util/spectraldb/parser/GnpsJsonParser.java
+++ b/src/main/java/io/github/mzmine/util/spectraldb/parser/GnpsJsonParser.java
@@ -118,7 +118,9 @@ public class GnpsJsonParser extends SpectralDBParser {
             if (o instanceof JsonNumber) {
               if (f.getObjectClass().equals(Integer.class)) {
                 o = ((JsonNumber) o).intValue();
-              } else {
+              } else if(f.getObjectClass().equals(Float.class)){
+                o = (float) ((JsonNumber) o).doubleValue();
+              }else {
                 o = ((JsonNumber) o).doubleValue();
               }
             }

--- a/src/main/java/io/github/mzmine/util/spectraldb/parser/MonaJsonParser.java
+++ b/src/main/java/io/github/mzmine/util/spectraldb/parser/MonaJsonParser.java
@@ -345,9 +345,9 @@ public class MonaJsonParser extends SpectralDBParser {
                   // to minutes
                   if (v.endsWith("sec")) {
                     v = v.substring(0, v.length() - 3);
-                    value = Double.parseDouble(v) / 60d;
+                    value = Float.parseFloat(v) / 60f;
                   } else {
-                    value = Double.parseDouble(v);
+                    value = Float.parseFloat(v);
                   }
                 } catch (Exception ex) {
                 }

--- a/src/main/java/io/github/mzmine/util/spectraldb/parser/SpectralDBParser.java
+++ b/src/main/java/io/github/mzmine/util/spectraldb/parser/SpectralDBParser.java
@@ -69,7 +69,6 @@ public abstract class SpectralDBParser {
     list.add(entry);
     if (list.size() % bufferEntries == 0) {
       // start new task for every 1000 entries
-      logger.info("Imported " + list.size() + " library entries");
       // push entries
       processor.processNextEntries(list, processedEntries);
       processedEntries += list.size();


### PR DESCRIPTION
This adds a ModularType that holds a modular data model as property
- all sub types are added as sub columns 
- SpectralLibraryMatchType uses a SummaryType (List<SpectralMatch>) 
- if first object of list changes - all other sub types are updated to point to the current match

### Data model changes
- columns are added automatically as soon as data type is set to row or feature
- new ModularFeature(feature) will copy all existing fields

## Teaser for @Annexhc 
![image](https://user-images.githubusercontent.com/10366914/102998839-42673300-4528-11eb-9878-77e6a87873e7.png)
