### PR TITLE
Auto add row bindings

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/features/ListRowBinding.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ListRowBinding.java
@@ -1,16 +1,16 @@
 /*
  * Copyright 2006-2020 The MZmine Development Team
- * 
+ *
  * This file is part of MZmine.
- * 
+ *
  * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
  * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
  * Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
  * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
  * USA
@@ -19,18 +19,36 @@
 package io.github.mzmine.datamodel.features;
 
 import io.github.mzmine.datamodel.features.types.DataType;
+import io.github.mzmine.datamodel.features.types.LinkedDataType;
 
-/**
- * A RowBinding automatically creates a {@link ModularFeatureListRow} column that is based on {@link
- * DataType}s in all {@link ModularFeature}s
- *
- * @author Robin Schmid (https://github.com/robinschmid)
- */
-public interface RowBinding {
+public class ListRowBinding implements RowBinding {
 
-  public void apply(ModularFeatureListRow row);
+  private final LinkedDataType rowType;
+  private final DataType featureType;
 
-  public DataType getRowType();
+  public ListRowBinding(LinkedDataType rowType, DataType featureType) {
+    this.rowType = rowType;
+    this.featureType = featureType;
+  }
 
-  public DataType getFeatureType();
+  @Override
+  public void apply(ModularFeatureListRow row) {
+    row.streamFeatures().map(f -> f.get(featureType)).forEach(prop -> {
+      prop.addListener((o, oldValue, newValue) -> {
+        if (row.get(rowType) != null) {
+          row.get(rowType).fireChangedEvent();
+        }
+      });
+    });
+  }
+
+  @Override
+  public DataType getRowType() {
+    return rowType;
+  }
+
+  @Override
+  public DataType getFeatureType() {
+    return featureType;
+  }
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularDataModel.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularDataModel.java
@@ -18,18 +18,18 @@
 
 package io.github.mzmine.datamodel.features;
 
-import java.lang.reflect.InvocationTargetException;
+import io.github.mzmine.datamodel.features.types.DataType;
+import io.github.mzmine.datamodel.features.types.exceptions.TypeColumnUndefinedException;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Stream;
-import io.github.mzmine.datamodel.features.types.DataType;
-import io.github.mzmine.datamodel.features.types.exceptions.TypeColumnUndefinedException;
 import javafx.beans.property.Property;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.ObservableMap;
+import javax.annotation.Nullable;
 
 public interface ModularDataModel {
 
@@ -124,6 +124,7 @@ public interface ModularDataModel {
    * @param type
    * @return
    */
+  @Nullable
   default <T extends Property<?>> T get(DataType<T> type) {
     return (T) getMap().get(type);
   }
@@ -135,6 +136,7 @@ public interface ModularDataModel {
    * @param tclass
    * @return
    */
+  @Nullable
   default <T extends Property<?>> T get(Class<? extends DataType<T>> tclass) {
     DataType<T> type = getTypeColumn(tclass);
     return get(type);

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureList.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureList.java
@@ -1,11 +1,8 @@
 package io.github.mzmine.datamodel.features;
 
-import io.github.mzmine.datamodel.features.types.AreaBarType;
-import io.github.mzmine.datamodel.features.types.AreaShareType;
-import io.github.mzmine.datamodel.features.types.FeatureShapeType;
-import io.github.mzmine.datamodel.features.types.modifiers.BindingsType;
-import io.github.mzmine.datamodel.features.types.numbers.*;
-import io.github.mzmine.util.DataTypeUtils;
+import com.google.common.collect.Range;
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.features.types.DataType;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -17,18 +14,10 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import io.github.mzmine.util.FeatureUtils;
-import javafx.collections.ObservableList;
-import javax.annotation.Nonnull;
-import com.google.common.collect.Range;
-import io.github.mzmine.datamodel.RawDataFile;
-import io.github.mzmine.datamodel.features.types.CommentType;
-import io.github.mzmine.datamodel.features.types.DataType;
-import io.github.mzmine.datamodel.features.types.FeaturesType;
-import io.github.mzmine.datamodel.features.types.RawFileType;
 import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import javafx.collections.ObservableMap;
+import javax.annotation.Nonnull;
 
 
 public class ModularFeatureList implements FeatureList {
@@ -73,14 +62,14 @@ public class ModularFeatureList implements FeatureList {
     dateCreated = DATA_FORMAT.format(new Date());
 
     // add standard row bindings even if data types are missing
-    addRowBinding(new RowBinding(new MZType(), BindingsType.AVERAGE));
-    addRowBinding(new RowBinding(new RTType(), BindingsType.AVERAGE));
-    addRowBinding(new RowBinding(new HeightType(), BindingsType.MAX));
-    addRowBinding(new RowBinding(new AreaType(), BindingsType.MAX));
-    addRowBinding(new RowBinding(new RTRangeType(), BindingsType.RANGE));
-    addRowBinding(new RowBinding(new MZRangeType(), BindingsType.RANGE));
-    addRowBinding(new RowBinding(new IntensityRangeType(), BindingsType.RANGE));
-    addRowBinding(new RowBinding(new ChargeType(), BindingsType.CONSENSUS));
+//    addRowBinding(new RowBinding(new MZType(), BindingsType.AVERAGE));
+//    addRowBinding(new RowBinding(new RTType(), BindingsType.AVERAGE));
+//    addRowBinding(new RowBinding(new HeightType(), BindingsType.MAX));
+//    addRowBinding(new RowBinding(new AreaType(), BindingsType.MAX));
+//    addRowBinding(new RowBinding(new RTRangeType(), BindingsType.RANGE));
+//    addRowBinding(new RowBinding(new MZRangeType(), BindingsType.RANGE));
+//    addRowBinding(new RowBinding(new IntensityRangeType(), BindingsType.RANGE));
+//    addRowBinding(new RowBinding(new ChargeType(), BindingsType.CONSENSUS));
   }
 
   @Override
@@ -101,6 +90,8 @@ public class ModularFeatureList implements FeatureList {
   public void addRowBinding(@Nonnull List<RowBinding> bindings) {
     for (RowBinding b : bindings) {
       rowBindings.add(b);
+      // add missing row types, that are based on RowBindings
+      addRowType(b.getRowType());
       // apply to all rows
       modularStream().forEach(b::apply);
     }
@@ -133,6 +124,8 @@ public class ModularFeatureList implements FeatureList {
       if (!featureTypes.containsKey(type.getClass())) {
         // all {@link ModularFeature} will automatically add a default property to their data map
         featureTypes.put(type.getClass(), type);
+        // add row bindings
+        addRowBinding(type.createDefaultRowBindings());
       }
     }
   }
@@ -271,7 +264,6 @@ public class ModularFeatureList implements FeatureList {
     }
 
     featureListRows.add(modularRow);
-
     applyRowBindings(modularRow);
 
     // TODO solve with bindings
@@ -475,8 +467,8 @@ public class ModularFeatureList implements FeatureList {
     public ModularFeatureList createCopy(String title) {
       ModularFeatureList flist = new ModularFeatureList(title, this.getRawDataFiles());
       // copy all rows and features
-      this.stream().map(row -> new ModularFeatureListRow(flist, (ModularFeatureListRow) row,true))
-              .forEach(newRow -> flist.addRow(newRow));
+      this.stream().map(row -> new ModularFeatureListRow(flist, (ModularFeatureListRow) row, true))
+          .forEach(newRow -> flist.addRow(newRow));
 
       // Load previous applied methods
       for (FeatureListAppliedMethod proc : this.getAppliedMethods()) {
@@ -484,4 +476,8 @@ public class ModularFeatureList implements FeatureList {
       }
       return flist;
     }
+
+  public List<RowBinding> getRowBindings() {
+    return rowBindings;
+  }
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureListRow.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureListRow.java
@@ -25,13 +25,10 @@ import io.github.mzmine.datamodel.FeatureStatus;
 import io.github.mzmine.datamodel.IsotopePattern;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.Scan;
-import io.github.mzmine.datamodel.features.types.AreaBarType;
-import io.github.mzmine.datamodel.features.types.AreaShareType;
 import io.github.mzmine.datamodel.features.types.CommentType;
 import io.github.mzmine.datamodel.features.types.DataType;
 import io.github.mzmine.datamodel.features.types.DetectionType;
 import io.github.mzmine.datamodel.features.types.FeatureInformationType;
-import io.github.mzmine.datamodel.features.types.FeatureShapeType;
 import io.github.mzmine.datamodel.features.types.FeaturesType;
 import io.github.mzmine.datamodel.features.types.IdentityType;
 import io.github.mzmine.datamodel.features.types.SpectralLibMatchSummaryType;
@@ -136,12 +133,6 @@ public class ModularFeatureListRow implements FeatureListRow, ModularDataModel {
       features = (FXCollections.observableMap(fmap));
       // set
       set(FeaturesType.class, features);
-
-      // TODO: MapProperty/Map? change DataTypeCellValueFactory? Bind to features?
-      // set(FeatureShapeType.class, getFeatures());
-      set(FeatureShapeType.class, getFeaturesProperty());
-      set(AreaBarType.class, getFeaturesProperty());
-      set(AreaShareType.class, getFeaturesProperty());
     } else {
       features = Collections.emptyMap();
     }

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureListRow.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureListRow.java
@@ -19,18 +19,35 @@
 package io.github.mzmine.datamodel.features;
 
 import com.google.common.collect.Range;
-import com.microsoft.schemas.office.visio.x2012.main.RowType;
 import io.github.mzmine.datamodel.FeatureIdentity;
 import io.github.mzmine.datamodel.FeatureInformation;
+import io.github.mzmine.datamodel.FeatureStatus;
 import io.github.mzmine.datamodel.IsotopePattern;
+import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.Scan;
-import io.github.mzmine.datamodel.features.types.*;
-import io.github.mzmine.datamodel.features.types.exceptions.TypeColumnUndefinedException;
-import io.github.mzmine.datamodel.features.types.numbers.*;
+import io.github.mzmine.datamodel.features.types.AreaBarType;
+import io.github.mzmine.datamodel.features.types.AreaShareType;
+import io.github.mzmine.datamodel.features.types.CommentType;
+import io.github.mzmine.datamodel.features.types.DataType;
+import io.github.mzmine.datamodel.features.types.DetectionType;
+import io.github.mzmine.datamodel.features.types.FeatureInformationType;
+import io.github.mzmine.datamodel.features.types.FeatureShapeType;
+import io.github.mzmine.datamodel.features.types.FeaturesType;
+import io.github.mzmine.datamodel.features.types.IdentityType;
+import io.github.mzmine.datamodel.features.types.SpectralLibMatchSummaryType;
+import io.github.mzmine.datamodel.features.types.SpectralLibraryMatchType;
+import io.github.mzmine.datamodel.features.types.numbers.AreaType;
+import io.github.mzmine.datamodel.features.types.numbers.ChargeType;
+import io.github.mzmine.datamodel.features.types.numbers.HeightType;
+import io.github.mzmine.datamodel.features.types.numbers.IDType;
+import io.github.mzmine.datamodel.features.types.numbers.IntensityRangeType;
+import io.github.mzmine.datamodel.features.types.numbers.MZRangeType;
+import io.github.mzmine.datamodel.features.types.numbers.MZType;
+import io.github.mzmine.datamodel.features.types.numbers.RTType;
 import io.github.mzmine.util.FeatureSorter;
 import io.github.mzmine.util.SortingDirection;
 import io.github.mzmine.util.SortingProperty;
-
+import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -39,19 +56,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
-
-import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
-import javafx.beans.property.ObjectProperty;
-import javafx.collections.MapChangeListener;
-import javafx.collections.ObservableList;
-import javax.annotation.Nonnull;
-import io.github.mzmine.datamodel.FeatureStatus;
-import io.github.mzmine.datamodel.RawDataFile;
 import javafx.beans.property.MapProperty;
+import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.Property;
 import javafx.collections.FXCollections;
+import javafx.collections.MapChangeListener;
+import javafx.collections.ObservableList;
 import javafx.collections.ObservableMap;
 import javafx.scene.Node;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**

--- a/src/main/java/io/github/mzmine/datamodel/features/SimpleRowBinding.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/SimpleRowBinding.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2006-2020 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package io.github.mzmine.datamodel.features;
+
+import io.github.mzmine.datamodel.features.types.DataType;
+import io.github.mzmine.datamodel.features.types.modifiers.BindingsFactoryType;
+import io.github.mzmine.datamodel.features.types.modifiers.BindingsType;
+import javafx.beans.binding.ObjectBinding;
+
+/**
+ * Create standard RowBindings for AVERAGE, SUM, MAX, MIN, RANGES, etc Specific {@link DataType}s
+ * define the binding
+ *
+ * @author Robin Schmid (https://github.com/robinschmid)
+ */
+public class SimpleRowBinding implements RowBinding {
+
+  private final DataType rowType;
+  private final BindingsFactoryType featureType;
+  private final BindingsType bindingType;
+
+  public SimpleRowBinding(BindingsFactoryType featureAndRowType, BindingsType bindingType) {
+    this((DataType) featureAndRowType, featureAndRowType, bindingType);
+  }
+
+  public SimpleRowBinding(DataType rowType, BindingsFactoryType featureType,
+      BindingsType bindingType) {
+    super();
+    assert featureType instanceof DataType : "feature type needs to be a DataType";
+    this.rowType = rowType;
+    this.featureType = featureType;
+    this.bindingType = bindingType;
+  }
+
+  @Override
+  public void apply(ModularFeatureListRow row) {
+    if (row.get(rowType) != null) {
+      ObjectBinding<?> binding = featureType.createBinding(bindingType, row);
+      row.get(rowType).bind(binding);
+    }
+  }
+
+  @Override
+  public DataType getRowType() {
+    return rowType;
+  }
+
+  @Override
+  public DataType getFeatureType() {
+    return (DataType) featureType;
+  }
+}

--- a/src/main/java/io/github/mzmine/datamodel/features/types/AreaBarType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/AreaBarType.java
@@ -22,8 +22,8 @@ import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.datamodel.features.types.graphicalnodes.AreaBarChart;
-import io.github.mzmine.datamodel.features.types.tasks.FeaturesGraphicalNodeTask;
 import io.github.mzmine.datamodel.features.types.modifiers.GraphicalColumType;
+import io.github.mzmine.datamodel.features.types.tasks.FeaturesGraphicalNodeTask;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.taskcontrol.TaskPriority;
@@ -67,7 +67,7 @@ public class AreaBarType extends DataType<MapProperty<RawDataFile, ModularFeatur
     StackPane pane = new StackPane();
 
     // TODO stop task if new task is started
-    Task task = new FeaturesGraphicalNodeTask(AreaBarChart.class, pane, row, coll);
+    Task task = new FeaturesGraphicalNodeTask(AreaBarChart.class, pane, row, coll.getText());
     MZmineCore.getTaskController().addTask(task, TaskPriority.NORMAL);
 
     return pane;

--- a/src/main/java/io/github/mzmine/datamodel/features/types/AreaShareType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/AreaShareType.java
@@ -22,8 +22,8 @@ import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.datamodel.features.types.graphicalnodes.AreaShareChart;
-import io.github.mzmine.datamodel.features.types.tasks.FeaturesGraphicalNodeTask;
 import io.github.mzmine.datamodel.features.types.modifiers.GraphicalColumType;
+import io.github.mzmine.datamodel.features.types.tasks.FeaturesGraphicalNodeTask;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.taskcontrol.TaskPriority;
@@ -67,7 +67,7 @@ public class AreaShareType extends DataType<MapProperty<RawDataFile, ModularFeat
     StackPane pane = new StackPane();
 
     // TODO stop task if new task is started
-    Task task = new FeaturesGraphicalNodeTask(AreaShareChart.class, pane, row, coll);
+    Task task = new FeaturesGraphicalNodeTask(AreaShareChart.class, pane, row, coll.getText());
     MZmineCore.getTaskController().addTask(task, TaskPriority.NORMAL);
 
     return pane;

--- a/src/main/java/io/github/mzmine/datamodel/features/types/DataType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/DataType.java
@@ -20,7 +20,10 @@ package io.github.mzmine.datamodel.features.types;
 
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.features.ModularDataModel;
+import io.github.mzmine.datamodel.features.ModularFeature;
+import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
+import io.github.mzmine.datamodel.features.RowBinding;
 import io.github.mzmine.datamodel.features.types.fx.DataTypeCellFactory;
 import io.github.mzmine.datamodel.features.types.fx.DataTypeCellValueFactory;
 import io.github.mzmine.datamodel.features.types.fx.EditComboCellFactory;
@@ -196,8 +199,21 @@ public abstract class DataType<T extends Property<?>> {
 
   /**
    * Creating a property which is used in a {@link ModularDataModel}
-   * 
+   *
    * @return
    */
   public abstract T createProperty();
+
+
+  /**
+   * In case this DataType is added to a {@link ModularFeature}, these row bindings are added to the
+   * {@link ModularFeatureList} to automatically calculate or visualize summary datatypes in a row
+   *
+   * @return
+   */
+  @Nonnull
+  public List<RowBinding> createDefaultRowBindings() {
+    return List.of();
+  }
+
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/FeatureShapeIonMobilityRetentionTimeHeatMapType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/FeatureShapeIonMobilityRetentionTimeHeatMapType.java
@@ -18,7 +18,6 @@
 
 package io.github.mzmine.datamodel.features.types;
 
-import javax.annotation.Nonnull;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
@@ -34,6 +33,7 @@ import javafx.scene.Node;
 import javafx.scene.control.TreeTableCell;
 import javafx.scene.control.TreeTableColumn;
 import javafx.scene.layout.StackPane;
+import javax.annotation.Nonnull;
 
 public class FeatureShapeIonMobilityRetentionTimeHeatMapType
     extends DataType<MapProperty<RawDataFile, ModularFeature>>
@@ -69,7 +69,7 @@ public class FeatureShapeIonMobilityRetentionTimeHeatMapType
 
     // TODO stop task if new task is started
     Task task = new FeaturesGraphicalNodeTask(
-        FeatureShapeIonMobilityRetentionTimeHeatMapChart.class, pane, row, coll);
+        FeatureShapeIonMobilityRetentionTimeHeatMapChart.class, pane, row, coll.getText());
     MZmineCore.getTaskController().addTask(task, TaskPriority.NORMAL);
 
     return pane;

--- a/src/main/java/io/github/mzmine/datamodel/features/types/FeatureShapeIonMobilityRetentionTimeType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/FeatureShapeIonMobilityRetentionTimeType.java
@@ -18,7 +18,6 @@
 
 package io.github.mzmine.datamodel.features.types;
 
-import javax.annotation.Nonnull;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
@@ -34,6 +33,7 @@ import javafx.scene.Node;
 import javafx.scene.control.TreeTableCell;
 import javafx.scene.control.TreeTableColumn;
 import javafx.scene.layout.StackPane;
+import javax.annotation.Nonnull;
 
 public class FeatureShapeIonMobilityRetentionTimeType
     extends DataType<MapProperty<RawDataFile, ModularFeature>>
@@ -69,7 +69,7 @@ public class FeatureShapeIonMobilityRetentionTimeType
 
     // TODO stop task if new task is started
     Task task = new FeaturesGraphicalNodeTask(FeatureShapeIonMobilityRetentionTimeChart.class, pane,
-        row, coll);
+        row, coll.getText());
     MZmineCore.getTaskController().addTask(task, TaskPriority.NORMAL);
 
     return pane;

--- a/src/main/java/io/github/mzmine/datamodel/features/types/FeatureShapeMobilogramType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/FeatureShapeMobilogramType.java
@@ -18,7 +18,6 @@
 
 package io.github.mzmine.datamodel.features.types;
 
-import javax.annotation.Nonnull;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
@@ -34,6 +33,7 @@ import javafx.scene.Node;
 import javafx.scene.control.TreeTableCell;
 import javafx.scene.control.TreeTableColumn;
 import javafx.scene.layout.StackPane;
+import javax.annotation.Nonnull;
 
 public class FeatureShapeMobilogramType extends DataType<MapProperty<RawDataFile, ModularFeature>>
     implements GraphicalColumType<MapProperty<RawDataFile, ModularFeature>> {
@@ -61,13 +61,15 @@ public class FeatureShapeMobilogramType extends DataType<MapProperty<RawDataFile
     // get existing buffered node from row (for column name)
     // TODO listen to changes in features data
     Node node = row.getBufferedColChart(coll.getText());
-    if (node != null)
+    if (node != null) {
       return node;
+    }
 
     StackPane pane = new StackPane();
 
     // TODO stop task if new task is started
-    Task task = new FeaturesGraphicalNodeTask(FeatureShapeMobilogramChart.class, pane, row, coll);
+    Task task = new FeaturesGraphicalNodeTask(FeatureShapeMobilogramChart.class, pane, row,
+        coll.getText());
     MZmineCore.getTaskController().addTask(task, TaskPriority.NORMAL);
 
     return pane;

--- a/src/main/java/io/github/mzmine/datamodel/features/types/FeatureShapeType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/FeatureShapeType.java
@@ -22,21 +22,26 @@ import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.datamodel.features.types.graphicalnodes.FeatureShapeChart;
-import io.github.mzmine.datamodel.features.types.tasks.FeaturesGraphicalNodeTask;
 import io.github.mzmine.datamodel.features.types.modifiers.GraphicalColumType;
+import io.github.mzmine.datamodel.features.types.numbers.DataPointsType;
+import io.github.mzmine.datamodel.features.types.tasks.FeaturesGraphicalNodeTask;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.taskcontrol.TaskPriority;
-import javafx.beans.property.MapProperty;
-import javafx.beans.property.SimpleMapProperty;
 import javafx.scene.Node;
 import javafx.scene.control.TreeTableCell;
 import javafx.scene.control.TreeTableColumn;
 import javafx.scene.layout.StackPane;
 import javax.annotation.Nonnull;
 
-public class FeatureShapeType extends DataType<MapProperty<RawDataFile, ModularFeature>>
-    implements GraphicalColumType<MapProperty<RawDataFile, ModularFeature>> {
+/**
+ * Contains no data - listens to changes in all {@link ModularFeature} in a {@link
+ * ModularFeatureListRow} On change of any {@link DataPointsType} - the chart is updated
+ *
+ * @author Robin Schmid (https://github.com/robinschmid)
+ */
+public class FeatureShapeType extends LinkedDataType
+    implements GraphicalColumType<Boolean> {
 
   @Nonnull
   @Override
@@ -45,30 +50,27 @@ public class FeatureShapeType extends DataType<MapProperty<RawDataFile, ModularF
   }
 
   @Override
-  public MapProperty<RawDataFile, ModularFeature> createProperty() {
-    return new SimpleMapProperty<RawDataFile, ModularFeature>();
-  }
-
-  @Override
-  public Node getCellNode(
-      TreeTableCell<ModularFeatureListRow, MapProperty<RawDataFile, ModularFeature>> cell,
-      TreeTableColumn<ModularFeatureListRow, MapProperty<RawDataFile, ModularFeature>> coll,
-      MapProperty<RawDataFile, ModularFeature> cellData, RawDataFile raw) {
+  public Node getCellNode(TreeTableCell<ModularFeatureListRow, Boolean> cell,
+      TreeTableColumn<ModularFeatureListRow, Boolean> coll,
+      Boolean cellData, RawDataFile raw) {
     ModularFeatureListRow row = cell.getTreeTableRow().getItem();
-    if (row == null)
+    if (row == null) {
       return null;
+    }
 
     // get existing buffered node from row (for column name)
     // TODO listen to changes in features data
     Node node = row.getBufferedColChart(coll.getText());
-    if (node != null)
+    if (node != null) {
       return node;
+    }
 
     StackPane pane = new StackPane();
 
     // TODO stop task if new task is started
-    Task task = new FeaturesGraphicalNodeTask(FeatureShapeChart.class, pane, row, coll);
-    MZmineCore.getTaskController().addTask(task, TaskPriority.NORMAL);
+    Task task = new FeaturesGraphicalNodeTask(FeatureShapeChart.class, pane, row, coll.getText());
+    // TODO change to TaskPriority.LOW priority
+    MZmineCore.getTaskController().addTask(task, TaskPriority.HIGH);
 
     return pane;
   }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/ImageType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/ImageType.java
@@ -1,6 +1,5 @@
 package io.github.mzmine.datamodel.features.types;
 
-import javax.annotation.Nonnull;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
@@ -16,6 +15,7 @@ import javafx.scene.Node;
 import javafx.scene.control.TreeTableCell;
 import javafx.scene.control.TreeTableColumn;
 import javafx.scene.layout.StackPane;
+import javax.annotation.Nonnull;
 
 public class ImageType extends DataType<MapProperty<RawDataFile, ModularFeature>>
     implements GraphicalColumType<MapProperty<RawDataFile, ModularFeature>> {
@@ -49,7 +49,7 @@ public class ImageType extends DataType<MapProperty<RawDataFile, ModularFeature>
     StackPane pane = new StackPane();
 
     // TODO stop task if new task is started
-    Task task = new FeaturesGraphicalNodeTask(ImageChart.class, pane, row, coll);
+    Task task = new FeaturesGraphicalNodeTask(ImageChart.class, pane, row, coll.getText());
     MZmineCore.getTaskController().addTask(task, TaskPriority.NORMAL);
 
     return pane;

--- a/src/main/java/io/github/mzmine/datamodel/features/types/LinkedDataType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/LinkedDataType.java
@@ -15,10 +15,15 @@
  * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-package io.github.mzmine.datamodel.features.types.modifiers;
+package io.github.mzmine.datamodel.features.types;
 
-public enum BindingsType {
+/**
+ * @author Robin Schmid (https://github.com/robinschmid)
+ */
+public abstract class LinkedDataType extends DataType<TypeListenerProperty> {
 
-  AVERAGE, SUM, MIN, MAX, COUNT, RANGE, CONSENSUS, LIST;
-
+  @Override
+  public TypeListenerProperty createProperty() {
+    return new TypeListenerProperty();
+  }
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/TypeListenerProperty.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/TypeListenerProperty.java
@@ -15,10 +15,24 @@
  * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-package io.github.mzmine.datamodel.features.types.modifiers;
+package io.github.mzmine.datamodel.features.types;
 
-public enum BindingsType {
+import io.github.mzmine.datamodel.features.ListRowBinding;
+import java.util.List;
+import javafx.beans.property.SimpleBooleanProperty;
 
-  AVERAGE, SUM, MIN, MAX, COUNT, RANGE, CONSENSUS, LIST;
+/**
+ * Holds no value but makes fireChangedEvent public. Used by {@link LinkedDataType} and {@link
+ * ListRowBinding} to listen to multiple feature DataTypes
+ *
+ * @author Robin Schmid (https://github.com/robinschmid)
+ */
+public class TypeListenerProperty extends SimpleBooleanProperty {
 
+  // Listen to multiple feature types for changes
+  private List<DataType> featureTypes;
+
+  public void fireChangedEvent() {
+    super.fireValueChangedEvent();
+  }
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/modifiers/BindingsFactoryType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/modifiers/BindingsFactoryType.java
@@ -18,8 +18,15 @@
 package io.github.mzmine.datamodel.features.types.modifiers;
 
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
+import io.github.mzmine.datamodel.features.RowBinding;
+import io.github.mzmine.datamodel.features.types.DataType;
 import javafx.beans.binding.ObjectBinding;
 
+/**
+ * A {@link DataType} that defines different BindingTypes for {@link RowBinding}
+ *
+ * @author Robin Schmid (https://github.com/robinschmid)
+ */
 public interface BindingsFactoryType {
 
 

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/AreaRangeType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/AreaRangeType.java
@@ -18,6 +18,10 @@
 
 package io.github.mzmine.datamodel.features.types.numbers;
 
+import io.github.mzmine.datamodel.features.RowBinding;
+import io.github.mzmine.datamodel.features.SimpleRowBinding;
+import io.github.mzmine.datamodel.features.types.modifiers.BindingsType;
+import java.util.List;
 import javax.annotation.Nonnull;
 
 public class AreaRangeType extends IntensityRangeType {
@@ -28,4 +32,9 @@ public class AreaRangeType extends IntensityRangeType {
     return "Area Range";
   }
 
+  @Nonnull
+  @Override
+  public List<RowBinding> createDefaultRowBindings() {
+    return List.of(new SimpleRowBinding(this, BindingsType.RANGE));
+  }
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/AreaType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/AreaType.java
@@ -1,22 +1,28 @@
 /*
  * Copyright 2006-2020 The MZmine Development Team
- * 
+ *
  * This file is part of MZmine.
- * 
+ *
  * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
  * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
  * Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
  * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
  * USA
  */
 
 package io.github.mzmine.datamodel.features.types.numbers;
+
+import io.github.mzmine.datamodel.features.RowBinding;
+import io.github.mzmine.datamodel.features.SimpleRowBinding;
+import io.github.mzmine.datamodel.features.types.modifiers.BindingsType;
+import java.util.List;
+import javax.annotation.Nonnull;
 
 public class AreaType extends HeightType {
 
@@ -25,4 +31,9 @@ public class AreaType extends HeightType {
     return "Area";
   }
 
+  @Nonnull
+  @Override
+  public List<RowBinding> createDefaultRowBindings() {
+    return List.of(new SimpleRowBinding(this, BindingsType.MAX));
+  }
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/ChargeType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/ChargeType.java
@@ -18,20 +18,20 @@
 
 package io.github.mzmine.datamodel.features.types.numbers;
 
-import com.google.common.collect.Range;
 import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
-import io.github.mzmine.datamodel.features.types.exceptions.UndefinedRowBindingException;
+import io.github.mzmine.datamodel.features.RowBinding;
+import io.github.mzmine.datamodel.features.SimpleRowBinding;
 import io.github.mzmine.datamodel.features.types.modifiers.BindingsType;
 import io.github.mzmine.datamodel.features.types.numbers.abstr.IntegerType;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.ObjectBinding;
 import javafx.beans.property.Property;
-
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.Map;
+import javax.annotation.Nonnull;
 
 public class ChargeType extends IntegerType {
 
@@ -41,11 +41,18 @@ public class ChargeType extends IntegerType {
   }
 
 
+  @Nonnull
+  @Override
+  public List<RowBinding> createDefaultRowBindings() {
+    return List.of(new SimpleRowBinding(this, BindingsType.CONSENSUS));
+  }
+
   @Override
   public ObjectBinding<?> createBinding(BindingsType bind, ModularFeatureListRow row) {
     // get all properties of all features
     @SuppressWarnings("unchecked")
-    Property<Integer>[] prop = row.streamFeatures().map(f -> (ModularFeature) f).map(f -> f.get(this)).toArray(Property[]::new);
+    Property<Integer>[] prop = row.streamFeatures().map(f -> (ModularFeature) f)
+        .map(f -> f.get(this)).toArray(Property[]::new);
     switch (bind) {
       case CONSENSUS:
         return Bindings.createObjectBinding(() -> {

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/DataPointsType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/DataPointsType.java
@@ -19,14 +19,33 @@
 package io.github.mzmine.datamodel.features.types.numbers;
 
 import io.github.mzmine.datamodel.DataPoint;
+import io.github.mzmine.datamodel.features.ListRowBinding;
+import io.github.mzmine.datamodel.features.ModularFeature;
+import io.github.mzmine.datamodel.features.RowBinding;
+import io.github.mzmine.datamodel.features.types.FeatureShapeType;
 import io.github.mzmine.datamodel.features.types.modifiers.NullColumnType;
 import io.github.mzmine.datamodel.features.types.numbers.abstr.ListDataType;
+import java.util.List;
+import javax.annotation.Nonnull;
 
+/**
+ * Holds all data points of a {@link ModularFeature}. Change listener from {@link
+ * #createDefaultRowBindings()} will create and update the {@link FeatureShapeType}
+ *
+ * @author Robin Schmid (https://github.com/robinschmid)
+ */
 public class DataPointsType extends ListDataType<DataPoint> implements NullColumnType {
 
   @Override
   public String getHeaderString() {
     return "DPs";
+  }
+
+  @Nonnull
+  @Override
+  public List<RowBinding> createDefaultRowBindings() {
+    // listen to changes in DataPointsType for all ModularFeatures
+    return List.of(new ListRowBinding(new FeatureShapeType(), this));
   }
 
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/FragmentScanNumbersType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/FragmentScanNumbersType.java
@@ -1,16 +1,16 @@
 /*
  * Copyright 2006-2020 The MZmine Development Team
- * 
+ *
  * This file is part of MZmine.
- * 
+ *
  * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
  * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
  * Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
  * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
  * USA
@@ -18,11 +18,23 @@
 
 package io.github.mzmine.datamodel.features.types.numbers;
 
+import io.github.mzmine.datamodel.features.RowBinding;
+import io.github.mzmine.datamodel.features.SimpleRowBinding;
+import io.github.mzmine.datamodel.features.types.modifiers.BindingsType;
+import java.util.List;
+import javax.annotation.Nonnull;
+
 public class FragmentScanNumbersType extends ScanNumbersType {
 
   @Override
   public String getHeaderString() {
     return "Fragment scans";
+  }
+
+  @Nonnull
+  @Override
+  public List<RowBinding> createDefaultRowBindings() {
+    return List.of(new SimpleRowBinding(this, BindingsType.CONSENSUS));
   }
 
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/HeightType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/HeightType.java
@@ -18,11 +18,15 @@
 
 package io.github.mzmine.datamodel.features.types.numbers;
 
-import java.text.DecimalFormat;
-import java.text.NumberFormat;
-import javax.annotation.Nonnull;
+import io.github.mzmine.datamodel.features.RowBinding;
+import io.github.mzmine.datamodel.features.SimpleRowBinding;
+import io.github.mzmine.datamodel.features.types.modifiers.BindingsType;
 import io.github.mzmine.datamodel.features.types.numbers.abstr.FloatType;
 import io.github.mzmine.main.MZmineCore;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.List;
+import javax.annotation.Nonnull;
 
 public class HeightType extends FloatType {
 
@@ -47,4 +51,9 @@ public class HeightType extends FloatType {
     return "Height";
   }
 
+  @Nonnull
+  @Override
+  public List<RowBinding> createDefaultRowBindings() {
+    return List.of(new SimpleRowBinding(this, BindingsType.MAX));
+  }
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/IntensityRangeType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/IntensityRangeType.java
@@ -18,11 +18,15 @@
 
 package io.github.mzmine.datamodel.features.types.numbers;
 
-import java.text.DecimalFormat;
-import java.text.NumberFormat;
-import javax.annotation.Nonnull;
+import io.github.mzmine.datamodel.features.RowBinding;
+import io.github.mzmine.datamodel.features.SimpleRowBinding;
+import io.github.mzmine.datamodel.features.types.modifiers.BindingsType;
 import io.github.mzmine.datamodel.features.types.numbers.abstr.FloatRangeType;
 import io.github.mzmine.main.MZmineCore;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.List;
+import javax.annotation.Nonnull;
 
 public class IntensityRangeType extends FloatRangeType {
 
@@ -46,4 +50,10 @@ public class IntensityRangeType extends FloatRangeType {
     return "Intensity range";
   }
 
+
+  @Nonnull
+  @Override
+  public List<RowBinding> createDefaultRowBindings() {
+    return List.of(new SimpleRowBinding(this, BindingsType.RANGE));
+  }
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/MZRangeType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/MZRangeType.java
@@ -18,13 +18,17 @@
 
 package io.github.mzmine.datamodel.features.types.numbers;
 
+import io.github.mzmine.datamodel.features.RowBinding;
+import io.github.mzmine.datamodel.features.SimpleRowBinding;
 import io.github.mzmine.datamodel.features.types.DataType;
+import io.github.mzmine.datamodel.features.types.modifiers.BindingsType;
 import io.github.mzmine.datamodel.features.types.modifiers.ExpandableType;
-import java.text.DecimalFormat;
-import java.text.NumberFormat;
-import javax.annotation.Nonnull;
 import io.github.mzmine.datamodel.features.types.numbers.abstr.DoubleRangeType;
 import io.github.mzmine.main.MZmineCore;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.List;
+import javax.annotation.Nonnull;
 
 public class MZRangeType extends DoubleRangeType implements ExpandableType {
 
@@ -58,5 +62,11 @@ public class MZRangeType extends DoubleRangeType implements ExpandableType {
   @Override
   public Class<? extends DataType<?>> getHiddenTypeClass() {
     return MZType.class;
+  }
+
+  @Nonnull
+  @Override
+  public List<RowBinding> createDefaultRowBindings() {
+    return List.of(new SimpleRowBinding(this, BindingsType.RANGE));
   }
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/MZType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/MZType.java
@@ -18,12 +18,16 @@
 
 package io.github.mzmine.datamodel.features.types.numbers;
 
+import io.github.mzmine.datamodel.features.RowBinding;
+import io.github.mzmine.datamodel.features.SimpleRowBinding;
 import io.github.mzmine.datamodel.features.types.DataType;
+import io.github.mzmine.datamodel.features.types.modifiers.BindingsType;
 import io.github.mzmine.datamodel.features.types.modifiers.ExpandableType;
-import java.text.DecimalFormat;
-import java.text.NumberFormat;
 import io.github.mzmine.datamodel.features.types.numbers.abstr.DoubleType;
 import io.github.mzmine.main.MZmineCore;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.List;
 import javax.annotation.Nonnull;
 
 public class MZType extends DoubleType implements ExpandableType {
@@ -57,5 +61,11 @@ public class MZType extends DoubleType implements ExpandableType {
   @Override
   public Class<? extends DataType<?>> getHiddenTypeClass() {
     return getClass();
+  }
+
+  @Nonnull
+  @Override
+  public List<RowBinding> createDefaultRowBindings() {
+    return List.of(new SimpleRowBinding(this, BindingsType.AVERAGE));
   }
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/RTRangeType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/RTRangeType.java
@@ -18,13 +18,17 @@
 
 package io.github.mzmine.datamodel.features.types.numbers;
 
+import io.github.mzmine.datamodel.features.RowBinding;
+import io.github.mzmine.datamodel.features.SimpleRowBinding;
 import io.github.mzmine.datamodel.features.types.DataType;
+import io.github.mzmine.datamodel.features.types.modifiers.BindingsType;
 import io.github.mzmine.datamodel.features.types.modifiers.ExpandableType;
-import java.text.DecimalFormat;
-import java.text.NumberFormat;
-import javax.annotation.Nonnull;
 import io.github.mzmine.datamodel.features.types.numbers.abstr.FloatRangeType;
 import io.github.mzmine.main.MZmineCore;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.List;
+import javax.annotation.Nonnull;
 
 public class RTRangeType extends FloatRangeType implements ExpandableType {
 
@@ -46,6 +50,12 @@ public class RTRangeType extends FloatRangeType implements ExpandableType {
   @Nonnull
   public String getHeaderString() {
     return "RT range";
+  }
+
+  @Nonnull
+  @Override
+  public List<RowBinding> createDefaultRowBindings() {
+    return List.of(new SimpleRowBinding(this, BindingsType.RANGE));
   }
 
   @Nonnull

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/RTType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/RTType.java
@@ -18,12 +18,16 @@
 
 package io.github.mzmine.datamodel.features.types.numbers;
 
+import io.github.mzmine.datamodel.features.RowBinding;
+import io.github.mzmine.datamodel.features.SimpleRowBinding;
 import io.github.mzmine.datamodel.features.types.DataType;
+import io.github.mzmine.datamodel.features.types.modifiers.BindingsType;
 import io.github.mzmine.datamodel.features.types.modifiers.ExpandableType;
-import java.text.DecimalFormat;
-import java.text.NumberFormat;
 import io.github.mzmine.datamodel.features.types.numbers.abstr.FloatType;
 import io.github.mzmine.main.MZmineCore;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.List;
 import javax.annotation.Nonnull;
 
 public class RTType extends FloatType implements ExpandableType {
@@ -45,6 +49,12 @@ public class RTType extends FloatType implements ExpandableType {
   @Override
   public String getHeaderString() {
     return "RT";
+  }
+
+  @Nonnull
+  @Override
+  public List<RowBinding> createDefaultRowBindings() {
+    return List.of(new SimpleRowBinding(this, BindingsType.AVERAGE));
   }
 
   @Nonnull

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/ScanNumbersType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/ScanNumbersType.java
@@ -1,16 +1,16 @@
 /*
  * Copyright 2006-2020 The MZmine Development Team
- * 
+ *
  * This file is part of MZmine.
- * 
+ *
  * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
  * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
  * Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
  * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
  * USA
@@ -18,15 +18,24 @@
 
 package io.github.mzmine.datamodel.features.types.numbers;
 
-import io.github.mzmine.datamodel.features.types.modifiers.NullColumnType;
+import io.github.mzmine.datamodel.features.ModularFeature;
+import io.github.mzmine.datamodel.features.ModularFeatureListRow;
+import io.github.mzmine.datamodel.features.types.exceptions.UndefinedRowBindingException;
+import io.github.mzmine.datamodel.features.types.modifiers.BindingsFactoryType;
+import io.github.mzmine.datamodel.features.types.modifiers.BindingsType;
 import io.github.mzmine.datamodel.features.types.numbers.abstr.ListDataType;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javafx.beans.binding.Bindings;
+import javafx.beans.binding.ObjectBinding;
 import javafx.beans.property.ListProperty;
-
+import javafx.collections.FXCollections;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.List;
 
-public class ScanNumbersType extends ListDataType<Integer> {
+public class ScanNumbersType extends ListDataType<Integer> implements BindingsFactoryType {
 
   @Override
   public String getHeaderString() {
@@ -43,8 +52,72 @@ public class ScanNumbersType extends ListDataType<Integer> {
   @Nonnull
   @Override
   public String getFormattedString(@Nullable Object value) {
-    if(value==null || !(value instanceof List))
+    if (value == null || !(value instanceof List)) {
       return "";
-    return String.valueOf(((List)value).size());
+    }
+    return String.valueOf(((List) value).size());
+  }
+
+
+  @Override
+  public ObjectBinding<?> createBinding(BindingsType bind, ModularFeatureListRow row) {
+    // get all properties of all features
+    @SuppressWarnings("unchecked")
+    ListProperty[] prop = row.streamFeatures().map(f -> (ModularFeature) f)
+        .map(f -> f.get(this)).toArray(ListProperty[]::new);
+    switch (bind) {
+      case AVERAGE:
+        return Bindings.createObjectBinding(() -> {
+          float sum = 0;
+          int n = 0;
+          for (ListProperty p : prop) {
+            if (p.getValue() != null) {
+              sum += p.size();
+              n++;
+            }
+          }
+          return n == 0 ? 0 : sum / n;
+        }, prop);
+      case MIN:
+        return Bindings.createObjectBinding(() -> {
+          int min = Integer.MAX_VALUE;
+          for (ListProperty p : prop) {
+            if (p.getValue() != null && p.size() < min) {
+              min = p.size();
+            }
+          }
+          return min;
+        }, prop);
+      case MAX:
+        return Bindings.createObjectBinding(() -> {
+          int max = Integer.MIN_VALUE;
+          for (ListProperty p : prop) {
+            if (p.getValue() != null && p.size() > max) {
+              max = p.size();
+            }
+          }
+          return max;
+        }, prop);
+      case SUM:
+        return Bindings.createObjectBinding(() -> {
+          int sum = 0;
+          for (ListProperty p : prop) {
+            if (p.getValue() != null) {
+              sum += p.size();
+            }
+          }
+          return sum;
+        }, prop);
+      case CONSENSUS:
+        return Bindings.createObjectBinding(() -> {
+          List collect = (List) Stream.of(prop).filter(Objects::nonNull)
+              .flatMap(ListProperty::stream).collect(Collectors.toList());
+          return FXCollections.observableList(collect);
+        }, prop);
+      case COUNT:
+      case RANGE:
+      default:
+        throw new UndefinedRowBindingException(this, bind);
+    }
   }
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/tasks/FeaturesGraphicalNodeTask.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/tasks/FeaturesGraphicalNodeTask.java
@@ -19,36 +19,34 @@
 package io.github.mzmine.datamodel.features.types.tasks;
 
 import com.google.common.util.concurrent.AtomicDouble;
-import io.github.mzmine.datamodel.RawDataFile;
-import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import java.lang.reflect.InvocationTargetException;
 import javafx.application.Platform;
-import javafx.beans.property.MapProperty;
 import javafx.scene.Node;
-import javafx.scene.control.TreeTableColumn;
 import javafx.scene.layout.StackPane;
 
 /**
  * Task for creating graphical nodes, having (ModularFeatureListRow row, AtomicDouble progress) constructor
  */
-public class FeaturesGraphicalNodeTask extends AbstractTask{
+public class FeaturesGraphicalNodeTask extends AbstractTask {
+
   Class<? extends Node> nodeClass;
   private StackPane pane;
   private ModularFeatureListRow row;
-  private TreeTableColumn<ModularFeatureListRow, MapProperty<RawDataFile, ModularFeature>> coll;
+  private String collHeader;
   private AtomicDouble progress = new AtomicDouble(0d);
   private int rowID = -1;
 
-  public FeaturesGraphicalNodeTask(Class<? extends Node> nodeClass, StackPane pane, ModularFeatureListRow row,
-      TreeTableColumn<ModularFeatureListRow, MapProperty<RawDataFile, ModularFeature>> coll) {
+  public FeaturesGraphicalNodeTask(Class<? extends Node> nodeClass, StackPane pane,
+      ModularFeatureListRow row,
+      String collHeader) {
     super();
     this.nodeClass = nodeClass;
     this.pane = pane;
     this.row = row;
-    this.coll = coll;
+    this.collHeader = collHeader;
   }
 
   @Override
@@ -67,7 +65,7 @@ public class FeaturesGraphicalNodeTask extends AbstractTask{
     }
     final Node node = n;
     // save chart for later
-    row.addBufferedColChart(coll.getText(), n);
+    row.addBufferedColChart(collHeader, n);
 
     Platform.runLater(() -> {
       pane.getChildren().add(node);
@@ -78,7 +76,7 @@ public class FeaturesGraphicalNodeTask extends AbstractTask{
 
   @Override
   public String getTaskDescription() {
-    return "Creating a graphical column for col: " + coll.getText()
+    return "Creating a graphical column for col: " + collHeader
         + " in row: " + rowID;
   }
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ModularADAPChromatogramBuilderTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ModularADAPChromatogramBuilderTask.java
@@ -21,15 +21,6 @@
 package io.github.mzmine.modules.dataprocessing.featdet_adapchromatogrambuilder;
 
 
-import io.github.mzmine.datamodel.features.types.FeatureShapeType;
-import io.github.mzmine.util.FeatureConvertors;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-import java.util.logging.Logger;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 import com.google.common.collect.TreeRangeSet;
@@ -47,11 +38,19 @@ import io.github.mzmine.parameters.parametertypes.selectors.ScanSelection;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import io.github.mzmine.util.ADAPChromatogramSorter;
 import io.github.mzmine.util.DataPointSorter;
 import io.github.mzmine.util.DataTypeUtils;
-import io.github.mzmine.util.ADAPChromatogramSorter;
+import io.github.mzmine.util.FeatureConvertors;
 import io.github.mzmine.util.SortingDirection;
 import io.github.mzmine.util.SortingProperty;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
 
 
 public class ModularADAPChromatogramBuilderTask extends AbstractTask {
@@ -395,7 +394,6 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
       ModularFeature modular = FeatureConvertors.ADAPChromatogramToModularFeature(finishedFeature);
       ModularFeatureListRow newRow =
           new ModularFeatureListRow(newFeatureList, newFeatureID, dataFile, modular);
-      newRow.set(FeatureShapeType.class, newRow.getFeaturesProperty());
       newFeatureList.addRow(newRow);
       newFeatureID++;
     }

--- a/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFXMLTabAnchorPaneController.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFXMLTabAnchorPaneController.java
@@ -202,9 +202,11 @@ public class FeatureTableFXMLTabAnchorPaneController {
     TreeItem<FeatureListRow> selectedItem = featureTable.getSelectionModel()
         .getSelectedItem();
 //    featureTable.getColumns().forEach(c -> logger.info(c.getText()));
-    logger.info(
-        "selected: " + featureTable.getSelectionModel().getSelectedCells().get(0).getTableColumn()
-            .getText());
+    if (!featureTable.getSelectionModel().getSelectedCells().isEmpty()) {
+      logger.info(
+          "selected: " + featureTable.getSelectionModel().getSelectedCells().get(0).getTableColumn()
+              .getText());
+    }
 
     if (selectedItem == null) {
       return;

--- a/src/main/java/io/github/mzmine/taskcontrol/TaskPriority.java
+++ b/src/main/java/io/github/mzmine/taskcontrol/TaskPriority.java
@@ -25,7 +25,7 @@ package io.github.mzmine.taskcontrol;
  * 
  */
 public enum TaskPriority {
-
+  // TODO add LOW
   HIGH, NORMAL
 
 }

--- a/src/main/java/io/github/mzmine/util/DataTypeUtils.java
+++ b/src/main/java/io/github/mzmine/util/DataTypeUtils.java
@@ -20,24 +20,31 @@
 
 package io.github.mzmine.util;
 
+import io.github.mzmine.datamodel.features.ModularFeatureList;
+import io.github.mzmine.datamodel.features.types.DataType;
+import io.github.mzmine.datamodel.features.types.DetectionType;
+import io.github.mzmine.datamodel.features.types.FeatureShapeType;
+import io.github.mzmine.datamodel.features.types.FeaturesType;
+import io.github.mzmine.datamodel.features.types.ManualAnnotationType;
+import io.github.mzmine.datamodel.features.types.RawFileType;
+import io.github.mzmine.datamodel.features.types.numbers.AreaType;
+import io.github.mzmine.datamodel.features.types.numbers.AsymmetryFactorType;
+import io.github.mzmine.datamodel.features.types.numbers.BestScanNumberType;
+import io.github.mzmine.datamodel.features.types.numbers.DataPointsType;
+import io.github.mzmine.datamodel.features.types.numbers.FwhmType;
+import io.github.mzmine.datamodel.features.types.numbers.HeightType;
+import io.github.mzmine.datamodel.features.types.numbers.IntensityRangeType;
+import io.github.mzmine.datamodel.features.types.numbers.MZRangeType;
+import io.github.mzmine.datamodel.features.types.numbers.MZType;
+import io.github.mzmine.datamodel.features.types.numbers.RTRangeType;
+import io.github.mzmine.datamodel.features.types.numbers.RTType;
+import io.github.mzmine.datamodel.features.types.numbers.ScanNumbersType;
+import io.github.mzmine.datamodel.features.types.numbers.TailingFactorType;
 import java.util.List;
 import javax.annotation.Nonnull;
-import io.github.mzmine.datamodel.features.ModularFeatureList;
-import io.github.mzmine.datamodel.features.RowBinding;
-import io.github.mzmine.datamodel.features.types.*;
-import io.github.mzmine.datamodel.features.types.modifiers.BindingsType;
-import io.github.mzmine.datamodel.features.types.numbers.*;
 
 @SuppressWarnings("null")
 public class DataTypeUtils {
-  // bindings from row to features
-  public static final @Nonnull List<RowBinding> DEFAULT_CHROMATOGRAPHIC_ROWBINDING =
-      List.of(new RowBinding(new MZType(), BindingsType.AVERAGE),
-          new RowBinding(new RTType(), BindingsType.AVERAGE)/*,
-          new RowBinding(new HeightType(), BindingsType.MAX),
-          new RowBinding(new AreaType(), BindingsType.MAX)*/,
-          new RowBinding(new RTRangeType(), BindingsType.RANGE),
-          new RowBinding(new MZRangeType(), BindingsType.RANGE));
 
   public static final @Nonnull List<DataType<?>> DEFAULT_CHROMATOGRAPHIC_ROW = List.of(
           new RTType(), new RTRangeType(), // needed next to each other for switching between RTType and RTRangeType
@@ -60,7 +67,6 @@ public class DataTypeUtils {
     flist.addRowType(DEFAULT_CHROMATOGRAPHIC_ROW);
     flist.addFeatureType(DEFAULT_CHROMATOGRAPHIC_FEATURE);
     // row bindigns are now added in the table
-    // flist.addRowBinding(DEFAULT_CHROMATOGRAPHIC_ROWBINDING);
   }
 
 }


### PR DESCRIPTION
This PR adds automatic row binding.

All feature types know their default row binding and those are added automatically to the featurelist

Add MZType to a feature will automatically add MZType to the RowTypes and add the binding