### PR TITLE
Fix: Deconvolution dialog gridlines

### DIFF
--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/PeakResolverSetupDialog.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/PeakResolverSetupDialog.java
@@ -106,7 +106,6 @@ public class PeakResolverSetupDialog extends ParameterSetupDialog {
       final Class<? extends PeakResolver> resolverClass, String message) {
 
     super(valueCheckRequired, resolverParameters, message);
-    paramsPane.setGridLinesVisible(true);
 
     // Instantiate resolver.
     try {


### PR DESCRIPTION
Made gridlines invisible. Turned them on when i was debugging the dialog and noticed they were still on.