### PR TITLE
Remove scan numbers

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/IMSRawDataFile.java
+++ b/src/main/java/io/github/mzmine/datamodel/IMSRawDataFile.java
@@ -67,17 +67,11 @@ public interface IMSRawDataFile extends RawDataFile {
   public int getNumberOfFrames();
 
   /**
-   * @return The frame numbers in this raw data file. Might be empty.
-   */
-  @Nonnull
-  public Set<Integer> getFrameNumbers();
-
-  /**
    * @param msLevel The ms level of the given frames.
    * @return The frame numbers in the specified ms level. Might be empty.
    */
   @Nonnull
-  public Set<Integer> getFrameNumbers(int msLevel);
+  public Set<Scan> getFrameNumbers(int msLevel);
 
   /**
    * @param msLevel
@@ -85,7 +79,7 @@ public interface IMSRawDataFile extends RawDataFile {
    * @return The frame numbers in the specified ms level and rt range. Might be empty.
    */
   @Nonnull
-  public Set<Integer> getFrameNumbers(int msLevel, @Nonnull Range<Float> rtRange);
+  public Set<Scan> getFrameNumbers(int msLevel, @Nonnull Range<Float> rtRange);
 
   /**
    * @return The mobility range of this raw data file. Might be empty.

--- a/src/main/java/io/github/mzmine/datamodel/Mobilogram.java
+++ b/src/main/java/io/github/mzmine/datamodel/Mobilogram.java
@@ -45,7 +45,7 @@ public interface Mobilogram {
   public MobilityDataPoint getHighestDataPoint();
 
   @Nonnull
-  List<Scan> getMobilityScanNumbers();
+  List<Integer> getMobilityScanNumbers();
 
   public MobilityType getMobilityType();
 

--- a/src/main/java/io/github/mzmine/datamodel/Mobilogram.java
+++ b/src/main/java/io/github/mzmine/datamodel/Mobilogram.java
@@ -45,7 +45,7 @@ public interface Mobilogram {
   public MobilityDataPoint getHighestDataPoint();
 
   @Nonnull
-  List<Integer> getMobilityScanNumbers();
+  List<Scan> getMobilityScanNumbers();
 
   public MobilityType getMobilityType();
 

--- a/src/main/java/io/github/mzmine/datamodel/RawDataFile.java
+++ b/src/main/java/io/github/mzmine/datamodel/RawDataFile.java
@@ -18,11 +18,12 @@
 
 package io.github.mzmine.datamodel;
 
-import javafx.beans.property.ObjectProperty;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import com.google.common.collect.Range;
 import java.util.List;
+import javafx.beans.property.ObjectProperty;
+import javafx.collections.ObservableList;
+import javafx.scene.paint.Color;
+import javax.annotation.Nonnull;
 
 public interface RawDataFile {
 
@@ -52,21 +53,13 @@ public interface RawDataFile {
   public int[] getMSLevels();
 
   /**
-   * Returns sorted array of all scan numbers in this file
-   *
-   * @return Sorted array of scan numbers, never returns null
-   */
-  @Nonnull
-  public int[] getScanNumbers();
-
-  /**
    * Returns sorted array of all scan numbers in given MS level
    *
-   * @param msLevel MS level
+   * @param msLevel MS level (0 for all scans)
    * @return Sorted array of scan numbers, never returns null
    */
   @Nonnull
-  public int[] getScanNumbers(int msLevel);
+  public ObservableList<Scan> getScanNumbers(int msLevel);
 
   /**
    * Returns sorted array of all scan numbers in given MS level and retention time range
@@ -76,7 +69,7 @@ public interface RawDataFile {
    * @return Sorted array of scan numbers, never returns null
    */
   @Nonnull
-  public int[] getScanNumbers(int msLevel, @Nonnull Range<Float> rtRange);
+  public Scan[] getScanNumbers(int msLevel, @Nonnull Range<Float> rtRange);
 
   /**
    * Scan could be null if scanID is not contained in the raw data file
@@ -84,8 +77,8 @@ public interface RawDataFile {
    * @param scan Desired scan number
    * @return Desired scan
    */
-  @Nullable
-  public Scan getScan(int scan);
+//  @Nullable
+//  public Scan getScan(int scan);
 
   /**
    * @param rt      The rt
@@ -93,14 +86,14 @@ public interface RawDataFile {
    * @return Returns the scan closest to the given rt in the given ms level. -1 if the rt exceeds
    * the rt range of this file.
    */
-  public int getScanNumberAtRT(float rt, int mslevel);
+  public Scan getScanNumberAtRT(float rt, int mslevel);
 
   /**
    * @param rt The rt
    * @return Returns the scan closest to the given rt in the given ms level. -1 if the rt exceeds
    * the rt range of this file.
    */
-  public int getScanNumberAtRT(float rt);
+  public Scan getScanNumberAtRT(float rt);
 
   @Nonnull
   public Range<Double> getDataMZRange();
@@ -128,15 +121,37 @@ public interface RawDataFile {
 
   public java.awt.Color getColorAWT();
 
-  public javafx.scene.paint.Color getColor();
+  public Color getColor();
 
-  public void setColor(javafx.scene.paint.Color color);
+  public void setColor(Color color);
 
-  public ObjectProperty<javafx.scene.paint.Color> colorProperty();
+  public ObjectProperty<Color> colorProperty();
 
   /**
    * Close the file in case it is removed from the project
    */
   public void close();
 
+  ObservableList<Scan> getScans();
+
+  /**
+   * The scan at the specified scan number or null
+   *
+   * @param scanNumber
+   * @return
+   */
+  default Scan getScanAtNumber(int scanNumber) {
+    return getScans().stream().filter(s -> s.getScanNumber() == scanNumber)
+        .findFirst().orElse(null);
+  }
+
+  /**
+   * Scan at index i in list getScans()
+   *
+   * @param i
+   * @return
+   */
+  default Scan getScan(int i) {
+    return getScans().get(i);
+  }
 }

--- a/src/main/java/io/github/mzmine/datamodel/Scan.java
+++ b/src/main/java/io/github/mzmine/datamodel/Scan.java
@@ -25,7 +25,7 @@ import com.google.common.collect.Range;
 /**
  * This class represent one spectrum of a raw data file.
  */
-public interface Scan extends MassSpectrum {
+public interface Scan extends MassSpectrum, Comparable<Scan> {
 
   /**
    *
@@ -88,5 +88,18 @@ public interface Scan extends MassSpectrum {
 
   public void removeMassList(@Nonnull MassList massList);
 
+
+  /**
+   * Standard method to sort scans
+   * @param s
+   * @return
+   */
+  @Override
+  default int compareTo(@Nonnull Scan s) {
+    int result = Integer.compare(this.getScanNumber(), s.getScanNumber());
+    if(result!=0)
+      return result;
+    else return Float.compare(this.getRetentionTime(), s.getRetentionTime());
+  }
 }
 

--- a/src/main/java/io/github/mzmine/datamodel/features/Feature.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/Feature.java
@@ -24,7 +24,6 @@ import io.github.mzmine.datamodel.IsotopePattern;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.impl.SimpleFeatureInformation;
-import java.util.Objects;
 import javafx.collections.ObservableList;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -70,33 +69,66 @@ public interface Feature {
    * This method returns numbers of scans that contain this feature
    */
   @Nonnull
-  ObservableList<Integer> getScanNumbers();
+  ObservableList<Scan> getScanNumbers();
 
   /**
-   * This method sets the number of most representative scan of this feature
-   */
-  void setRepresentativeScanNumber(int representiveScanNumber);
-
-  /**
-   * This method returns the number of most representative scan of this feature
-   */
-  int getRepresentativeScanNumber();
-
-  /**
-   * This method returns the best scan
-   */
-  default @Nonnull
-  Scan getRepresentativeScan() {
-    return Objects.requireNonNull(getRawDataFile().getScan(getRepresentativeScanNumber()));
-  };
-
-  /**
-   * This method returns m/z and intensity of this feature in a given scan. This m/z and intensity does
-   * not need to match any actual raw data point. May return null, if there is no data point in
-   * given scan.
+   * Used to loop over scans and data points in combination with ({@link #getDataPointAtIndex(int)}
+   *
+   * @param i
+   * @return
    */
   @Nullable
-  DataPoint getDataPoint(int scanNumber);
+  default Scan getScanAtIndex(int i) {
+    ObservableList<Scan> scans = getScanNumbers();
+    return scans == null ? null : scans.get(i);
+  }
+
+  /**
+   * Used to loop over retention time, scans, and data points in combination with ({@link
+   * #getDataPointAtIndex(int)}
+   *
+   * @param i
+   * @return
+   */
+  @Nullable
+  default float getRetentionTimeAtIndex(int i) {
+    ObservableList<Scan> scans = getScanNumbers();
+    return scans == null ? null : scans.get(i).getRetentionTime();
+  }
+
+  /**
+   * Used to loop over scans and data points in combination with ({@link #getDataPointAtIndex(int)}
+   *
+   * @param i
+   * @return
+   */
+  @Nullable
+  default DataPoint getDataPointAtIndex(int i) {
+    ObservableList<DataPoint> dataPoints = getDataPoints();
+    return dataPoints == null ? null : dataPoints.get(i);
+  }
+
+  /**
+   * This method returns the best scan (null if no raw file is attached)
+   */
+  @Nullable
+  Scan getRepresentativeScan();
+
+  /**
+   * The representative scan of this feature
+   *
+   * @param scan
+   */
+  void setRepresentativeScan(Scan scan);
+
+  /**
+   * This method returns m/z and intensity of this feature in a given scan. This m/z and intensity
+   * does not need to match any actual raw data point. May return null, if there is no data point in
+   * given scan. Tip: Better loop over the data points and scans with an index to retrieve all
+   * information
+   */
+  @Nullable
+  DataPoint getDataPoint(Scan scan);
 
   /**
    * Returns all data points.
@@ -124,12 +156,12 @@ public interface Feature {
   /**
    * Returns the number of scan that represents the fragmentation of this feature in MS2 level.
    */
-  int getMostIntenseFragmentScanNumber();
+  Scan getMostIntenseFragmentScan();
 
   /**
    * Returns all scan numbers that represent fragmentations of this feature in MS2 level.
    */
-  ObservableList<Integer> getAllMS2FragmentScanNumbers();
+  ObservableList<Scan> getAllMS2FragmentScans();
 
   /**
    * Sets raw M/Z value of the feature
@@ -152,11 +184,11 @@ public interface Feature {
   void setArea(float area);
 
   /**
-   * Set best fragment scan numbers
+   * Set best fragment scan
    *
-   * @param fragmentScanNumber
+   * @param fragmentScan
    */
-  void setFragmentScanNumber(int fragmentScanNumber);
+  void setFragmentScan(Scan fragmentScan);
 
   /**
    * Set all fragment scan numbers
@@ -164,7 +196,7 @@ public interface Feature {
    * @param allMS2FragmentScanNumbers
    */
   //void setAllMS2FragmentScanNumbers(List<Integer> allMS2FragmentScanNumbers); ?
-  void setAllMS2FragmentScanNumbers(ObservableList<Integer> allMS2FragmentScanNumbers);
+  void setAllMS2FragmentScans(ObservableList<Scan> allMS2FragmentScanNumbers);
 
   /**
    * Returns the isotope pattern of this feature or null if no pattern is attached
@@ -235,4 +267,8 @@ public interface Feature {
 
   void setFeatureList(@Nonnull FeatureList featureList);
 
+  default int getNumberOfDataPoints() {
+    ObservableList<DataPoint> dp = getDataPoints();
+    return dp == null? -1 : dp.size();
+  }
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularDataModel.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularDataModel.java
@@ -21,6 +21,7 @@ package io.github.mzmine.datamodel.features;
 import io.github.mzmine.datamodel.features.types.DataType;
 import io.github.mzmine.datamodel.features.types.exceptions.TypeColumnUndefinedException;
 import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -215,12 +216,18 @@ public interface ModularDataModel {
       property = realType.createProperty();
       setProperty(realType, property);
     }
+    if(value == null) {
+      property.setValue(null);
+      return;
+    }
+
     if(value instanceof Property)
       value = ((Property)value).getValue();
 
     // lists need to be ObservableList
-    if (value instanceof List && !(value instanceof ObservableList))
+    if (value instanceof List && !(value instanceof ObservableList)) {
       property.setValue(FXCollections.observableList((List) value));
+    }
     else if (value instanceof Map && !(value instanceof ObservableMap))
       property.setValue(FXCollections.observableMap((Map) value));
     else

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeature.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeature.java
@@ -238,6 +238,9 @@ public class ModularFeature implements Feature, ModularDataModel {
 
   @Override
   public DataPoint getDataPoint(Scan scan) {
+    if(!scan.getDataFile().equals(getRawDataFile())) {
+      throw new IllegalArgumentException("the scan data file must equal the feature data file");
+    }
     int index = getScanNumbers().indexOf(scan);
     if (index < 0) {
       return null;

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeature.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeature.java
@@ -50,6 +50,7 @@ import io.github.mzmine.modules.tools.qualityparameters.QualityParameters;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import javafx.beans.property.ListProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.Property;
@@ -122,7 +123,7 @@ public class ModularFeature implements Feature, ModularDataModel {
     setFragmentScan(fragmentScanNumber);
     setRepresentativeScan(representativeScan);
     // add values to feature
-    set(ScanNumbersType.class, scanNumbers);
+    set(ScanNumbersType.class, List.of(scanNumbers));
     set(RawFileType.class, dataFile);
     set(DetectionType.class, featureStatus);
     set(MZType.class, mz);
@@ -139,7 +140,7 @@ public class ModularFeature implements Feature, ModularDataModel {
     set(RTRangeType.class, rtRange);
     set(IntensityRangeType.class, intensityRange);
 
-    set(FragmentScanNumbersType.class, allMS2FragmentScanNumbers);
+    set(FragmentScanNumbersType.class, List.of(allMS2FragmentScanNumbers));
 
     float fwhm = QualityParameters.calculateFWHM(this);
     if(!Float.isNaN(fwhm)) {

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureListRow.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureListRow.java
@@ -557,8 +557,7 @@ public class ModularFeatureListRow implements FeatureListRow, ModularDataModel {
         continue;
       }
 
-      int bestScanNumber = feature.getMostIntenseFragmentScanNumber();
-      Scan theScan = rawData.getScan(bestScanNumber);
+      Scan theScan = feature.getMostIntenseFragmentScan();
       double theTIC = 0.0;
       if (theScan != null) {
         theTIC = theScan.getTIC();
@@ -578,10 +577,9 @@ public class ModularFeatureListRow implements FeatureListRow, ModularDataModel {
     ObservableList<Scan> allMS2ScansList = FXCollections.observableArrayList();
     for (Feature feature : getFeatures()) {
       RawDataFile rawData = feature.getRawDataFile();
-      ObservableList<Integer> scanNumbers = feature.getAllMS2FragmentScanNumbers();
-      if (scanNumbers != null) {
-        for (int scanNumber : scanNumbers) {
-          Scan scan = rawData.getScan(scanNumber);
+      ObservableList<Scan> scans = feature.getAllMS2FragmentScans();
+      if (scans != null) {
+        for (Scan scan : scans) {
           allMS2ScansList.add(scan);
         }
       }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/graphicalnodes/FeatureShapeChart.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/graphicalnodes/FeatureShapeChart.java
@@ -21,12 +21,14 @@ package io.github.mzmine.datamodel.features.types.graphicalnodes;
 import com.google.common.util.concurrent.AtomicDouble;
 import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.util.color.ColorsFX;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javafx.collections.ObservableList;
 import javafx.event.EventHandler;
 import javafx.scene.Node;
 import javafx.scene.chart.LineChart;
@@ -58,12 +60,12 @@ public class FeatureShapeChart extends StackPane {
         }
 
         XYChart.Series<Number, Number> data = new XYChart.Series<>();
-        List<Integer> scans = f.getScanNumbers();
+        ObservableList<Scan> scans = f.getScanNumbers();
         RawDataFile raw = f.getRawDataFile();
         // add data points retention time -> intensity
         for (int i = 0; i < scans.size(); i++) {
           DataPoint dp = dps.get(i);
-          double retentionTime = raw.getScan(scans.get(i)).getRetentionTime();
+          double retentionTime = scans.get(i).getRetentionTime();
           double intensity = dp == null ? 0 : dp.getIntensity();
           data.getData().add(new XYChart.Data<>(retentionTime, intensity));
           /*

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/BestFragmentScanNumberType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/BestFragmentScanNumberType.java
@@ -18,14 +18,23 @@
 
 package io.github.mzmine.datamodel.features.types.numbers;
 
+import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.datamodel.features.types.DataType;
 import io.github.mzmine.datamodel.features.types.modifiers.NullColumnType;
-import io.github.mzmine.datamodel.features.types.numbers.abstr.IntegerType;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
 
-public class BestFragmentScanNumberType extends IntegerType implements NullColumnType {
+public class BestFragmentScanNumberType extends DataType<ObjectProperty<Scan>> implements
+    NullColumnType {
 
   @Override
   public String getHeaderString() {
-    return "Best Fragment Scan #";
+    return "Best fragment scan";
+  }
+
+  @Override
+  public ObjectProperty<Scan> createProperty() {
+    return new SimpleObjectProperty<>();
   }
 
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/BestScanNumberType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/BestScanNumberType.java
@@ -18,14 +18,22 @@
 
 package io.github.mzmine.datamodel.features.types.numbers;
 
+import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.datamodel.features.types.DataType;
 import io.github.mzmine.datamodel.features.types.modifiers.NullColumnType;
-import io.github.mzmine.datamodel.features.types.numbers.abstr.IntegerType;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
 
-public class BestScanNumberType extends IntegerType implements NullColumnType {
+public class BestScanNumberType extends DataType<ObjectProperty<Scan>> implements NullColumnType {
 
   @Override
   public String getHeaderString() {
-    return "Best Scan #";
+    return "Best scan";
+  }
+
+  @Override
+  public ObjectProperty<Scan> createProperty() {
+    return new SimpleObjectProperty<Scan>();
   }
 
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/ScanNumbersType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/ScanNumbersType.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.datamodel.features.types.numbers;
 
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.datamodel.features.types.exceptions.UndefinedRowBindingException;
@@ -35,7 +36,7 @@ import javafx.collections.FXCollections;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public class ScanNumbersType extends ListDataType<Integer> implements BindingsFactoryType {
+public class ScanNumbersType extends ListDataType<Scan> implements BindingsFactoryType {
 
   @Override
   public String getHeaderString() {
@@ -45,7 +46,7 @@ public class ScanNumbersType extends ListDataType<Integer> implements BindingsFa
 
   @Nonnull
   @Override
-  public String getFormattedString(@Nonnull ListProperty<Integer> property) {
+  public String getFormattedString(@Nonnull ListProperty<Scan> property) {
     return property.getValue() != null ? String.valueOf(property.getValue().size()) : "";
   }
 

--- a/src/main/java/io/github/mzmine/datamodel/impl/MZmineToMSDKRawDataFile.java
+++ b/src/main/java/io/github/mzmine/datamodel/impl/MZmineToMSDKRawDataFile.java
@@ -18,17 +18,17 @@
 
 package io.github.mzmine.datamodel.impl;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-
 import io.github.msdk.datamodel.Chromatogram;
 import io.github.msdk.datamodel.FileType;
 import io.github.msdk.datamodel.MsScan;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.Scan;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import javafx.collections.ObservableList;
 
 /**
  * Simple implementation of the Scan interface.
@@ -45,13 +45,11 @@ public class MZmineToMSDKRawDataFile implements io.github.msdk.datamodel.RawData
   public MZmineToMSDKRawDataFile(RawDataFile mzmineRawdataFile) {
     this.mzmineRawdataFile = mzmineRawdataFile;
 
-    int scanNumbers[] = mzmineRawdataFile.getScanNumbers();
-    for (int scanNum : scanNumbers) {
-      Scan mzmineScan = mzmineRawdataFile.getScan(scanNum);
+    ObservableList<Scan> scanNumbers = mzmineRawdataFile.getScans();
+    for (Scan mzmineScan : scanNumbers) {
       MsScan msdkScan = new MZmineToMSDKMsScan(mzmineScan);
       scans.add(msdkScan);
     }
-
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/datamodel/impl/MobilityDataPoint.java
+++ b/src/main/java/io/github/mzmine/datamodel/impl/MobilityDataPoint.java
@@ -19,15 +19,16 @@
 package io.github.mzmine.datamodel.impl;
 
 import io.github.mzmine.datamodel.DataPoint;
+import io.github.mzmine.datamodel.Scan;
 
 public class MobilityDataPoint implements DataPoint {
 
   private final double mz;
   private final double intensity;
   private final double mobility;
-  private final int scanNum;
+  private final Scan scanNum;
 
-  public MobilityDataPoint(double mz, double intensity, double mobility, int scanNum) {
+  public MobilityDataPoint(double mz, double intensity, double mobility, Scan scanNum) {
     this.mz = mz;
     this.intensity = intensity;
     this.mobility = mobility;
@@ -48,7 +49,7 @@ public class MobilityDataPoint implements DataPoint {
     return intensity;
   }
 
-  public int getScanNum() {
+  public Scan getScanNum() {
     return scanNum;
   }
 }

--- a/src/main/java/io/github/mzmine/datamodel/impl/MobilityDataPoint.java
+++ b/src/main/java/io/github/mzmine/datamodel/impl/MobilityDataPoint.java
@@ -26,9 +26,9 @@ public class MobilityDataPoint implements DataPoint {
   private final double mz;
   private final double intensity;
   private final double mobility;
-  private final Scan scanNum;
+  private final int scanNum;
 
-  public MobilityDataPoint(double mz, double intensity, double mobility, Scan scanNum) {
+  public MobilityDataPoint(double mz, double intensity, double mobility, int scanNum) {
     this.mz = mz;
     this.intensity = intensity;
     this.mobility = mobility;
@@ -49,7 +49,7 @@ public class MobilityDataPoint implements DataPoint {
     return intensity;
   }
 
-  public Scan getScanNum() {
+  public int getScanNum() {
     return scanNum;
   }
 }

--- a/src/main/java/io/github/mzmine/datamodel/impl/SimpleMobilogram.java
+++ b/src/main/java/io/github/mzmine/datamodel/impl/SimpleMobilogram.java
@@ -21,6 +21,7 @@ package io.github.mzmine.datamodel.impl;
 import com.google.common.collect.Range;
 import com.google.common.math.Quantiles;
 import io.github.mzmine.datamodel.IMSRawDataFile;
+import io.github.mzmine.datamodel.MobilityScan;
 import io.github.mzmine.datamodel.MobilityType;
 import io.github.mzmine.datamodel.Mobilogram;
 import io.github.mzmine.datamodel.Scan;
@@ -45,7 +46,7 @@ public class SimpleMobilogram implements Mobilogram {
   private static NumberFormat mobilityFormat = MZmineCore.getConfiguration().getMobilityFormat();
   private static NumberFormat mzFormat = MZmineCore.getConfiguration().getMZFormat();
   private final IMSRawDataFile rawDataFile;
-  private final SortedMap<Scan, MobilityDataPoint> dataPoints;
+  private final SortedMap<Integer, MobilityDataPoint> dataPoints;
   private final MobilityType mt;
   private double mobility;
   private double mz;
@@ -140,7 +141,7 @@ public class SimpleMobilogram implements Mobilogram {
 
   @Nonnull
   @Override
-  public List<Scan> getMobilityScanNumbers() {
+  public List<Integer> getMobilityScanNumbers() {
     return new ArrayList<>(dataPoints.keySet());
   }
 

--- a/src/main/java/io/github/mzmine/datamodel/impl/SimpleMobilogram.java
+++ b/src/main/java/io/github/mzmine/datamodel/impl/SimpleMobilogram.java
@@ -23,6 +23,7 @@ import com.google.common.math.Quantiles;
 import io.github.mzmine.datamodel.IMSRawDataFile;
 import io.github.mzmine.datamodel.MobilityType;
 import io.github.mzmine.datamodel.Mobilogram;
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.main.MZmineCore;
 import java.text.NumberFormat;
 import java.util.ArrayList;
@@ -44,7 +45,7 @@ public class SimpleMobilogram implements Mobilogram {
   private static NumberFormat mobilityFormat = MZmineCore.getConfiguration().getMobilityFormat();
   private static NumberFormat mzFormat = MZmineCore.getConfiguration().getMZFormat();
   private final IMSRawDataFile rawDataFile;
-  private final SortedMap<Integer, MobilityDataPoint> dataPoints;
+  private final SortedMap<Scan, MobilityDataPoint> dataPoints;
   private final MobilityType mt;
   private double mobility;
   private double mz;
@@ -139,7 +140,7 @@ public class SimpleMobilogram implements Mobilogram {
 
   @Nonnull
   @Override
-  public List<Integer> getMobilityScanNumbers() {
+  public List<Scan> getMobilityScanNumbers() {
     return new ArrayList<>(dataPoints.keySet());
   }
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/adap_hierarchicalclustering/ADAP3DecompositionV1_5Task.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/adap_hierarchicalclustering/ADAP3DecompositionV1_5Task.java
@@ -15,6 +15,7 @@
  */
 package io.github.mzmine.modules.dataprocessing.adap_hierarchicalclustering;
 
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
@@ -34,6 +35,7 @@ import java.util.NavigableMap;
 import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javafx.collections.ObservableList;
 import javax.annotation.Nonnull;
 import dulab.adap.common.algorithms.FeatureTools;
 import dulab.adap.datamodel.Component;
@@ -261,14 +263,14 @@ public class ADAP3DecompositionV1_5Task extends AbstractTask {
 
     for (FeatureListRow row : peakList.getRows()) {
       Feature peak = row.getBestFeature();
-      int[] scanNumbers = peak.getScanNumbers().stream().mapToInt(i -> i).toArray();
+      ObservableList<Scan> scanNumbers = peak.getScanNumbers();
 
       // Build chromatogram
       NavigableMap<Double, Double> chromatogram = new TreeMap<>();
-      for (int scanNumber : scanNumbers) {
-        DataPoint dataPoint = peak.getDataPoint(scanNumber);
+      for (int i=0; i< scanNumbers.size(); i++) {
+        DataPoint dataPoint = peak.getDataPointAtIndex(i);
         if (dataPoint != null)
-          chromatogram.put((double) dataFile.getScan(scanNumber).getRetentionTime(),
+          chromatogram.put(Double.valueOf(String.valueOf(peak.getRetentionTimeAtIndex(i))),
               dataPoint.getIntensity());
       }
 
@@ -285,17 +287,17 @@ public class ADAP3DecompositionV1_5Task extends AbstractTask {
         info.peakID = row.getID() - 1;
 
         double height = -Double.MIN_VALUE;
-        for (int scan : scanNumbers) {
-          double intensity = peak.getDataPoint(scan).getIntensity();
+        for (int i=0; i<scanNumbers.size(); i++) {
+          double intensity = peak.getDataPointAtIndex(i).getIntensity();
 
           if (intensity > height) {
             height = intensity;
-            info.peakIndex = scan;
+            info.peakIndex = scanNumbers.get(i).getScanNumber();
           }
         }
 
-        info.leftApexIndex = scanNumbers[0];
-        info.rightApexIndex = scanNumbers[scanNumbers.length - 1];
+        info.leftApexIndex = scanNumbers.get(0).getScanNumber();
+        info.rightApexIndex = scanNumbers.get(scanNumbers.size() - 1).getScanNumber();
         info.retTime = peak.getRT();
         info.mzValue = peak.getMZ();
         info.intensity = peak.getHeight();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/adap_mcr/ADAP3DecompositionV2Task.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/adap_mcr/ADAP3DecompositionV2Task.java
@@ -15,6 +15,7 @@
  */
 package io.github.mzmine.modules.dataprocessing.adap_mcr;
 
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
@@ -253,11 +254,11 @@ public class ADAP3DecompositionV2Task extends AbstractTask {
     Chromatogram chromatogram = peak.chromatogram;
 
     // Retrieve scan numbers
-    int representativeScan = 0;
-    int[] scanNumbers = new int[chromatogram.length];
+    Scan representativeScan = null;
+    Scan[] scanNumbers = new Scan[chromatogram.length];
     int count = 0;
-    for (int num : file.getScanNumbers()) {
-      double retTime = file.getScan(num).getRetentionTime();
+    for (Scan num : file.getScans()) {
+      double retTime = num.getRetentionTime();
       Double intensity = chromatogram.getIntensity(retTime, false);
       if (intensity != null)
         scanNumbers[count++] = num;
@@ -281,7 +282,7 @@ public class ADAP3DecompositionV2Task extends AbstractTask {
 
     ModularFeature newFeature = new ModularFeature(newPeakList, file, peak.getMZ(), (float) peak.getRetTime(),
         (float) peak.getIntensity(), (float) area, scanNumbers, dataPoints, FeatureStatus.MANUAL,
-        representativeScan, representativeScan, new int[] {}, Range.closed((float) peak.getFirstRetTime(),
+        representativeScan, representativeScan, new Scan[] {}, Range.closed((float) peak.getFirstRetTime(),
         (float) peak.getLastRetTime()), Range.closed(peak.getMZ() - 0.01, peak.getMZ() + 0.01),
         Range.closed(0f, (float) peak.getIntensity()));
     return newFeature;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/adap_mcr/ADAP3DecompositionV2Utils.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/adap_mcr/ADAP3DecompositionV2Utils.java
@@ -8,6 +8,7 @@ import io.github.mzmine.datamodel.*;
 import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
+import javafx.collections.ObservableList;
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -22,11 +23,8 @@ import java.util.logging.Logger;
 public class ADAP3DecompositionV2Utils {
   private final Logger log;
 
-  private final Map<Integer, Float> retTimes;
-
   public ADAP3DecompositionV2Utils() {
     this.log = Logger.getLogger(ADAP3DecompositionV2Task.class.getName());
-    this.retTimes = new HashMap<>();
   }
 
   /**
@@ -43,15 +41,15 @@ public class ADAP3DecompositionV2Utils {
 
     for (FeatureListRow row : peakList.getRows()) {
       Feature peak = row.getBestFeature();
-      int[] scanNumbers = peak.getScanNumbers().stream().mapToInt(i -> i).toArray();
+      ObservableList<Scan> scanNumbers = peak.getScanNumbers();
 
       // Build chromatogram
-      double[] retTimes = new double[scanNumbers.length];
-      double[] intensities = new double[scanNumbers.length];
-      for (int i = 0; i < scanNumbers.length; ++i) {
-        int scan = scanNumbers[i];
-        retTimes[i] = getRetTime(dataFile, scan);
-        DataPoint dataPoint = peak.getDataPoint(scan);
+      double[] retTimes = new double[scanNumbers.size()];
+      double[] intensities = new double[scanNumbers.size()];
+      for (int i = 0; i < scanNumbers.size(); ++i) {
+        Scan scan = scanNumbers.get(i);
+        retTimes[i] = peak.getRetentionTimeAtIndex(i);
+        DataPoint dataPoint = peak.getDataPointAtIndex(i);
         if (dataPoint != null)
           intensities[i] = dataPoint.getIntensity();
       }
@@ -70,9 +68,9 @@ public class ADAP3DecompositionV2Utils {
         info.peakID = row.getID() - 1;
 
         double height = -Double.MIN_VALUE;
-        for (int scan : scanNumbers) {
-          DataPoint dataPoint = peak.getDataPoint(scan);
 
+        for (int i = 0; i < scanNumbers.size(); i++) {
+          DataPoint dataPoint = peak.getDataPointAtIndex(i);
           if (dataPoint == null)
             continue;
 
@@ -80,12 +78,12 @@ public class ADAP3DecompositionV2Utils {
 
           if (intensity > height) {
             height = intensity;
-            info.peakIndex = scan;
+            info.peakIndex = scanNumbers.get(i).getScanNumber();
           }
         }
 
-        info.leftApexIndex = scanNumbers[0];
-        info.rightApexIndex = scanNumbers[scanNumbers.length - 1];
+        info.leftApexIndex = scanNumbers.get(0).getScanNumber();
+        info.rightApexIndex = scanNumbers.get(scanNumbers.size() - 1).getScanNumber();
         info.retTime = peak.getRT();
         info.mzValue = peak.getMZ();
         info.intensity = peak.getHeight();
@@ -105,12 +103,4 @@ public class ADAP3DecompositionV2Utils {
     return peaks;
   }
 
-  private double getRetTime(RawDataFile dataFile, int scan) {
-    Float retTime = retTimes.get(scan);
-    if (retTime == null) {
-      retTime = dataFile.getScan(scan).getRetentionTime();
-      retTimes.put(scan, retTime);
-    }
-    return retTime;
-  }
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_adap3/ADAP3AlignerTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_adap3/ADAP3AlignerTask.java
@@ -17,6 +17,7 @@
  */
 package io.github.mzmine.modules.dataprocessing.align_adap3;
 
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
@@ -252,14 +253,12 @@ public class ADAP3AlignerTask extends AbstractTask {
 
     // Read Chromatogram
     final Feature peak = row.getBestFeature();
-    final RawDataFile dataFile = peak.getRawDataFile();
-
     NavigableMap<Double, Double> chromatogram = new TreeMap<>();
 
-    for (final int scan : peak.getScanNumbers()) {
-      final DataPoint dataPoint = peak.getDataPoint(scan);
+    for(int i=0; i<peak.getNumberOfDataPoints(); i++) {
+      final DataPoint dataPoint = peak.getDataPointAtIndex(i);
       if (dataPoint != null)
-        chromatogram.put((double) dataFile.getScan(scan).getRetentionTime(), dataPoint.getIntensity());
+        chromatogram.put(Double.valueOf(String.valueOf(peak.getRetentionTimeAtIndex(i))), dataPoint.getIntensity());
     }
 
     return new Component(null,

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_hierarchical/RowVsRowScoreGC.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_hierarchical/RowVsRowScoreGC.java
@@ -198,7 +198,7 @@ public class RowVsRowScoreGC implements Comparable<RowVsRowScoreGC> {
       // peakListRow.getRawDataFiles()[0], true);
       // }
 
-      Scan apexScan = refRDF.getScan(peakListRow.getBestFeature().getRepresentativeScanNumber());
+      Scan apexScan = refRDF.getScanAtNumber(peakListRow.getBestFeature().getRepresentativeScan().getScanNumber());
       //
       // Get scan m/z vector.
       // logger.info("DPs MZ Range: " + apexScan.getMZRange());
@@ -238,7 +238,7 @@ public class RowVsRowScoreGC implements Comparable<RowVsRowScoreGC> {
         // true);
         // }
 
-        apexScan = refRDF.getScan(alignedRow.getFeature(rdf).getRepresentativeScanNumber());
+        apexScan = alignedRow.getFeature(rdf).getRepresentativeScan();
         // if (useDetectedMzOnly &&
         // alignedRow.getBestPeak().getIsotopePattern() != null)
         // dataPoints =
@@ -264,12 +264,12 @@ public class RowVsRowScoreGC implements Comparable<RowVsRowScoreGC> {
       // refRDF = DataFileUtils.getAncestorDataFile(this.project,
       // peakListRow.getRawDataFiles()[0], true);
       // }
-      Scan apexScan = refRDF.getScan(peakListRow.getBestFeature().getRepresentativeScanNumber());
+      Scan apexScan = refRDF.getScanAtNumber(peakListRow.getBestFeature().getRepresentativeScan().getScanNumber());
       //
       // vec1
       // Scan numbers to be averaged
       int apexScanNumber = apexScan.getScanNumber();
-      int[] peakScanNumbers = peakListRow.getBestFeature().getScanNumbers().stream().mapToInt(i -> i).toArray();
+      int[] peakScanNumbers = peakListRow.getBestFeature().getScanNumbers().stream().mapToInt(s -> s.getScanNumber()).toArray();
       int nbSideScans = (int) Math.round(peakScanNumbers.length * 5.0 / 100.0);
       int firstScanNum = Math.max(apexScanNumber - nbSideScans, peakScanNumbers[0]);
       int lastScanNum =
@@ -278,7 +278,7 @@ public class RowVsRowScoreGC implements Comparable<RowVsRowScoreGC> {
       //
       // Compute average
       for (int i = firstScanNum; i < lastScanNum; ++i) {
-        Scan curScan = refRDF.getScan(i);
+        Scan curScan = refRDF.getScanAtNumber(i);
         DataPoint[] dataPoints = curScan.getDataPoints();
         for (int j = 0; j < dataPoints.length; ++j) {
           DataPoint dp = dataPoints[j];
@@ -297,10 +297,10 @@ public class RowVsRowScoreGC implements Comparable<RowVsRowScoreGC> {
       // refRDF = DataFileUtils.getAncestorDataFile(this.project,
       // alignedRow.getRawDataFiles()[0], true);
       // }
-      apexScan = refRDF.getScan(alignedRow.getBestFeature().getRepresentativeScanNumber());
+      apexScan = refRDF.getScanAtNumber(alignedRow.getBestFeature().getRepresentativeScan().getScanNumber());
       // Scan numbers to be averaged
       apexScanNumber = apexScan.getScanNumber();
-      peakScanNumbers = alignedRow.getBestFeature().getScanNumbers().stream().mapToInt(i -> i).toArray();
+      peakScanNumbers = alignedRow.getBestFeature().getScanNumbers().stream().mapToInt(s -> s.getScanNumber()).toArray();
       firstScanNum = Math.max(apexScanNumber - nbSideScans, peakScanNumbers[0]);
       lastScanNum =
           Math.min(apexScanNumber + nbSideScans, peakScanNumbers[peakScanNumbers.length - 1]);
@@ -308,7 +308,7 @@ public class RowVsRowScoreGC implements Comparable<RowVsRowScoreGC> {
       //
       // Compute average
       for (int i = firstScanNum; i < lastScanNum; ++i) {
-        Scan curScan = refRDF.getScan(i);
+        Scan curScan = refRDF.getScanAtNumber(i);
         DataPoint[] dataPoints = curScan.getDataPoints();
         for (int j = 0; j < dataPoints.length; ++j) {
           DataPoint dp = dataPoints[j];

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_ransac/RansacAlignerTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_ransac/RansacAlignerTask.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Range;
 import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
@@ -186,9 +187,9 @@ class RansacAlignerTask extends AbstractTask {
 
       SortedMap<Double, Double> chromatogram = new TreeMap<>();
 
-      for (int scan : feature.getScanNumbers()) {
-        DataPoint dataPoint = feature.getDataPoint(scan);
-        double retTime = dataFile.getScan(scan).getRetentionTime() + retTimeDelta;
+      for (int i=0; i < feature.getNumberOfDataPoints(); i++) {
+        DataPoint dataPoint = feature.getDataPointAtIndex(i);
+        double retTime = feature.getRetentionTimeAtIndex(i) + retTimeDelta;
         if (dataPoint != null)
           chromatogram.put(retTime, dataPoint.getIntensity());
       }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ADAPChromatogram.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ADAPChromatogram.java
@@ -101,6 +101,7 @@ public class ADAPChromatogram {
 
   private double highPointMZ = 0;
 
+  // full stack of scans
   private final Scan scanNumbers[];
 
   public int tmp_see_same_scan_count = 0;
@@ -218,6 +219,8 @@ public class ADAPChromatogram {
       tmp_see_same_scan_count += 1;
       return;
     }
+    if(mzValue==null)
+      return;
 
     dataPointsMap.put(scanNumber, mzValue);
     lastMzFeature = mzValue;
@@ -313,7 +316,7 @@ public class ADAPChromatogram {
   }
 
   public @Nonnull Scan[] getScanNumbers() {
-    return scanNumbers;
+    return dataPointsMap.keySet().toArray(Scan[]::new);
   }
 
   public @Nonnull RawDataFile getDataFile() {

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ADAPChromatogram.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ADAPChromatogram.java
@@ -34,6 +34,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.TreeMap;
 import java.util.Vector;
 import javax.annotation.Nonnull;
 import com.google.common.collect.Range;
@@ -58,7 +59,7 @@ public class ADAPChromatogram {
 
   // Data points of the chromatogram (map of scan number -> m/z feature)
   // private Hashtable<Integer, DataPoint> dataPointsMap;
-  private HashMap<Scan, DataPoint> dataPointsMap;
+  private TreeMap<Scan, DataPoint> dataPointsMap;
 
   // Chromatogram m/z, RT, height, area. The mz value will be the highest points mz value
   private double mz, rt, height, area, weightedMz;
@@ -118,7 +119,7 @@ public class ADAPChromatogram {
 
     rawDataPointsRTRange = dataFile.getDataRTRange(1);
 
-    dataPointsMap = new HashMap<Scan, DataPoint>();
+    dataPointsMap = new TreeMap<Scan, DataPoint>();
     buildingSegment = new Vector<Scan>();
     chromScanList = new ArrayList<Scan>();
   }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ADAPHighestDataPointConnector.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ADAPHighestDataPointConnector.java
@@ -20,6 +20,7 @@
 
 package io.github.mzmine.modules.dataprocessing.featdet_adapchromatogrambuilder;
 
+import io.github.mzmine.datamodel.Scan;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -39,12 +40,12 @@ public class ADAPHighestDataPointConnector {
   private final MZTolerance mzTolerance;
   private final double minimumTimeSpan, minimumHeight;
   private final RawDataFile dataFile;
-  private final int allScanNumbers[];
+  private final Scan allScanNumbers[];
 
   // Mapping of last data point m/z --> chromatogram
   private Set<ADAPChromatogram> buildingChromatograms;
 
-  public ADAPHighestDataPointConnector(RawDataFile dataFile, int allScanNumbers[],
+  public ADAPHighestDataPointConnector(RawDataFile dataFile, Scan allScanNumbers[],
       double minimumTimeSpan, double minimumHeight, MZTolerance mzTolerance) {
 
     this.mzTolerance = mzTolerance;
@@ -60,7 +61,7 @@ public class ADAPHighestDataPointConnector {
 
   }
 
-  public void addScan(int scanNumber, DataPoint mzValues[]) {
+  public void addScan(Scan scanNumber, DataPoint mzValues[]) {
 
     // Sort m/z features by descending intensity
     Arrays.sort(mzValues,

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ExpandedDataPoint.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ExpandedDataPoint.java
@@ -26,6 +26,7 @@
 package io.github.mzmine.modules.dataprocessing.featdet_adapchromatogrambuilder;
 
 import io.github.mzmine.datamodel.DataPoint;
+import io.github.mzmine.datamodel.Scan;
 
 
 /**
@@ -33,14 +34,14 @@ import io.github.mzmine.datamodel.DataPoint;
  */
 public class ExpandedDataPoint implements DataPoint {
 
-  private int scanNumber = -1;
+  private Scan scan = null;
   private double mz, intensity;
 
   /**
    */
-  public ExpandedDataPoint(double mz, double intensity, int scanNumber) {
+  public ExpandedDataPoint(double mz, double intensity, Scan scan) {
 
-    this.scanNumber = scanNumber;
+    this.scan = scan;
     this.mz = mz;
     this.intensity = intensity;
 
@@ -57,16 +58,16 @@ public class ExpandedDataPoint implements DataPoint {
   /**
    * Constructor which copies the data from another DataPoint and takes the scan number
    */
-  public ExpandedDataPoint(DataPoint dp, int scanNumIn) {
+  public ExpandedDataPoint(DataPoint dp, Scan scanNumIn) {
     this.mz = dp.getMZ();
     this.intensity = dp.getIntensity();
-    this.scanNumber = scanNumIn;
+    this.scan = scanNumIn;
   }
 
   public ExpandedDataPoint() {
     this.mz = 0.0;
     this.intensity = 0.0;
-    this.scanNumber = -1;
+    this.scan = null;
   }
 
   @Override
@@ -79,10 +80,7 @@ public class ExpandedDataPoint implements DataPoint {
     return mz;
   }
 
-  public int getScanNumber() {
-    return scanNumber;
+  public Scan getScan() {
+    return scan;
   }
-
-
-
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ModularADAPChromatogramBuilderTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ModularADAPChromatogramBuilderTask.java
@@ -146,8 +146,6 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
     logger.info("Started chromatogram builder on " + dataFile);
 
     scans = scanSelection.getMatchingScans(dataFile);
-    int allScanNumbers[] = scanSelection.getMatchingScanNumbers(dataFile);
-
     List<Float> rtListForChromCDF = new ArrayList<Float>();
 
     // Check if the scans are properly ordered by RT
@@ -220,7 +218,7 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
       }
 
       for (DataPoint mzFeature : mzValues) {
-        ExpandedDataPoint curDatP = new ExpandedDataPoint(mzFeature, scan.getScanNumber());
+        ExpandedDataPoint curDatP = new ExpandedDataPoint(mzFeature, scan);
         allMzValues.add(curDatP);
         // corespondingScanNum.add(scan.getScanNumber());
       }
@@ -311,9 +309,9 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
 
         if (toBeLowerBound < toBeUpperBound) {
           Range<Double> newRange = Range.open(toBeLowerBound, toBeUpperBound);
-          ADAPChromatogram newChrom = new ADAPChromatogram(dataFile, allScanNumbers);
+          ADAPChromatogram newChrom = new ADAPChromatogram(dataFile, scans);
 
-          newChrom.addMzFeature(mzFeature.getScanNumber(), mzFeature);
+          newChrom.addMzFeature(mzFeature.getScan(), mzFeature);
 
           newChrom.setHighPointMZ(mzFeature.getMZ());
 
@@ -324,7 +322,7 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
           rangeSet.add(newRange);
         } else if (toBeLowerBound.equals(toBeUpperBound) && plusRange != null) {
           ADAPChromatogram curChrom = rangeToChromMap.get(plusRange);
-          curChrom.addMzFeature(mzFeature.getScanNumber(), mzFeature);
+          curChrom.addMzFeature(mzFeature.getScan(), mzFeature);
         } else
           throw new IllegalStateException(String.format("Incorrect range [%f, %f] for m/z %f",
               toBeLowerBound, toBeUpperBound, mzFeature.getMZ()));
@@ -334,7 +332,7 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
 
         ADAPChromatogram curChrom = rangeToChromMap.get(containsPointRange);
 
-        curChrom.addMzFeature(mzFeature.getScanNumber(), mzFeature);
+        curChrom.addMzFeature(mzFeature.getScan(), mzFeature);
 
         // update the entry in the map
         rangeToChromMap.put(containsPointRange, curChrom);

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogrambuilder/ChromatogramBuilderTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogrambuilder/ChromatogramBuilderTask.java
@@ -114,7 +114,6 @@ public class ChromatogramBuilderTask extends AbstractTask {
     logger.info("Started chromatogram builder on " + dataFile);
 
     scans = scanSelection.getMatchingScans(dataFile);
-    int allScanNumbers[] = scanSelection.getMatchingScanNumbers(dataFile);
     totalScans = scans.length;
 
     // Check if the scans are properly ordered by RT
@@ -137,7 +136,7 @@ public class ChromatogramBuilderTask extends AbstractTask {
 
     Chromatogram[] chromatograms;
     HighestDataPointConnector massConnector = new HighestDataPointConnector(dataFile,
-        allScanNumbers, minimumTimeSpan, minimumHeight, mzTolerance);
+        scans, minimumTimeSpan, minimumHeight, mzTolerance);
 
     for (Scan scan : scans) {
 
@@ -161,7 +160,7 @@ public class ChromatogramBuilderTask extends AbstractTask {
         return;
       }
 
-      massConnector.addScan(scan.getScanNumber(), mzValues);
+      massConnector.addScan(scan, mzValues);
       processedScans++;
     }
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogrambuilder/HighestDataPointConnector.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogrambuilder/HighestDataPointConnector.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.modules.dataprocessing.featdet_chromatogrambuilder;
 
+import io.github.mzmine.datamodel.Scan;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -37,12 +38,12 @@ public class HighestDataPointConnector {
   private final MZTolerance mzTolerance;
   private final double minimumTimeSpan, minimumHeight;
   private final RawDataFile dataFile;
-  private final int allScanNumbers[];
+  private final Scan allScanNumbers[];
 
   // Mapping of last data point m/z --> chromatogram
   private Set<Chromatogram> buildingChromatograms;
 
-  public HighestDataPointConnector(RawDataFile dataFile, int allScanNumbers[],
+  public HighestDataPointConnector(RawDataFile dataFile, Scan allScanNumbers[],
       double minimumTimeSpan, double minimumHeight, MZTolerance mzTolerance) {
 
     this.mzTolerance = mzTolerance;
@@ -58,7 +59,7 @@ public class HighestDataPointConnector {
 
   }
 
-  public void addScan(int scanNumber, DataPoint mzValues[]) {
+  public void addScan(Scan scanNumber, DataPoint mzValues[]) {
 
     // Sort m/z peaks by descending intensity
     Arrays.sort(mzValues,

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/ADAPpeakpicking/ADAPDetector.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/ADAPpeakpicking/ADAPDetector.java
@@ -31,12 +31,14 @@ import static io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconv
 import static io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.ADAPpeakpicking.WaveletCoefficientsSNParameters.ABS_WAV_COEFFS;
 import static io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.ADAPpeakpicking.WaveletCoefficientsSNParameters.HALF_WAVELET_WINDOW;
 
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.impl.SimpleFeatureInformation;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
+import javafx.collections.ObservableList;
 import javax.annotation.Nonnull;
 import com.google.common.collect.Range;
 import dulab.adap.datamodel.PeakInfo;
@@ -105,15 +107,15 @@ public class ADAPDetector implements PeakResolver {
       RSessionWrapper rSession, CenterFunction mzCenterFunction, double msmsRange,
       float rTRangeMSMS) throws RSessionWrapperException {
 
-    int scanNumbers[] = chromatogram.getScanNumbers().stream().mapToInt(i -> i).toArray();
-    final int scanCount = scanNumbers.length;
+    ObservableList<Scan> scanNumbers = chromatogram.getScanNumbers();
+    final int scanCount = scanNumbers.size();
     double retentionTimes[] = new double[scanCount];
     double intensities[] = new double[scanCount];
     RawDataFile dataFile = chromatogram.getRawDataFile();
     for (int i = 0; i < scanCount; i++) {
-      final int scanNum = scanNumbers[i];
-      retentionTimes[i] = dataFile.getScan(scanNum).getRetentionTime();
-      DataPoint dp = chromatogram.getDataPoint(scanNum);
+      final Scan scanNum = scanNumbers.get(i);
+      retentionTimes[i] = scanNum.getRetentionTime();
+      DataPoint dp = chromatogram.getDataPointAtIndex(i);
       if (dp != null)
         intensities[i] = dp.getIntensity();
       else

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/ChromatogramTICDataSet.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/ChromatogramTICDataSet.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution;
 
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
 import org.jfree.data.xy.AbstractXYDataset;
 
@@ -32,12 +33,12 @@ public class ChromatogramTICDataSet extends AbstractXYDataset {
   private static final long serialVersionUID = 1L;
   private Feature chromatogram;
   private RawDataFile dataFile;
-  private int scanNumbers[];
+  private Scan scanNumbers[];
 
   public ChromatogramTICDataSet(Feature chromatogram) {
     this.chromatogram = chromatogram;
     this.dataFile = chromatogram.getRawDataFile();
-    this.scanNumbers = chromatogram.getScanNumbers().stream().mapToInt(i -> i).toArray();
+    this.scanNumbers = chromatogram.getScanNumbers().toArray(Scan[]::new);
   }
 
   public Comparable<?> getSeriesKey(int series) {
@@ -49,11 +50,11 @@ public class ChromatogramTICDataSet extends AbstractXYDataset {
   }
 
   public Number getX(int series, int index) {
-    return dataFile.getScan(scanNumbers[index]).getRetentionTime();
+    return scanNumbers[index].getRetentionTime();
   }
 
   public Number getY(int series, int index) {
-    DataPoint mzPeak = chromatogram.getDataPoint(scanNumbers[index]);
+    DataPoint mzPeak = chromatogram.getDataPointAtIndex(index);
     if (mzPeak == null)
       return 0;
     return mzPeak.getIntensity();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/baseline/BaselinePeakDetector.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/baseline/BaselinePeakDetector.java
@@ -22,9 +22,11 @@ import static io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconv
 import static io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.baseline.BaselinePeakDetectorParameters.MIN_PEAK_HEIGHT;
 import static io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.baseline.BaselinePeakDetectorParameters.PEAK_DURATION;
 
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
 import java.util.ArrayList;
 import java.util.List;
+import javafx.collections.ObservableList;
 import javax.annotation.Nonnull;
 import com.google.common.collect.Range;
 
@@ -53,15 +55,15 @@ public class BaselinePeakDetector implements PeakResolver {
       RSessionWrapper rSession, CenterFunction mzCenterFunction, double msmsRange,
       float rTRangeMSMS) {
 
-    int scanNumbers[] = chromatogram.getScanNumbers().stream().mapToInt(i -> i).toArray();
-    final int scanCount = scanNumbers.length;
+    ObservableList<Scan> scanNumbers = chromatogram.getScanNumbers();
+    final int scanCount = scanNumbers.size();
     double retentionTimes[] = new double[scanCount];
     double intensities[] = new double[scanCount];
     RawDataFile dataFile = chromatogram.getRawDataFile();
     for (int i = 0; i < scanCount; i++) {
-      final int scanNum = scanNumbers[i];
-      retentionTimes[i] = dataFile.getScan(scanNum).getRetentionTime();
-      DataPoint dp = chromatogram.getDataPoint(scanNum);
+      final Scan scanNum = scanNumbers.get(i);
+      retentionTimes[i] = scanNum.getRetentionTime();
+      DataPoint dp = chromatogram.getDataPointAtIndex(i);
       if (dp != null)
         intensities[i] = dp.getIntensity();
       else
@@ -80,7 +82,7 @@ public class BaselinePeakDetector implements PeakResolver {
     for (int currentRegionStart = 0; currentRegionStart < scanCount; currentRegionStart++) {
 
       // Find a start of the region.
-      final DataPoint startPeak = chromatogram.getDataPoint(scanNumbers[currentRegionStart]);
+      final DataPoint startPeak = chromatogram.getDataPointAtIndex(currentRegionStart);
       if (startPeak != null && startPeak.getIntensity() >= baselineLevel) {
 
         double currentRegionHeight = startPeak.getIntensity();
@@ -90,7 +92,7 @@ public class BaselinePeakDetector implements PeakResolver {
         for (currentRegionEnd =
             currentRegionStart + 1; currentRegionEnd < scanCount; currentRegionEnd++) {
 
-          final DataPoint endPeak = chromatogram.getDataPoint(scanNumbers[currentRegionEnd]);
+          final DataPoint endPeak = chromatogram.getDataPointAtIndex(currentRegionEnd);
           if (endPeak == null || endPeak.getIntensity() < baselineLevel) {
 
             break;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/centwave/CentWaveDetector.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/centwave/CentWaveDetector.java
@@ -29,11 +29,13 @@ import static io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconv
 import static io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.centwave.CentWaveDetectorParameters.PEAK_SCALES;
 import static io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.centwave.CentWaveDetectorParameters.SN_THRESHOLD;
 
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
+import javafx.collections.ObservableList;
 import javax.annotation.Nonnull;
 import com.google.common.collect.Range;
 
@@ -104,15 +106,15 @@ public class CentWaveDetector implements PeakResolver {
       RSessionWrapper rSession, CenterFunction mzCenterFunction, double msmsRange,
       float rTRangeMSMS) throws RSessionWrapperException {
 
-    int scanNumbers[] = chromatogram.getScanNumbers().stream().mapToInt(i -> i).toArray();
-    final int scanCount = scanNumbers.length;
+    ObservableList<Scan> scanNumbers = chromatogram.getScanNumbers();
+    final int scanCount = scanNumbers.size();
     double retentionTimes[] = new double[scanCount];
     double intensities[] = new double[scanCount];
     RawDataFile dataFile = chromatogram.getRawDataFile();
     for (int i = 0; i < scanCount; i++) {
-      final int scanNum = scanNumbers[i];
-      retentionTimes[i] = dataFile.getScan(scanNum).getRetentionTime();
-      DataPoint dp = chromatogram.getDataPoint(scanNum);
+      final Scan scanNum = scanNumbers.get(i);
+      retentionTimes[i] = scanNum.getRetentionTime();
+      DataPoint dp = chromatogram.getDataPointAtIndex(i);
       if (dp != null)
         intensities[i] = dp.getIntensity();
       else
@@ -151,11 +153,11 @@ public class CentWaveDetector implements PeakResolver {
         // a peak for each.
         for (int start = peakLeft; start < peakRight; start++) {
 
-          if (chromatogram.getDataPoint(scanNumbers[start]) != null) {
+          if (chromatogram.getDataPointAtIndex(start) != null) {
 
             int end = start;
 
-            while (end < peakRight && chromatogram.getDataPoint(scanNumbers[end + 1]) != null) {
+            while (end < peakRight && chromatogram.getDataPointAtIndex(end + 1) != null) {
 
               end++;
             }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/minimumsearch/MinimumSearchPeakDetector.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/minimumsearch/MinimumSearchPeakDetector.java
@@ -25,9 +25,11 @@ import static io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconv
 import static io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.minimumsearch.MinimumSearchPeakDetectorParameters.PEAK_DURATION;
 import static io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.minimumsearch.MinimumSearchPeakDetectorParameters.SEARCH_RT_RANGE;
 
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
 import java.util.ArrayList;
 import java.util.List;
+import javafx.collections.ObservableList;
 import javax.annotation.Nonnull;
 import com.google.common.collect.Range;
 
@@ -57,15 +59,14 @@ public class MinimumSearchPeakDetector implements PeakResolver {
   public ResolvedPeak[] resolvePeaks(final Feature chromatogram, ParameterSet parameters,
       RSessionWrapper rSession, CenterFunction mzCenterFunction, double msmsRange,
       float rTRangeMSMS) {
-    int scanNumbers[] = chromatogram.getScanNumbers().stream().mapToInt(i -> i).toArray();
-    final int scanCount = scanNumbers.length;
+    ObservableList<Scan> scanNumbers = chromatogram.getScanNumbers();
+    final int scanCount = scanNumbers.size();
     double retentionTimes[] = new double[scanCount];
     double intensities[] = new double[scanCount];
-    RawDataFile dataFile = chromatogram.getRawDataFile();
     for (int i = 0; i < scanCount; i++) {
-      final int scanNum = scanNumbers[i];
-      retentionTimes[i] = dataFile.getScan(scanNum).getRetentionTime();
-      DataPoint dp = chromatogram.getDataPoint(scanNum);
+      final Scan scanNum = scanNumbers.get(i);
+      retentionTimes[i] = scanNum.getRetentionTime();
+      DataPoint dp = chromatogram.getDataPointAtIndex(i);
       if (dp != null)
         intensities[i] = dp.getIntensity();
       else

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/noiseamplitude/NoiseAmplitudePeakDetector.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/noiseamplitude/NoiseAmplitudePeakDetector.java
@@ -22,10 +22,12 @@ import static io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconv
 import static io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.noiseamplitude.NoiseAmplitudePeakDetectorParameters.NOISE_AMPLITUDE;
 import static io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.noiseamplitude.NoiseAmplitudePeakDetectorParameters.PEAK_DURATION;
 
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.TreeMap;
+import javafx.collections.ObservableList;
 import javax.annotation.Nonnull;
 import com.google.common.collect.Range;
 
@@ -57,15 +59,14 @@ public class NoiseAmplitudePeakDetector implements PeakResolver {
       RSessionWrapper rSession, CenterFunction mzCenterFunction, double msmsRange,
       float rTRangeMSMS) {
 
-    int scanNumbers[] = chromatogram.getScanNumbers().stream().mapToInt(i -> i).toArray();
-    final int scanCount = scanNumbers.length;
+    ObservableList<Scan> scanNumbers = chromatogram.getScanNumbers();
+    final int scanCount = scanNumbers.size();
     double retentionTimes[] = new double[scanCount];
     double intensities[] = new double[scanCount];
-    RawDataFile dataFile = chromatogram.getRawDataFile();
     for (int i = 0; i < scanCount; i++) {
-      final int scanNum = scanNumbers[i];
-      retentionTimes[i] = dataFile.getScan(scanNum).getRetentionTime();
-      DataPoint dp = chromatogram.getDataPoint(scanNum);
+      final Scan scanNum = scanNumbers.get(i);
+      retentionTimes[i] = scanNum.getRetentionTime();
+      DataPoint dp = chromatogram.getDataPointAtIndex(i);
       if (dp != null)
         intensities[i] = dp.getIntensity();
       else

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_ionmobilitytracebuilder/IonMobilityTraceBuilderTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_ionmobilitytracebuilder/IonMobilityTraceBuilderTask.java
@@ -153,7 +153,7 @@ public class IonMobilityTraceBuilderTask extends AbstractTask {
         } else {
           Arrays.stream(scan.getMassList(massList).getDataPoints()).forEach(
               dp -> allDataPoints.add(new RetentionTimeMobilityDataPoint(scan.getMobility(),
-                  dp.getMZ(), scan.getRetentionTime(), dp.getIntensity(), frame.getFrameId(),
+                  dp.getMZ(), scan.getRetentionTime(), dp.getIntensity(), frame,
                   scan.getMobilityScamNumber(), mobilityWidth, paintScaleParameter)));
         }
       }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_ionmobilitytracebuilder/RetentionTimeMobilityDataPoint.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_ionmobilitytracebuilder/RetentionTimeMobilityDataPoint.java
@@ -19,6 +19,7 @@
 package io.github.mzmine.modules.dataprocessing.featdet_ionmobilitytracebuilder;
 
 import io.github.mzmine.datamodel.DataPoint;
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.gui.chartbasics.chartutils.paintscales.PaintScale;
 
 public class RetentionTimeMobilityDataPoint implements DataPoint {
@@ -27,19 +28,19 @@ public class RetentionTimeMobilityDataPoint implements DataPoint {
   private final double mz;
   private final Float retentionTime;
   private final double intensity;
-  private final int frameNumber;
+  private final Scan frame;
   private final int scanNumber;
   private final double mobilityWidth;
   private final PaintScale paintScale;
 
   public RetentionTimeMobilityDataPoint(double mobility, double mz, Float retentionTime,
-      double intensity, int frameNumber, int scanNumber, double mobilityWidth,
+      double intensity, Scan frame, int scanNumber, double mobilityWidth,
       PaintScale paintScale) {
     this.mobility = mobility;
     this.mz = mz;
     this.retentionTime = retentionTime;
     this.intensity = intensity;
-    this.frameNumber = frameNumber;
+    this.frame = frame;
     this.scanNumber = scanNumber;
     this.mobilityWidth = mobilityWidth;
     this.paintScale = paintScale;
@@ -61,8 +62,8 @@ public class RetentionTimeMobilityDataPoint implements DataPoint {
     return intensity;
   }
 
-  public int getFrameNumber() {
-    return frameNumber;
+  public Scan getFrame() {
+    return frame;
   }
 
   public int getScanNumber() {

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_masscalibration/MassCalibrationTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_masscalibration/MassCalibrationTask.java
@@ -43,6 +43,7 @@ import io.github.mzmine.parameters.parametertypes.tolerances.RTTolerance;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskPriority;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import javafx.collections.ObservableList;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.jfree.data.xy.XYSeries;
 
@@ -71,7 +72,7 @@ public class MassCalibrationTask extends AbstractTask {
 
   // scan counter
   protected int processedScans = 0, totalScans;
-  protected int[] scanNumbers;
+  protected ObservableList<Scan> scanNumbers;
 
   // task timer
   protected Long startMillis;
@@ -208,13 +209,13 @@ public class MassCalibrationTask extends AbstractTask {
     }
 
 
-    scanNumbers = dataFile.getScanNumbers();
-    totalScans = scanNumbers.length;
+    scanNumbers = dataFile.getScans();
+    totalScans = scanNumbers.size();
 
     // Check if we have at least one scan with a mass list of given name
     boolean haveMassList = false;
     for (int i = 0; i < totalScans; i++) {
-      Scan scan = dataFile.getScan(scanNumbers[i]);
+      Scan scan = scanNumbers.get(i);
       MassList massList = scan.getMassList(massListName);
       if (massList != null) {
         haveMassList = true;
@@ -236,7 +237,7 @@ public class MassCalibrationTask extends AbstractTask {
         return;
       }
 
-      Scan scan = dataFile.getScan(scanNumbers[i]);
+      Scan scan = scanNumbers.get(i);
 
       MassList massList = scan.getMassList(massListName);
 
@@ -253,7 +254,7 @@ public class MassCalibrationTask extends AbstractTask {
        * scan.getRetentionTime(), massPeakMatches); errors.addAll(massListErrors);
        */
 
-      massCalibrator.addMassList(mzPeaks, scan.getRetentionTime(), scanNumbers[i],
+      massCalibrator.addMassList(mzPeaks, scan.getRetentionTime(), scanNumbers.get(i),
           intensityThreshold);
 
       processedScans++;
@@ -296,8 +297,7 @@ public class MassCalibrationTask extends AbstractTask {
         return;
       }
 
-      Scan scan = dataFile.getScan(scanNumbers[i]);
-
+      Scan scan = scanNumbers.get(i);
       MassList massList = scan.getMassList(massListName);
 
       // Skip those scans which do not have a mass list of given name

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_masscalibration/MassCalibrator.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_masscalibration/MassCalibrator.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.modules.dataprocessing.featdet_masscalibration;
 
+import io.github.mzmine.datamodel.Scan;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -125,7 +126,7 @@ public class MassCalibrator {
   }
 
   public ArrayList<MassPeakMatch> addMassList(DataPoint[] massList, float retentionTime) {
-    return addMassList(massList, retentionTime, -1, 0.0);
+    return addMassList(massList, retentionTime, null, 0.0);
   }
 
   /**
@@ -138,7 +139,7 @@ public class MassCalibrator {
    * @return
    */
   public ArrayList<MassPeakMatch> addMassList(DataPoint[] massList, float retentionTime,
-      int scanNumber, double intensityThreshold) {
+      Scan scanNumber, double intensityThreshold) {
     ArrayList<MassPeakMatch> matches =
         matchPeaksWithCalibrants(massList, retentionTime, scanNumber, intensityThreshold);
     massPeakMatches.addAll(matches);
@@ -396,7 +397,7 @@ public class MassCalibrator {
 
   protected ArrayList<MassPeakMatch> matchPeaksWithCalibrants(DataPoint[] massList,
       float retentionTime) {
-    return matchPeaksWithCalibrants(massList, retentionTime, -1, 0.0);
+    return matchPeaksWithCalibrants(massList, retentionTime, null, 0.0);
   }
 
   /**
@@ -411,7 +412,7 @@ public class MassCalibrator {
    * @return list of mass peak matches
    */
   protected ArrayList<MassPeakMatch> matchPeaksWithCalibrants(DataPoint[] massList,
-      float retentionTime, int scanNumber, double intensityThreshold) {
+      float retentionTime, Scan scanNumber, double intensityThreshold) {
     ArrayList<MassPeakMatch> matches = new ArrayList<>();
 
     StandardsList retentionTimeFiltered;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_masscalibration/MassPeakMatch.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_masscalibration/MassPeakMatch.java
@@ -19,6 +19,7 @@
 package io.github.mzmine.modules.dataprocessing.featdet_masscalibration;
 
 import io.github.mzmine.datamodel.DataPoint;
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.modules.dataprocessing.featdet_masscalibration.errormodeling.errortypes.ErrorType;
 import io.github.mzmine.modules.dataprocessing.featdet_masscalibration.standardslist.StandardsListItem;
 import java.util.Comparator;
@@ -40,7 +41,7 @@ public class MassPeakMatch {
 
   protected DataPoint measuredDataPoint;
   protected StandardsListItem matchedCalibrant;
-  protected int scanNumber;
+  protected Scan scan;
 
   public MassPeakMatch(double measuredMzRatio, double measuredRetentionTime, double matchedMzRatio,
       double matchedRetentionTime) {
@@ -65,17 +66,17 @@ public class MassPeakMatch {
 
   public MassPeakMatch(double measuredMzRatio, double measuredRetentionTime, double matchedMzRatio,
       double matchedRetentionTime, ErrorType mzErrorType, DataPoint measuredDataPoint,
-      int scanNumber) {
+      Scan scan) {
     this(measuredMzRatio, measuredRetentionTime, matchedMzRatio, matchedRetentionTime, mzErrorType,
         measuredDataPoint);
-    this.scanNumber = scanNumber;
+    this.scan = scan;
   }
 
   public MassPeakMatch(double measuredMzRatio, double measuredRetentionTime, double matchedMzRatio,
       double matchedRetentionTime, ErrorType mzErrorType, DataPoint measuredDataPoint,
-      int scanNumber, StandardsListItem matchedCalibrant) {
+      Scan scan, StandardsListItem matchedCalibrant) {
     this(measuredMzRatio, measuredRetentionTime, matchedMzRatio, matchedRetentionTime, mzErrorType,
-        measuredDataPoint, scanNumber);
+        measuredDataPoint, scan);
     this.matchedCalibrant = matchedCalibrant;
   }
 
@@ -118,7 +119,7 @@ public class MassPeakMatch {
     return matchedCalibrant;
   }
 
-  public int getScanNumber() {
-    return scanNumber;
+  public Scan getScan() {
+    return scan;
   }
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_masscalibration/charts/ChartUtils.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_masscalibration/charts/ChartUtils.java
@@ -84,7 +84,7 @@ public class ChartUtils {
             rtFormat.format(match.getMeasuredRetentionTime()),
             match.getMatchedRetentionTime() == -1 ? "none" : rtFormat.format(match.getMatchedRetentionTime()),
             ppmFormat.format(match.getMzError()), match.getMzErrorType(),
-            intensityFormat.format(match.getMeasuredDataPoint().getIntensity()), match.getScanNumber());
+            intensityFormat.format(match.getMeasuredDataPoint().getIntensity()), match.getScan());
     StringBuilder tooltipTextBuilder = new StringBuilder(tooltipText);
     if (match.getMatchedCalibrant().getMolecularFormula() != null) {
       tooltipTextBuilder.append("\nIon formula: " + match.getMatchedCalibrant().getMolecularFormula());

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_shoulderpeaksfilter/ShoulderPeaksFilterTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_shoulderpeaksfilter/ShoulderPeaksFilterTask.java
@@ -28,6 +28,7 @@ import io.github.mzmine.datamodel.impl.SimpleMassList;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import javafx.collections.ObservableList;
 
 /**
  *
@@ -39,7 +40,7 @@ public class ShoulderPeaksFilterTask extends AbstractTask {
 
   // scan counter
   private int processedScans = 0, totalScans;
-  private int[] scanNumbers;
+  private ObservableList<Scan> scanNumbers;
 
   // User parameters
   private String massListName, suffix;
@@ -92,13 +93,13 @@ public class ShoulderPeaksFilterTask extends AbstractTask {
 
     logger.info("Started mass filter on " + dataFile);
 
-    scanNumbers = dataFile.getScanNumbers();
-    totalScans = scanNumbers.length;
+    scanNumbers = dataFile.getScans();
+    totalScans = scanNumbers.size();
 
     // Check if we have at least one scan with a mass list of given name
     boolean haveMassList = false;
     for (int i = 0; i < totalScans; i++) {
-      Scan scan = dataFile.getScan(scanNumbers[i]);
+      Scan scan = scanNumbers.get(i);
       MassList massList = scan.getMassList(massListName);
       if (massList != null) {
         haveMassList = true;
@@ -117,7 +118,7 @@ public class ShoulderPeaksFilterTask extends AbstractTask {
       if (isCanceled())
         return;
 
-      Scan scan = dataFile.getScan(scanNumbers[i]);
+      Scan scan = scanNumbers.get(i);
 
       MassList massList = scan.getMassList(massListName);
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_targeted/Gap.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_targeted/Gap.java
@@ -81,10 +81,10 @@ class Gap {
     GapDataPoint currentDataPoint;
     if (basePeak != null) {
       currentDataPoint =
-          new GapDataPoint(scan.getScanNumber(), basePeak.getMZ(), scanRT, basePeak.getIntensity());
+          new GapDataPoint(scan, basePeak.getMZ(), scanRT, basePeak.getIntensity());
     } else {
       final double mzCenter = (mzRange.lowerEndpoint() + mzRange.upperEndpoint()) / 2.0;
-      currentDataPoint = new GapDataPoint(scan.getScanNumber(), mzCenter, scanRT, 0);
+      currentDataPoint = new GapDataPoint(scan, mzCenter, scanRT, 0);
     }
 
     // If we have not yet started, just create a new peak
@@ -125,11 +125,11 @@ class Gap {
 
       double mz = 0;
       float rt = 0, area = 0, height = 0;
-      int scanNumbers[] = new int[bestPeakDataPoints.size()];
+      Scan scanNumbers[] = new Scan[bestPeakDataPoints.size()];
       DataPoint finalDataPoint[] = new DataPoint[bestPeakDataPoints.size()];
       Range<Double> finalMZRange = null;
       Range<Float> finalRTRange = null, finalIntensityRange = null;
-      int representativeScan = 0;
+      Scan representativeScan = null;
 
       // Process all datapoints
       for (int i = 0; i < bestPeakDataPoints.size(); i++) {
@@ -147,7 +147,7 @@ class Gap {
           finalIntensityRange = finalIntensityRange.span(Range.singleton((float) dp.getIntensity()));
         }
 
-        scanNumbers[i] = bestPeakDataPoints.get(i).getScanNumber();
+        scanNumbers[i] = bestPeakDataPoints.get(i).getScan();
         finalDataPoint[i] = new SimpleDataPoint(dp.getMZ(), dp.getIntensity());
         mz += bestPeakDataPoints.get(i).getMZ();
 
@@ -155,7 +155,7 @@ class Gap {
         if (bestPeakDataPoints.get(i).getIntensity() > height) {
           height = (float) bestPeakDataPoints.get(i).getIntensity();
           rt = (float) bestPeakDataPoints.get(i).getRT();
-          representativeScan = bestPeakDataPoints.get(i).getScanNumber();
+          representativeScan = bestPeakDataPoints.get(i).getScan();
         }
 
         // Skip last data point
@@ -183,10 +183,10 @@ class Gap {
       mz /= bestPeakDataPoints.size();
 
       // Find the best fragmentation scan, if available
-      int fragmentScan = ScanUtils.findBestFragmentScan(rawDataFile, finalRTRange, finalMZRange);
+      Scan fragmentScan = ScanUtils.findBestFragmentScan(rawDataFile, finalRTRange, finalMZRange);
 
       // Find all MS2 fragment scans, if available
-      int[] allMS2fragmentScanNumbers =
+      Scan[] allMS2fragmentScanNumbers =
           ScanUtils.findAllMS2FragmentScans(rawDataFile, finalRTRange, finalMZRange);
 
       // Is intensity above the noise level?

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_targeted/GapDataPoint.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_targeted/GapDataPoint.java
@@ -19,28 +19,28 @@
 package io.github.mzmine.modules.dataprocessing.featdet_targeted;
 
 import io.github.mzmine.datamodel.DataPoint;
+import io.github.mzmine.datamodel.Scan;
 
 /**
  * DataPoint implementation extended with retention time and scan number
  */
 class GapDataPoint implements DataPoint {
 
-  private int scanNumber;
+  private Scan scan;
   private double mz, rt, intensity;
 
   /**
    */
-  GapDataPoint(int scanNumber, double mz, double rt, double intensity) {
-
-    this.scanNumber = scanNumber;
+  GapDataPoint(Scan scan, double mz, double rt, double intensity) {
+    this.scan = scan;
     this.mz = mz;
     this.rt = rt;
     this.intensity = intensity;
 
   }
 
-  int getScanNumber() {
-    return scanNumber;
+  Scan getScan() {
+    return scan;
   }
 
   public double getIntensity() {

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_targeted/TargetedPeakDetectionModuleTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_targeted/TargetedPeakDetectionModuleTask.java
@@ -136,7 +136,7 @@ class TargetedPeakDetectionModuleTask extends AbstractTask {
     }
 
     // Get all scans of this data file
-    int scanNumbers[] = dataFile.getScanNumbers(msLevel);
+    Scan scanNumbers[] = dataFile.getScanNumbers(msLevel).toArray(Scan[]::new);
     if (scanNumbers == null) {
       logger.log(Level.WARNING, "Could not read file with the MS level of " + msLevel);
       setStatus(TaskStatus.ERROR);
@@ -144,15 +144,12 @@ class TargetedPeakDetectionModuleTask extends AbstractTask {
     }
 
     // Process each scan
-    for (int scanNumber : scanNumbers) {
+    for (Scan scan : scanNumbers) {
 
       // Canceled?
       if (isCanceled()) {
         return;
       }
-
-      // Get the scan
-      Scan scan = dataFile.getScan(scanNumber);
 
       // Feed this scan to all gaps
       for (Gap gap : gaps) {

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_alignscans/AlignScansTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_alignscans/AlignScansTask.java
@@ -42,7 +42,7 @@ public class AlignScansTask extends AbstractTask {
 
   // scan counter
   private int processedScans = 0, totalScans;
-  private int[] scanNumbers;
+  private Scan[] scanNumbers;
 
   // User parameters
   private String suffix;
@@ -100,7 +100,7 @@ public class AlignScansTask extends AbstractTask {
 
     logger.info("Started Scan Alignment on " + dataFile);
 
-    scanNumbers = dataFile.getScanNumbers(1);
+    scanNumbers = dataFile.getScanNumbers(1).toArray(Scan[]::new);
     totalScans = scanNumbers.length;
 
     RawDataFileWriter newRDFW = null;
@@ -115,7 +115,7 @@ public class AlignScansTask extends AbstractTask {
         if (isCanceled())
           return;
 
-        Scan scan = dataFile.getScan(scanNumbers[i]);
+        Scan scan = scanNumbers[i];
         si = (int) Math.max(0, i - scanSpan);
         sj = (int) (si + 2 * scanSpan);
         if (sj >= totalScans) {
@@ -128,7 +128,7 @@ public class AlignScansTask extends AbstractTask {
             mzValues = new DataPoint[sj - si + 1][];
           // Load Data Points
           for (j = si; j <= sj; j++) {
-            Scan xscan = dataFile.getScan(scanNumbers[j]);
+            Scan xscan = scanNumbers[j];
             mzValues[j - si] = xscan.getDataPoints();
           }
           // Estimate Correlations

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_baselinecorrection/BaselineCorrector.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_baselinecorrection/BaselineCorrector.java
@@ -76,7 +76,7 @@ public abstract class BaselineCorrector implements BaselineProvider, MZmineModul
   /**
    * Getting general parameters (common to all the correctors).
    * 
-   * @param generalParameters The parameters common to all methods (grabbed from
+   * @param parameters The parameters common to all methods (grabbed from
    *        "BaselineCorrectionParameters")
    */
   public void collectCommonParameters(final ParameterSet parameters) {
@@ -136,7 +136,7 @@ public abstract class BaselineCorrector implements BaselineProvider, MZmineModul
     // progressMax = 0;
     for (final int level : levels) {
       final boolean isMSLevel = msLevel == level;
-      final int numScans = origDataFile.getScanNumbers(level).length;
+      final int numScans = origDataFile.getScanNumbers(level).size();
       foundLevel |= isMSLevel;
       // progressMax += isMSLevel || msLevel == 0 ? 2 * numScans +
       // numBins : numScans;
@@ -198,14 +198,14 @@ public abstract class BaselineCorrector implements BaselineProvider, MZmineModul
     logger.finest("Copy scans");
 
     // Get scan numbers for MS-level.
-    final int[] scanNumbers = origDataFile.getScanNumbers(level);
+    final Scan[] scanNumbers = origDataFile.getScanNumbers(level).toArray(Scan[]::new);
     final int numScans = scanNumbers.length;
 
     // Create copy of scans.
     for (int scanIndex = 0; !isAborted(origDataFile) && scanIndex < numScans; scanIndex++) {
 
       // Get original scan.
-      final Scan origScan = origDataFile.getScan(scanNumbers[scanIndex]);
+      final Scan origScan = scanNumbers[scanIndex];
 
       // Get data points (m/z and intensity pairs) of the original scan
       final DataPoint[] origDataPoints = origScan.getDataPoints();
@@ -235,7 +235,6 @@ public abstract class BaselineCorrector implements BaselineProvider, MZmineModul
    * @param parameters parameters specific to the actual method for baseline computing.
    * @throws IOException if there are i/o problems.
    * @throws RSessionWrapperException
-   * @throws BaselineCorrectionException
    * @throws InterruptedException
    */
   private void correctBasePeakBaselines(final RSessionWrapper rSession,
@@ -244,7 +243,7 @@ public abstract class BaselineCorrector implements BaselineProvider, MZmineModul
       throws IOException, RSessionWrapperException {
 
     // Get scan numbers from original file.
-    final int[] scanNumbers = origDataFile.getScanNumbers(level);
+    final Scan[] scanNumbers = origDataFile.getScanNumbers(level).toArray(Scan[]::new);
     final int numScans = scanNumbers.length;
 
     // Build chromatograms.
@@ -265,7 +264,7 @@ public abstract class BaselineCorrector implements BaselineProvider, MZmineModul
     for (int scanIndex = 0; !isAborted(origDataFile) && scanIndex < numScans; scanIndex++) {
 
       // Get original scan.
-      final Scan origScan = origDataFile.getScan(scanNumbers[scanIndex]);
+      final Scan origScan = scanNumbers[scanIndex];
 
       // Get data points (m/z and intensity pairs) of the original scan
       final DataPoint[] origDataPoints = origScan.getDataPoints();
@@ -289,14 +288,13 @@ public abstract class BaselineCorrector implements BaselineProvider, MZmineModul
    * @param parameters parameters specific to the actual method for baseline computing.
    * @throws IOException if there are i/o problems.
    * @throws RSessionWrapperException
-   * @throws BaselineCorrectionException
    */
   private void correctTICBaselines(final RSessionWrapper rSession, final RawDataFile origDataFile,
       final RawDataFileWriter writer, final int level, final int numBins,
       final ParameterSet parameters) throws IOException, RSessionWrapperException {
 
     // Get scan numbers from original file.
-    final int[] scanNumbers = origDataFile.getScanNumbers(level);
+    final Scan[] scanNumbers = origDataFile.getScanNumbers(level).toArray(Scan[]::new);
     final int numScans = scanNumbers.length;
 
     // Build chromatograms.
@@ -328,7 +326,7 @@ public abstract class BaselineCorrector implements BaselineProvider, MZmineModul
     for (int scanIndex = 0; !isAborted(origDataFile) && scanIndex < numScans; scanIndex++) {
 
       // Get original scan.
-      final Scan origScan = origDataFile.getScan(scanNumbers[scanIndex]);
+      final Scan origScan = scanNumbers[scanIndex];
 
       // Get data points (m/z and intensity pairs) of the original scan
       final DataPoint[] origDataPoints = origScan.getDataPoints();
@@ -355,7 +353,7 @@ public abstract class BaselineCorrector implements BaselineProvider, MZmineModul
       final int numBins) {
 
     // Get scan numbers from original file.
-    final int[] scanNumbers = origDataFile.getScanNumbers(level);
+    final Scan[] scanNumbers = origDataFile.getScanNumbers(level).toArray(Scan[]::new);
     final int numScans = scanNumbers.length;
 
     // Determine MZ range.
@@ -367,7 +365,7 @@ public abstract class BaselineCorrector implements BaselineProvider, MZmineModul
     for (int scanIndex = 0; !isAborted(origDataFile) && scanIndex < numScans; scanIndex++) {
 
       // Get original scan.
-      final Scan scan = origDataFile.getScan(scanNumbers[scanIndex]);
+      final Scan scan = scanNumbers[scanIndex];
 
       // Process data points.
       for (final DataPoint dataPoint : scan.getDataPoints()) {
@@ -395,7 +393,7 @@ public abstract class BaselineCorrector implements BaselineProvider, MZmineModul
       final int numBins) {
 
     // Get scan numbers from original file.
-    final int[] scanNumbers = origDataFile.getScanNumbers(level);
+    final Scan[] scanNumbers = origDataFile.getScanNumbers(level).toArray(Scan[]::new);
     final int numScans = scanNumbers.length;
 
     // Determine MZ range.
@@ -407,7 +405,7 @@ public abstract class BaselineCorrector implements BaselineProvider, MZmineModul
     for (int scanIndex = 0; !isAborted(origDataFile) && scanIndex < numScans; scanIndex++) {
 
       // Get original scan.
-      final Scan scan = origDataFile.getScan(scanNumbers[scanIndex]);
+      final Scan scan = scanNumbers[scanIndex];
 
       // Process data points.
       for (final DataPoint dataPoint : scan.getDataPoints()) {

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_baselinecorrection/BaselineCorrectorSetupDialog.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_baselinecorrection/BaselineCorrectorSetupDialog.java
@@ -217,7 +217,7 @@ public class BaselineCorrectorSetupDialog extends ParameterSetupDialogWithChroma
         final ScanSelection sel = new ScanSelection(rtRange, 1);
         Scan scans[] = sel.getMatchingScans(dataFile);
 
-        TICDataSet ticDataset = new TICDataSet(dataFile, scans, mzRange, null, getPlotType());
+        TICDataSet ticDataset = new TICDataSet(dataFile, List.of(scans), mzRange, null, getPlotType());
         ticPlot.addTICDataSet(ticDataset);
 
         try {
@@ -235,7 +235,7 @@ public class BaselineCorrectorSetupDialog extends ParameterSetupDialogWithChroma
           if (newDataFile != null) {
             scans = sel.getMatchingScans(newDataFile);
             final TICDataSet newDataset =
-                new TICDataSet(newDataFile, scans, mzRange, null, getPlotType());
+                new TICDataSet(newDataFile, List.of(scans), mzRange, null, getPlotType());
             ticPlot.addTICDataSet(newDataset);
 
             // Show the trend line as well
@@ -442,12 +442,15 @@ public class BaselineCorrectorSetupDialog extends ParameterSetupDialogWithChroma
     DataPoint dp, new_dp;
 
     // Get scan numbers from original file.
-    final int[] scanNumbers = dataFile.getScanNumbers(1);
-    final int numScans = scanNumbers.length;
+    final Scan[] scans = dataFile.getScanNumbers(1).toArray(Scan[]::new);
+    final Scan[] newScans = newDataFile.getScanNumbers(1).toArray(Scan[]::new);
+    assert scans.length == newScans.length;
+
+    final int numScans = scans.length;
     for (int scanIndex = 0; scanIndex < numScans; ++scanIndex) {
 
-      sc = dataFile.getScan(scanNumbers[scanIndex]);
-      new_sc = newDataFile.getScan(scanNumbers[scanIndex]);
+      sc = scans[scanIndex];
+      new_sc = newScans[scanIndex];
 
       if (plotType == TICPlotType.BASEPEAK) {
         dp = sc.getHighestDataPoint();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_extractscans/ExtractScansTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_extractscans/ExtractScansTask.java
@@ -93,7 +93,7 @@ class ExtractScansTask extends AbstractTask {
         double max = 0;
         // find center scan
         for (int i = 0; i < raw.getNumOfScans(); i++) {
-          Scan scan = raw.getScan(raw.getScanNumbers()[i]);
+          Scan scan = raw.getScan(i);
           double rt = scan.getRetentionTime();
           if (autoMax) {
             double tic = scan.getTIC();
@@ -129,7 +129,7 @@ class ExtractScansTask extends AbstractTask {
         int start = -1;
         int end = -1;
         for (int i = 0; i < raw.getNumOfScans(); i++) {
-          Scan scan = raw.getScan(raw.getScanNumbers()[i]);
+          Scan scan = raw.getScan(i);
           double rt = scan.getRetentionTime();
 
           if (i == raw.getNumOfScans() - 1) {
@@ -168,19 +168,19 @@ class ExtractScansTask extends AbstractTask {
     File fileDir = new File(dir, FilenameUtils.removeExtension(raw.getName()));
     FileAndPathUtil.createDirectory(fileDir);
     int end = Math.min(scans + start, raw.getNumOfScans());
-    String linescans = "scan" + delimiter + raw.getScanNumbers()[start] + delimiter + "to"
-        + delimiter + raw.getScanNumbers()[end - 1] + "\n";
-    String lineRT = "RT" + delimiter + raw.getScan(raw.getScanNumbers()[start]).getRetentionTime()
-        + "to" + raw.getScan(raw.getScanNumbers()[end - 1]).getRetentionTime() + "\n";
+    String linescans = "scan" + delimiter + raw.getScan(start).getScanNumber() + delimiter + "to"
+        + delimiter + raw.getScan(end - 1).getScanNumber() + "\n";
+    String lineRT = "RT" + delimiter + raw.getScan(start).getRetentionTime()
+        + "to" + raw.getScan(end - 1).getRetentionTime() + "\n";
     String linePath = raw.getName() + "\n";
     String lineOptions = "export of" + delimiter;
     if (!useCenterTime) {
-      double st = raw.getScan(raw.getScanNumbers()[start]).getRetentionTime();
-      double et = raw.getScan(raw.getScanNumbers()[end]).getRetentionTime();
+      double st = raw.getScan(start).getRetentionTime();
+      double et = raw.getScan(end).getRetentionTime();
       lineOptions += scans + delimiter + "scans from time " + delimiter + st + " to " + et + "\n";
     } else if (autoMax) {
       lineOptions += scans + delimiter + "scans around scan with maximum intensity:" + delimiter
-          + raw.getScanNumbers()[scanMaxTIC] + "\n";
+          + raw.getScan(scanMaxTIC).getScanNumber() + "\n";
     } else {
       lineOptions +=
           scans + delimiter + "scans around center time:" + delimiter + centerTime + "\n";
@@ -198,7 +198,7 @@ class ExtractScansTask extends AbstractTask {
       }
       // EXPORT
       try {
-        Scan s = raw.getScan(raw.getScanNumbers()[i]);
+        Scan s = raw.getScan(i);
         // write header
         if (exportHeader) {
           out.append(linePath);
@@ -207,7 +207,7 @@ class ExtractScansTask extends AbstractTask {
           out.append(lineOptions);
 
           out.append("TIC" + delimiter + s.getTIC() + "\n");
-          out.append("scan number" + delimiter + raw.getScanNumbers()[i] + "\n");
+          out.append("scan number" + delimiter + raw.getScan(i).getScanNumber() + "\n");
           out.append("retention time" + delimiter + s.getRetentionTime() + "\n\n");
           out.append("mz" + delimiter + "intensity\n");
         }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_featurefilter/FeatureFilterTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_featurefilter/FeatureFilterTask.java
@@ -18,13 +18,13 @@
 
 package io.github.mzmine.modules.dataprocessing.filter_featurefilter;
 
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
-import io.github.mzmine.util.FeatureUtils;
 import io.github.mzmine.util.RangeUtils;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -168,7 +168,7 @@ public class FeatureFilterTask extends AbstractTask {
         final double peakArea = peak.getArea();
         final double peakHeight = peak.getHeight();
         final int peakDatapoints = peak.getScanNumbers().size();
-        final int msmsScanNumber = peak.getMostIntenseFragmentScanNumber();
+        final Scan msmsScanNumber = peak.getMostIntenseFragmentScan();
 
         Float peakFWHM = peak.getFWHM();
         Float peakTailingFactor = peak.getTailingFactor();
@@ -259,7 +259,7 @@ public class FeatureFilterTask extends AbstractTask {
 
         // Check MS/MS filter
         if (filterByMS2) {
-          if (msmsScanNumber < 1)
+          if (msmsScanNumber != null)
             keepPeak[i] = false;
         }
       }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_merge/RawFileMergeTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_merge/RawFileMergeTask.java
@@ -33,6 +33,7 @@ import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import javafx.collections.ObservableList;
 
 /**
  * Merge multiple raw data files into one. For example one positive, one negative and multiple with
@@ -93,12 +94,11 @@ class RawFileMergeTask extends AbstractTask {
       for (RawDataFile r : raw) {
         // some files are only for MS2
         boolean isMS2Only = useMS2Marker && r.getName().contains(ms2Marker);
-        int[] snarray = r.getScanNumbers();
-        for (int sn : snarray) {
+        ObservableList<Scan> snarray = r.getScans();
+        for (Scan scan : snarray) {
           if (isCanceled())
             return;
 
-          Scan scan = r.getScan(sn);
           if (!isMS2Only || scan.getMSLevel() > 1) {
             scans.add(scan);
           }
@@ -106,12 +106,7 @@ class RawFileMergeTask extends AbstractTask {
       }
 
       // sort by rt
-      scans.sort(new Comparator<Scan>() {
-        @Override
-        public int compare(Scan a, Scan b) {
-          return Double.compare(a.getRetentionTime(), b.getRetentionTime());
-        }
-      });
+      scans.sort(Comparator.comparingDouble(Scan::getRetentionTime));
 
       // create new file
       RawDataFileWriter rawDataFileWriter =

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_rowsfilter/RowsFilterTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_rowsfilter/RowsFilterTask.java
@@ -401,7 +401,7 @@ public class RowsFilterTask extends AbstractTask {
         // iterates the features
         int failCounts = 0;
         for (int i = 0; i < featureCount; i++) {
-          if (row.getFeatures().get(i).getMostIntenseFragmentScanNumber() < 1) {
+          if (row.getFeatures().get(i).getMostIntenseFragmentScan() == null) {
             failCounts++;
             // filterRowCriteriaFailed = true;
             // break;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_scanfilters/ScanFilteringTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_scanfilters/ScanFilteringTask.java
@@ -31,6 +31,7 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.parametertypes.selectors.ScanSelection;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import javafx.collections.ObservableList;
 
 class ScanFilteringTask extends AbstractTask {
 
@@ -41,7 +42,7 @@ class ScanFilteringTask extends AbstractTask {
 
   // scan counter
   private int processedScans = 0, totalScans;
-  private int[] scanNumbers;
+  private ObservableList<Scan> scanNumbers;
 
   // User parameters
   private String suffix;
@@ -102,8 +103,8 @@ class ScanFilteringTask extends AbstractTask {
 
     logger.info("Started filtering scans on " + dataFile);
 
-    scanNumbers = dataFile.getScanNumbers();
-    totalScans = scanNumbers.length;
+    scanNumbers = dataFile.getScans();
+    totalScans = scanNumbers.size();
 
     try {
 
@@ -118,7 +119,7 @@ class ScanFilteringTask extends AbstractTask {
           return;
         }
 
-        Scan scan = dataFile.getScan(scanNumbers[i]);
+        Scan scan = scanNumbers.get(i);
         Scan newScan = null;
         if (select.matches(scan))
           newScan = rawDataFilter.getModule().filterScan(scan, rawDataFilter.getParameterSet());
@@ -153,7 +154,6 @@ class ScanFilteringTask extends AbstractTask {
       setErrorMessage(e.toString());
       return;
     }
-
   }
 
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_scansmoothing/ScanSmoothingTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_scansmoothing/ScanSmoothingTask.java
@@ -32,6 +32,7 @@ import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import javafx.collections.ObservableList;
 
 public class ScanSmoothingTask extends AbstractTask {
 
@@ -42,7 +43,7 @@ public class ScanSmoothingTask extends AbstractTask {
 
   // scan counter
   private int processedScans = 0, totalScans;
-  private int[] scanNumbers;
+  private ObservableList<Scan> scanNumbers;
 
   // User parameters
   private String suffix;
@@ -103,7 +104,7 @@ public class ScanSmoothingTask extends AbstractTask {
     logger.info("Started Scan Smoothing on " + dataFile);
 
     scanNumbers = dataFile.getScanNumbers(1);
-    totalScans = scanNumbers.length;
+    totalScans = scanNumbers.size();
 
     RawDataFileWriter newRDFW = null;
     int timepassed = 0;
@@ -119,7 +120,7 @@ public class ScanSmoothingTask extends AbstractTask {
           return;
 
         // Smoothing in TIME space
-        Scan scan = dataFile.getScan(scanNumbers[i]);
+        Scan scan = scanNumbers.get(i);
         if (scan != null) {
           double rt = scan.getRetentionTime();
           final SimpleScan newScan = new SimpleScan(scan);
@@ -129,13 +130,13 @@ public class ScanSmoothingTask extends AbstractTask {
           if (timeSpan > 0 || scanSpan > 0) {
             double timeMZtol = Math.max(mzTol, 1e-5);
             for (si = i; si > 1; si--) {
-              Scan scanS = dataFile.getScan(scanNumbers[si - 1]);
+              Scan scanS = scanNumbers.get(si - 1);
               if (scanS == null || scanS.getRetentionTime() < rt - timeSpan / 2) {
                 break;
               }
             }
             for (sj = i; sj < totalScans - 1; sj++) {
-              Scan scanS = dataFile.getScan(scanNumbers[sj + 1]);
+              Scan scanS = scanNumbers.get(sj + 1);
               if (scanS == null || scanS.getRetentionTime() >= rt + timeSpan / 2) {
                 break;
               }
@@ -163,7 +164,7 @@ public class ScanSmoothingTask extends AbstractTask {
                 mzValues = new DataPoint[sj - si + 1][];
               // Load Data Points
               for (j = si; j <= sj; j++) {
-                Scan xscan = dataFile.getScan(scanNumbers[j]);
+                Scan xscan = scanNumbers.get(j);
                 mzValues[j - si] = xscan.getDataPoints();
               }
               // Estimate Averages

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/Gap.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/Gap.java
@@ -80,10 +80,10 @@ public class Gap {
     GapDataPoint currentDataPoint;
     if (basePeak != null) {
       currentDataPoint =
-          new GapDataPoint(scan.getScanNumber(), basePeak.getMZ(), scanRT, basePeak.getIntensity());
+          new GapDataPoint(scan, basePeak.getMZ(), scanRT, basePeak.getIntensity());
     } else {
       currentDataPoint =
-          new GapDataPoint(scan.getScanNumber(), RangeUtils.rangeCenter(mzRange), scanRT, 0);
+          new GapDataPoint(scan, RangeUtils.rangeCenter(mzRange), scanRT, 0);
     }
 
     // If we have not yet started, just create a new peak
@@ -128,11 +128,11 @@ public class Gap {
 
       double mz = 0;
       float rt = 0, height = 0, area = 0;
-      int scanNumbers[] = new int[bestPeakDataPoints.size()];
+      Scan scanNumbers[] = new Scan[bestPeakDataPoints.size()];
       DataPoint finalDataPoint[] = new DataPoint[bestPeakDataPoints.size()];
       Range<Double> finalMZRange = null;
       Range<Float> finalRTRange = null, finalIntensityRange = null;
-      int representativeScan = 0;
+      Scan representativeScan = null;
 
       // Process all datapoints
       for (int i = 0; i < bestPeakDataPoints.size(); i++) {
@@ -150,7 +150,7 @@ public class Gap {
           finalIntensityRange = finalIntensityRange.span(Range.singleton((float) dp.getIntensity()));
         }
 
-        scanNumbers[i] = bestPeakDataPoints.get(i).getScanNumber();
+        scanNumbers[i] = bestPeakDataPoints.get(i).getScan();
         finalDataPoint[i] = new SimpleDataPoint(dp.getMZ(), dp.getIntensity());
         mz += bestPeakDataPoints.get(i).getMZ();
 
@@ -158,7 +158,7 @@ public class Gap {
         if (bestPeakDataPoints.get(i).getIntensity() > height) {
           height = (float) bestPeakDataPoints.get(i).getIntensity();
           rt = (float) bestPeakDataPoints.get(i).getRT();
-          representativeScan = bestPeakDataPoints.get(i).getScanNumber();
+          representativeScan = bestPeakDataPoints.get(i).getScan();
         }
 
         // Skip last data point
@@ -182,10 +182,10 @@ public class Gap {
       mz /= bestPeakDataPoints.size();
 
       // Find the best fragmentation scan, if available
-      int fragmentScan = ScanUtils.findBestFragmentScan(rawDataFile, finalRTRange, finalMZRange);
+      Scan fragmentScan = ScanUtils.findBestFragmentScan(rawDataFile, finalRTRange, finalMZRange);
 
       // Find all MS2 level scans
-      int[] allMS2FragmentScanNumbers =
+      Scan[] allMS2FragmentScanNumbers =
           ScanUtils.findAllMS2FragmentScans(rawDataFile, finalRTRange, finalMZRange);
 
       ModularFeature newPeak = new ModularFeature((ModularFeatureList) peakListRow.getFeatureList(),

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/GapDataPoint.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/GapDataPoint.java
@@ -19,27 +19,26 @@
 package io.github.mzmine.modules.dataprocessing.gapfill_peakfinder;
 
 import io.github.mzmine.datamodel.DataPoint;
+import io.github.mzmine.datamodel.Scan;
 
 /**
  * DataPoint implementation extended with retention time and scan number
  */
 class GapDataPoint implements DataPoint {
 
-  private int scanNumber;
+  private Scan scanNumber;
   private double mz, rt, intensity;
 
   /**
    */
-  GapDataPoint(int scanNumber, double mz, double rt, double intensity) {
-
+  GapDataPoint(Scan scanNumber, double mz, double rt, double intensity) {
     this.scanNumber = scanNumber;
     this.mz = mz;
     this.rt = rt;
     this.intensity = intensity;
-
   }
 
-  int getScanNumber() {
+  Scan getScan() {
     return scanNumber;
   }
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/PeakFinderTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/PeakFinderTask.java
@@ -147,26 +147,16 @@ class PeakFinderTask extends AbstractTask {
         }
 
         // Get all scans of this data file
-        int scanNumbers[] = dataFile.getScanNumbers(1);
+        dataFile.getScanNumbers(1).forEach(scan -> {
+          if(!isCanceled()) {
+            // Feed this scan to all gaps
+            for (Gap gap : gaps) {
+              gap.offerNextScan(scan);
+            }
 
-        // Process each scan
-        for (int scanNumber : scanNumbers) {
-          // Canceled?
-          if (isCanceled()) {
-            // inside stream - only skips this element
-            return;
+            processedScans.incrementAndGet();
           }
-
-          // Get the scan
-          Scan scan = dataFile.getScan(scanNumber);
-
-          // Feed this scan to all gaps
-          for (Gap gap : gaps) {
-            gap.offerNextScan(scan);
-          }
-
-          processedScans.incrementAndGet();
-        }
+        });
 
         // Finalize gaps
         for (Gap gap : gaps) {
@@ -272,24 +262,19 @@ class PeakFinderTask extends AbstractTask {
         }
 
         // Get all scans of this data file
-        int scanNumbers[] = datafile1.getScanNumbers(1);
-
-        // Process each scan
-        for (int scanNumber : scanNumbers) {
-
-          // Canceled?
-          if (isCanceled()) {
-            return;
+        datafile1.getScanNumbers(1).forEach(scan -> {
+          if(!isCanceled()) {
+            // Feed this scan to all gaps
+            for (Gap gap : gaps) {
+              gap.offerNextScan(scan);
+            }
+            processedScans.incrementAndGet();
           }
+        });
 
-          // Get the scan
-          Scan scan = datafile1.getScan(scanNumber);
-
-          // Feed this scan to all gaps
-          for (Gap gap : gaps) {
-            gap.offerNextScan(scan);
-          }
-          processedScans.incrementAndGet();
+        // Canceled?
+        if (isCanceled()) {
+          return;
         }
 
         // Finalize gaps

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_samerange/SameRangeTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_samerange/SameRangeTask.java
@@ -180,17 +180,14 @@ class SameRangeTask extends AbstractTask {
     Range<Double> mzRangeWithTol = mzTolerance.getToleranceRange(mzRange);
 
     // Get scan numbers
-    int[] scanNumbers = column.getScanNumbers(1, rtRange);
+    Scan[] scanNumbers = column.getScanNumbers(1, rtRange);
 
     boolean dataPointFound = false;
 
-    for (int scanNumber : scanNumbers) {
+    for (Scan scan : scanNumbers) {
 
       if (isCanceled())
         return null;
-
-      // Get next scan
-      Scan scan = column.getScan(scanNumber);
 
       // Find most intense m/z peak
       DataPoint basePeak = ScanUtils.findBasePeak(scan, mzRangeWithTol);
@@ -198,10 +195,10 @@ class SameRangeTask extends AbstractTask {
       if (basePeak != null) {
         if (basePeak.getIntensity() > 0)
           dataPointFound = true;
-        newPeak.addDatapoint(scan.getScanNumber(), basePeak);
+        newPeak.addDatapoint(scan, basePeak);
       } else {
         DataPoint fakeDataPoint = new SimpleDataPoint(RangeUtils.rangeCenter(mzRangeWithTol), 0);
-        newPeak.addDatapoint(scan.getScanNumber(), fakeDataPoint);
+        newPeak.addDatapoint(scan, fakeDataPoint);
       }
 
     }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_camera/CameraSearchTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_camera/CameraSearchTask.java
@@ -256,7 +256,7 @@ public class CameraSearchTask extends AbstractTask {
       final Map<Scan, Set<DataPoint>> peakDataPointsByScan =
           new HashMap<Scan, Set<DataPoint>>(rawFile.getNumOfScans(MS_LEVEL));
       int dataPointCount = 0;
-      for (final int scanNumber : rawFile.getScanNumbers(MS_LEVEL)) {
+      for (final Scan scan : rawFile.getScanNumbers(MS_LEVEL)) {
 
         // Create a set to hold data points (sorted by m/z).
         final Set<DataPoint> dataPoints = new TreeSet<DataPoint>(ASCENDING_MASS_SORTER);
@@ -266,7 +266,7 @@ public class CameraSearchTask extends AbstractTask {
         dataPointCount++;
 
         // Map the set.
-        peakDataPointsByScan.put(rawFile.getScan(scanNumber), dataPoints);
+        peakDataPointsByScan.put(scan, dataPoints);
       }
 
       // Add peaks.
@@ -280,17 +280,15 @@ public class CameraSearchTask extends AbstractTask {
         final double mz = peak.getMZ();
 
         // Get the peak's data points per scan.
-        for (final int scanNumber : peak.getScanNumbers()) {
-
-          final Scan scan = rawFile.getScan(scanNumber);
+        for (int i=0; i<peak.getNumberOfDataPoints(); i++){
+          Scan scan = peak.getScanAtIndex(i);
           if (scan.getMSLevel() != MS_LEVEL) {
-
             throw new IllegalStateException(
                 "CAMERA can only process feature lists from MS-level " + MS_LEVEL);
           }
 
           // Copy the data point.
-          final DataPoint dataPoint = peak.getDataPoint(scanNumber);
+          final DataPoint dataPoint = peak.getDataPointAtIndex(i);
           if (dataPoint != null) {
 
             final double intensity = dataPoint.getIntensity();
@@ -346,15 +344,12 @@ public class CameraSearchTask extends AbstractTask {
       // Fill vectors.
       int scanIndex = 0;
       int pointIndex = 0;
-      for (final int scanNumber : rawFile.getScanNumbers(MS_LEVEL)) {
-
-        final Scan scan = rawFile.getScan(scanNumber);
+      for (final Scan scan : rawFile.getScanNumbers(MS_LEVEL)) {
         scanTimes[scanIndex] = scan.getRetentionTime();
         scanIndices[scanIndex] = pointIndex + 1;
         scanIndex++;
 
         for (final DataPoint dataPoint : peakDataPointsByScan.get(scan)) {
-
           masses[pointIndex] = dataPoint.getMZ();
           intensities[pointIndex] = dataPoint.getIntensity();
           pointIndex++;
@@ -499,8 +494,8 @@ public class CameraSearchTask extends AbstractTask {
    * Add pseudo-spectra identities.
    *
    * @param peaks peaks to annotate with identities.
-   * @param spectraExp the pseudo-spectra ids vector.
-   * @param isotopeExp the isotopes vector.
+   * @param spectra the pseudo-spectra ids vector.
+   * @param isotopes the isotopes vector.
    */
   private void addPseudoSpectraIdentities(final Feature[] peaks, final int[] spectra,
       final String[] isotopes, final String[] adducts) {

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_cliquems/cliquemsimplementation/ComputeCliqueModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_cliquems/cliquemsimplementation/ComputeCliqueModule.java
@@ -22,6 +22,7 @@ package io.github.mzmine.modules.dataprocessing.id_cliquems.cliquemsimplementati
 import com.google.common.collect.Range;
 import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.modules.dataprocessing.id_cliquems.CliqueMSTask;
@@ -121,16 +122,16 @@ public class ComputeCliqueModule {
   private double[][] getEIC(RawDataFile file, List<PeakData> peakDataList) {
     List<List<DataPoint>> dataPoints = new ArrayList<>(); // contains m/z and intensity data
     List<Double> rts = new ArrayList<>(); // holds Retention Time values in seconds
-    for (int z : file.getScanNumbers()) {
-      rts.add(file.getScan(z).getRetentionTime() * 60.0); // conversion for minutes to seconds
+    for (Scan scan : file.getScans()) {
+      rts.add(scan.getRetentionTime() * 60.0); // conversion for minutes to seconds
       List<DataPoint> dps = new ArrayList<DataPoint>(
-          Arrays.asList(file.getScan(z).getDataPoints()));
+          Arrays.asList(scan.getDataPoints()));
 
       dataPoints.add(dps);
     }
     // nrows = #rts , ncols = # peaks, already transposed as in R code
-    double EIC[][] = new double[file.getScanNumbers().length][peakDataList.size()];
-    for (int i = 0; i < file.getScanNumbers().length; i++) {
+    double EIC[][] = new double[file.getScans().size()][peakDataList.size()];
+    for (int i = 0; i < file.getScans().size(); i++) {
       for (int j = 0; j < peakDataList.size(); j++) {
         EIC[i][j] = 0.0;
       }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_formulaprediction/FormulaPredictionModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_formulaprediction/FormulaPredictionModule.java
@@ -42,10 +42,9 @@ public class FormulaPredictionModule implements MZmineModule {
     double mzValue = row.getAverageMZ();
     parameters.getParameter(FormulaPredictionParameters.neutralMass).setIonMass(mzValue);
 
-    int bestScanNum = row.getBestFeature().getRepresentativeScanNumber();
-    if (bestScanNum > 0) {
+    Scan bestScan = row.getBestFeature().getRepresentativeScan();
+    if (bestScan != null) {
       RawDataFile dataFile = row.getBestFeature().getRawDataFile();
-      Scan bestScan = dataFile.getScan(bestScanNum);
       PolarityType scanPolarity = bestScan.getPolarity();
       switch (scanPolarity) {
         case POSITIVE:

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_formulaprediction/ResultWindowController.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_formulaprediction/ResultWindowController.java
@@ -224,7 +224,7 @@ public class ResultWindowController {
         Feature peak = peakListRow.getBestFeature();
 
         RawDataFile dataFile = peak.getRawDataFile();
-        int scanNumber = peak.getRepresentativeScanNumber();
+        Scan scanNumber = peak.getRepresentativeScan();
         SpectraVisualizerModule.addNewSpectrumTab(dataFile, scanNumber, null,
                 peak.getIsotopePattern(), predictedPattern);
     }
@@ -257,9 +257,9 @@ public class ResultWindowController {
         Feature bestPeak = peakListRow.getBestFeature();
 
         RawDataFile dataFile = bestPeak.getRawDataFile();
-        int msmsScanNumber = bestPeak.getMostIntenseFragmentScanNumber();
+        Scan msmsScanNumber = bestPeak.getMostIntenseFragmentScan();
 
-        if (msmsScanNumber < 1)
+        if (msmsScanNumber == null)
             return;
 
         SpectraVisualizerTab msmsPlot =

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_formulaprediction/SingleRowPredictionTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_formulaprediction/SingleRowPredictionTask.java
@@ -242,15 +242,14 @@ public class SingleRowPredictionTask extends AbstractTask {
     Feature bestPeak = peakListRow.getBestFeature();
     RawDataFile dataFile = bestPeak.getRawDataFile();
     Map<DataPoint, String> msmsAnnotations = null;
-    int msmsScanNumber = bestPeak.getMostIntenseFragmentScanNumber();
+    Scan msmsScan = bestPeak.getMostIntenseFragmentScan();
 
-    if ((checkMSMS) && (msmsScanNumber > 0)) {
-      Scan msmsScan = dataFile.getScan(msmsScanNumber);
+    if ((checkMSMS) && (msmsScan != null)) {
       String massListName = msmsParameters.getParameter(MSMSScoreParameters.massList).getValue();
       MassList ms2MassList = msmsScan.getMassList(massListName);
       if (ms2MassList == null) {
         setStatus(TaskStatus.ERROR);
-        setErrorMessage("The MS/MS scan #" + msmsScanNumber + " in file " + dataFile.getName()
+        setErrorMessage("The MS/MS scan #" + msmsScan.getScanNumber() + " in file " + dataFile.getName()
             + " does not have a mass list called '" + massListName + "'");
         return;
       }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_formulapredictionfeaturelist/FormulaPredictionFeatureListTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_formulapredictionfeaturelist/FormulaPredictionFeatureListTask.java
@@ -80,8 +80,6 @@ public class FormulaPredictionFeatureListTask extends AbstractTask {
    *
    * @param parameters
    * @param featureList
-   * @param peakListRow
-   * @param peak
    */
   FormulaPredictionFeatureListTask(FeatureList featureList, ParameterSet parameters) {
 
@@ -279,15 +277,14 @@ public class FormulaPredictionFeatureListTask extends AbstractTask {
     Double msmsScore = null;
     Feature bestFeature = featureListRow.getBestFeature();
     RawDataFile dataFile = bestFeature.getRawDataFile();
-    int msmsScanNumber = bestFeature.getMostIntenseFragmentScanNumber();
+    Scan msmsScan = bestFeature.getMostIntenseFragmentScan();
 
-    if ((checkMSMS) && (msmsScanNumber > 0)) {
-      Scan msmsScan = dataFile.getScan(msmsScanNumber);
+    if ((checkMSMS) && (msmsScan != null)) {
       String massListName = msmsParameters.getParameter(MSMSScoreParameters.massList).getValue();
       MassList ms2MassList = msmsScan.getMassList(massListName);
       if (ms2MassList == null) {
         setStatus(TaskStatus.ERROR);
-        setErrorMessage("The MS/MS scan #" + msmsScanNumber + " in file " + dataFile.getName()
+        setErrorMessage("The MS/MS scan #" + msmsScan.getScanNumber() + " in file " + dataFile.getName()
             + " does not have a mass list called '" + massListName + "'");
         return null;
       }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_fragmentsearch/FragmentSearchTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_fragmentsearch/FragmentSearchTask.java
@@ -156,12 +156,10 @@ public class FragmentSearchTask extends AbstractTask {
       return false;
 
     // Get MS/MS scan, if exists
-    int fragmentScanNumber = mainPeak.getBestFeature().getMostIntenseFragmentScanNumber();
-    if (fragmentScanNumber <= 0)
+    Scan fragmentScan = mainPeak.getBestFeature().getMostIntenseFragmentScan();
+    if (fragmentScan == null)
       return false;
 
-    RawDataFile dataFile = mainPeak.getBestFeature().getRawDataFile();
-    Scan fragmentScan = dataFile.getScan(fragmentScanNumber);
     if (fragmentScan == null)
       return false;
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_isotopepeakscanner/Candidates.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_isotopepeakscanner/Candidates.java
@@ -31,6 +31,7 @@ import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.impl.SimpleDataPoint;
 import io.github.mzmine.modules.dataprocessing.id_isotopepeakscanner.IsotopePeakScannerTask.RatingType;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
+import javafx.collections.ObservableList;
 
 /**
  * This class is used to manage objects of the Candidate class and to calculate an average rating if
@@ -293,10 +294,10 @@ public class Candidates {
       if (!raw.getDataMZRange().contains(mz))
         continue;
 
-      int[] scanNums = raw.getScanNumbers();
+      ObservableList<Scan> scanNums = raw.getScans();
 
-      for (int i = 0; i < scanNums.length; i++) {
-        Scan scan = raw.getScan(scanNums[i]);
+      for (int i = 0; i < scanNums.size(); i++) {
+        Scan scan = scanNums.get(i);
 
         MassList list = scan.getMassList(massListName);
 
@@ -350,10 +351,10 @@ public class Candidates {
       if (!raw.getDataMZRange().contains(rows[0].getAverageMZ()))
         continue;
 
-      int[] scanNums = raw.getScanNumbers();
+      ObservableList<Scan> scanNums = raw.getScans();
 
-      for (int i = 0; i < scanNums.length; i++) {
-        Scan scan = raw.getScan(scanNums[i]);
+      for (int i = 0; i < scanNums.size(); i++) {
+        Scan scan = scanNums.get(i);
 
         MassList list = scan.getMassList(massListName);
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_isotopepeakscanner/IsotopePeakScannerTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_isotopepeakscanner/IsotopePeakScannerTask.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.modules.dataprocessing.id_isotopepeakscanner;
 
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureList.FeatureListAppliedMethod;
@@ -34,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
+import javafx.collections.ObservableList;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.openscience.cdk.interfaces.IIsotope;
@@ -809,9 +811,8 @@ public class IsotopePeakScannerTask extends AbstractTask {
   }
 
   private PolarityType getPeakListPolarity(FeatureList peakList) {
-    int[] scans = peakList.getRow(0).getFeatures().get(0).getScanNumbers().stream().mapToInt(i -> i).toArray();
-    RawDataFile raw = peakList.getRow(0).getFeatures().get(0).getRawDataFile();
-    return raw.getScan(scans[0]).getPolarity();
+    return peakList.getRawDataFiles().stream().map(raw -> raw.getDataPolarity().stream().findFirst().orElse(PolarityType.UNKNOWN)).findFirst()
+        .orElse(PolarityType.UNKNOWN);
   }
 
   private boolean checkParameters() {
@@ -844,9 +845,9 @@ public class IsotopePeakScannerTask extends AbstractTask {
       RawDataFile[] raws = peakList.getRawDataFiles().toArray(RawDataFile[]::new);
       boolean foundMassList = false;
       for (RawDataFile raw : raws) {
-        int scanNumbers[] = raw.getScanNumbers();
-        for (int scan : scanNumbers) {
-          MassList[] massLists = raw.getScan(scan).getMassLists();
+        ObservableList<Scan> scanNumbers = raw.getScans();
+        for (Scan scan : scanNumbers) {
+          MassList[] massLists = scan.getMassLists();
           for (MassList list : massLists) {
             if (list.getName().equals(massListName))
               foundMassList = true;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_onlinecompounddb/ResultWindowController.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_onlinecompounddb/ResultWindowController.java
@@ -190,7 +190,7 @@ public class ResultWindowController {
         Feature peak = peakListRow.getBestFeature();
 
         RawDataFile dataFile = peak.getRawDataFile();
-        int scanNumber = peak.getRepresentativeScanNumber();
+        Scan scanNumber = peak.getRepresentativeScan();
         SpectraVisualizerModule.addNewSpectrumTab(dataFile, scanNumber, null,
                 peak.getIsotopePattern(), predictedPattern);
     }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/norm_linear/LinearNormalizerTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/norm_linear/LinearNormalizerTask.java
@@ -176,8 +176,7 @@ class LinearNormalizerTask extends AbstractTask {
       // - normalization by total raw signal
       if (normalizationType == NormalizationType.TotalRawSignal) {
         normalizationFactor = 0;
-        for (int scanNumber : file.getScanNumbers(1)) {
-          Scan scan = file.getScan(scanNumber);
+        for (Scan scan : file.getScanNumbers(1)) {
           normalizationFactor += scan.getTIC();
         }
       }

--- a/src/main/java/io/github/mzmine/modules/io/csvimport/CsvImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/csvimport/CsvImportTask.java
@@ -24,6 +24,7 @@ import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.FeatureStatus;
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.ModularFeature;
@@ -115,15 +116,15 @@ public class CsvImportTask extends AbstractTask {
         finalMZRange = Range.closed(mzMin, mzMax);
         finalRTRange = Range.closed(rtMin, rtMax);
         finalIntensityRange = Range.singleton(intensity);
-        int[] scanNumbers = {};
+        Scan[] scanNumbers = {};
         DataPoint[] finalDataPoint = new DataPoint[1];
         finalDataPoint[0] = new SimpleDataPoint(feature_mz, feature_height);
         FeatureStatus status = FeatureStatus.UNKNOWN; // abundance unknown
-        int representativeScan = 0;
-        for(int s_no : rawDataFile.getScanNumbers()){
-          if(rawDataFile.getScan(s_no).getRetentionTime() == feature_rt){
+        Scan representativeScan = null;
+        for(Scan s_no : rawDataFile.getScans()){
+          if(s_no.getRetentionTime() == feature_rt){
             representativeScan = s_no;
-            for(DataPoint dp : rawDataFile.getScan(s_no).getDataPoints()){
+            for(DataPoint dp : s_no.getDataPoints()){
               if(dp.getMZ() == feature_mz){
                 finalDataPoint[0] = dp;
                 break;
@@ -132,8 +133,8 @@ public class CsvImportTask extends AbstractTask {
           }
         }
 
-        int fragmentScan = -1;
-        int[] allFragmentScans = new int[]{0};
+        Scan fragmentScan = null;
+        Scan[] allFragmentScans = new Scan[]{};
 
         Feature feature = new ModularFeature(newFeatureList, rawDataFile, feature_mz, feature_rt, feature_height, abundance,
             scanNumbers, finalDataPoint, status, representativeScan, fragmentScan, allFragmentScans,

--- a/src/main/java/io/github/mzmine/modules/io/gnpsexport/fbmn/GnpsFbmnExportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/gnpsexport/fbmn/GnpsFbmnExportTask.java
@@ -171,7 +171,7 @@ public class GnpsFbmnExportTask extends AbstractTask {
       Feature bestFeature = row.getBestFeature();
       if (bestFeature == null)
         continue;
-      int msmsScanNumber = bestFeature.getMostIntenseFragmentScanNumber();
+      Scan msmsScan = bestFeature.getMostIntenseFragmentScan();
       if (rowID != null) {
         // TODO why?
         FeatureListRow copyRow = new ModularFeatureListRow((ModularFeatureList)row.getFeatureList(), row, true);
@@ -180,26 +180,23 @@ public class GnpsFbmnExportTask extends AbstractTask {
         bestFeature = copyRow.getBestFeature();
 
         // Get the MS/MS scan number
-
-        msmsScanNumber = bestFeature.getMostIntenseFragmentScanNumber();
-        while (msmsScanNumber < 1) {
+        msmsScan = bestFeature.getMostIntenseFragmentScan();
+        while (msmsScan == null) {
           copyRow.removeFeature(bestFeature.getRawDataFile());
           if (copyRow.getFeatures().size() == 0)
             break;
 
           bestFeature = copyRow.getBestFeature();
-          msmsScanNumber = bestFeature.getMostIntenseFragmentScanNumber();
+          msmsScan = bestFeature.getMostIntenseFragmentScan();
         }
       }
-      if (msmsScanNumber >= 1) {
+      if (msmsScan != null) {
         // MS/MS scan must exist, because msmsScanNumber was > 0
-        Scan msmsScan = bestFeature.getRawDataFile().getScan(msmsScanNumber);
-
         MassList massList = msmsScan.getMassList(massListName);
 
         if (massList == null) {
           MZmineCore.getDesktop().displayErrorMessage("There is no mass list called " + massListName
-                  + " for MS/MS scan #" + msmsScanNumber + " (" + bestFeature.getRawDataFile() + ")");
+                  + " for MS/MS scan #" + msmsScan.getScanNumber() + " (" + bestFeature.getRawDataFile() + ")");
           return;
         }
 

--- a/src/main/java/io/github/mzmine/modules/io/mztabimport/MzTabImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/mztabimport/MzTabImportTask.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.modules.io.mztabimport;
 
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
@@ -442,12 +443,12 @@ class MzTabImportTask extends AbstractTask {
           feature_height = 0f;
         }
 
-        int scanNumbers[] = {};
+        Scan scanNumbers[] = {};
         DataPoint finalDataPoint[] = new DataPoint[1];
         finalDataPoint[0] = new SimpleDataPoint(feature_mz, feature_height);
-        int representativeScan = 0;
-        int fragmentScan = 0;
-        int[] allFragmentScans = new int[] {0};
+        Scan representativeScan = null;
+        Scan fragmentScan = null;
+        Scan[] allFragmentScans = new Scan[] {};
         Range<Float> finalRTRange = Range.singleton(feature_rt);
         Range<Double> finalMZRange = Range.singleton(feature_mz);
         Range<Float> finalIntensityRange = Range.singleton(feature_height);

--- a/src/main/java/io/github/mzmine/modules/io/mztabmexport/MZTabmExportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/mztabmexport/MZTabmExportTask.java
@@ -295,9 +295,9 @@ public class MZTabmExportTask extends AbstractTask {
               if (feature != null) {
                 //Spectra ref
                 List<SpectraRef> sr = new ArrayList<>();
-                for(int x:feature.getScanNumbers()){
+                for(Scan scan : feature.getScanNumbers()){
                   sr.add(new SpectraRef().msRun(rawDataFileToAssay.get(feature.getRawDataFile()).
-                      getMsRunRef().get(0)).reference("index=" + x));
+                      getMsRunRef().get(0)).reference("index=" + scan.getScanNumber()));
                 }
                 if(sr.size() == 0){
                 sr.add(new SpectraRef().msRun(rawDataFileToAssay.get(feature.getRawDataFile()).

--- a/src/main/java/io/github/mzmine/modules/io/mztabmimport/MzTabmImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/mztabmimport/MzTabmImportTask.java
@@ -407,12 +407,12 @@ public class MzTabmImportTask extends AbstractTask {
             }
           }
         }
-        int scanNumbers[] = {};
+        Scan scanNumbers[] = {};
         DataPoint finalDataPoint[] = new DataPoint[1];
         finalDataPoint[0] = new SimpleDataPoint(feature_mz, feature_height);
-        int representativeScan = 0;
-        int fragmentScan = 0;
-        int[] allFragmentScans = new int[]{0};
+        Scan representativeScan = null;
+        Scan fragmentScan = null;
+        Scan[] allFragmentScans = new Scan[]{};
 
         Range<Float> finalRTRange = Range.singleton(feature_rt);
         Range<Double> finalMZRange = Range.singleton(feature_mz);

--- a/src/main/java/io/github/mzmine/modules/io/projectload/version_3_0/PeakListOpenHandler_3_0.java
+++ b/src/main/java/io/github/mzmine/modules/io/projectload/version_3_0/PeakListOpenHandler_3_0.java
@@ -61,13 +61,14 @@ public class PeakListOpenHandler_3_0 extends DefaultHandler implements PeakListO
   private ModularFeatureListRow buildingRow;
   private ModularFeatureList buildingPeakList;
 
-  private int numOfMZpeaks, representativeScan, fragmentScan;
+  private int numOfMZpeaks;
+  private Scan representativeScan, fragmentScan;
   private String peakColumnID;
   private double mass;
   private float rt, area;
-  private int[] scanNumbers;
-  private int[] allMS2FragmentScanNumbers;
-  private Vector<Integer> currentAllMS2FragmentScans;
+  private Scan[] scanNumbers;
+  private Scan[] allMS2FragmentScanNumbers;
+  private Vector<Scan> currentAllMS2FragmentScans;
   private float height;
   private double[] masses, intensities;
   private String peakStatus, peakListName, name, identityPropertyName, rawDataFileID;
@@ -115,7 +116,7 @@ public class PeakListOpenHandler_3_0 extends DefaultHandler implements PeakListO
     appliedMethodParameters = new Vector<String>();
     currentPeakListDataFiles = new Vector<RawDataFile>();
     currentIsotopes = new Vector<DataPoint>();
-    currentAllMS2FragmentScans = new Vector<Integer>();
+    currentAllMS2FragmentScans = new Vector<Scan>();
 
     buildingPeakList = null;
 
@@ -243,6 +244,7 @@ public class PeakListOpenHandler_3_0 extends DefaultHandler implements PeakListO
    */
   @Override
   public void endElement(String namespaceURI, String sName, String qName) throws SAXException {
+    RawDataFile dataFile = dataFilesIDMap.get(peakColumnID);
 
     if (canceled)
       throw new SAXException("Parsing canceled");
@@ -268,7 +270,6 @@ public class PeakListOpenHandler_3_0 extends DefaultHandler implements PeakListO
     // <RAW_FILE>
     if (qName.equals(PeakListElementName_3_0.RAWFILE.getElementName())) {
       rawDataFileID = getTextOfElement();
-      RawDataFile dataFile = dataFilesIDMap.get(rawDataFileID);
       if (dataFile == null) {
         throw new SAXException(
             "Cannot open feature list, because raw data file " + rawDataFileID + " is missing.");
@@ -282,10 +283,10 @@ public class PeakListOpenHandler_3_0 extends DefaultHandler implements PeakListO
       byte[] bytes = Base64.decodeToBytes(getTextOfElement());
       // make a data input stream
       DataInputStream dataInputStream = new DataInputStream(new ByteArrayInputStream(bytes));
-      scanNumbers = new int[numOfMZpeaks];
+      scanNumbers = new Scan[numOfMZpeaks];
       for (int i = 0; i < numOfMZpeaks; i++) {
         try {
-          scanNumbers[i] = dataInputStream.readInt();
+          scanNumbers[i] = dataFile.getScanAtNumber(dataInputStream.readInt());
         } catch (IOException ex) {
           throw new SAXException(ex);
         }
@@ -294,18 +295,18 @@ public class PeakListOpenHandler_3_0 extends DefaultHandler implements PeakListO
 
     // <REPRESENTATIVE_SCAN>
     if (qName.equals(PeakListElementName_3_0.REPRESENTATIVE_SCAN.getElementName())) {
-      representativeScan = Integer.valueOf(getTextOfElement());
+      representativeScan = dataFile.getScanAtNumber(Integer.valueOf(getTextOfElement()));
     }
 
     // <FRAGMENT_SCAN>
     if (qName.equals(PeakListElementName_3_0.FRAGMENT_SCAN.getElementName())) {
-      fragmentScan = Integer.valueOf(getTextOfElement());
+      fragmentScan = dataFile.getScanAtNumber(Integer.valueOf(getTextOfElement()));
     }
 
     // <All_MS2_FRAGMENT_SCANS>
     if (qName.equals(PeakListElementName_3_0.ALL_MS2_FRAGMENT_SCANS.getElementName())) {
       Integer fragmentNumber = Integer.valueOf(getTextOfElement());
-      currentAllMS2FragmentScans.add(fragmentNumber);
+      currentAllMS2FragmentScans.add(dataFile.getScanAtNumber(fragmentNumber));
     }
 
     // <MASS>
@@ -346,14 +347,13 @@ public class PeakListOpenHandler_3_0 extends DefaultHandler implements PeakListO
       DataPoint[] mzPeaks = new DataPoint[numOfMZpeaks];
       Range<Double> peakMZRange = null;
       Range<Float> peakRTRange = null, peakIntensityRange = null;
-      RawDataFile dataFile = dataFilesIDMap.get(peakColumnID);
 
       if (dataFile == null)
         throw new SAXException("Error in project: data file " + peakColumnID + " not found");
 
       for (int i = 0; i < numOfMZpeaks; i++) {
 
-        Scan sc = dataFile.getScan(scanNumbers[i]);
+        Scan sc = scanNumbers[i];
         float retentionTime = sc.getRetentionTime();
 
         double mz = masses[i];
@@ -384,7 +384,7 @@ public class PeakListOpenHandler_3_0 extends DefaultHandler implements PeakListO
       FeatureStatus status = FeatureStatus.valueOf(peakStatus);
 
       // convert vector of allMS2FragmentScans to array
-      allMS2FragmentScanNumbers = new int[currentAllMS2FragmentScans.size()];
+      allMS2FragmentScanNumbers = new Scan[currentAllMS2FragmentScans.size()];
       for (int i = 0; i < allMS2FragmentScanNumbers.length; i++) {
         allMS2FragmentScanNumbers[i] = currentAllMS2FragmentScans.get(i);
       }

--- a/src/main/java/io/github/mzmine/modules/io/projectsave/PeakListSaveHandler.java
+++ b/src/main/java/io/github/mzmine/modules/io/projectsave/PeakListSaveHandler.java
@@ -20,6 +20,7 @@ package io.github.mzmine.modules.io.projectsave;
 
 import io.github.mzmine.datamodel.FeatureIdentity;
 import io.github.mzmine.datamodel.FeatureInformation;
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureList.FeatureListAppliedMethod;
@@ -35,6 +36,7 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 import javafx.collections.ObservableList;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
@@ -70,7 +72,6 @@ public class PeakListSaveHandler {
    * Create an XML document with the feature list information an save it into the project zip file
    *
    * @param featureList
-   * @param peakListSavedName name of the feature list
    * @throws java.io.IOException
    */
   public void savePeakList(FeatureList featureList)
@@ -184,7 +185,6 @@ public class PeakListSaveHandler {
    * Add the row information into the XML document
    *
    * @param row
-   * @param element
    * @throws IOException
    */
   private void fillRowElement(FeatureListRow row, TransformerHandler hd)
@@ -261,7 +261,6 @@ public class PeakListSaveHandler {
    * Add the peak identity information into the XML document
    *
    * @param identity
-   * @param element
    */
   private void fillIdentityElement(FeatureIdentity identity, TransformerHandler hd)
       throws SAXException {
@@ -307,8 +306,6 @@ public class PeakListSaveHandler {
    * Add the peaks information into the XML document
    *
    * @param feature
-   * @param element
-   * @param dataFileID
    * @throws IOException
    */
   private void fillPeakElement(Feature feature, TransformerHandler hd)
@@ -317,20 +314,19 @@ public class PeakListSaveHandler {
 
     // <REPRESENTATIVE_SCAN>
     hd.startElement("", "", PeakListElementName.REPRESENTATIVE_SCAN.getElementName(), atts);
-    hd.characters(String.valueOf(feature.getRepresentativeScanNumber()).toCharArray(), 0,
-        String.valueOf(feature.getRepresentativeScanNumber()).length());
+    hd.characters(String.valueOf(feature.getRepresentativeScan().getScanNumber()).toCharArray(), 0,
+        String.valueOf(feature.getRepresentativeScan().getScanNumber()).length());
     hd.endElement("", "", PeakListElementName.REPRESENTATIVE_SCAN.getElementName());
 
     // <FRAGMENT_SCAN>
     hd.startElement("", "", PeakListElementName.FRAGMENT_SCAN.getElementName(), atts);
-    hd.characters(String.valueOf(feature.getMostIntenseFragmentScanNumber()).toCharArray(), 0,
-        String.valueOf(feature.getMostIntenseFragmentScanNumber()).length());
+    hd.characters(String.valueOf(feature.getMostIntenseFragmentScan().getScanNumber()).toCharArray(), 0,
+        String.valueOf(feature.getMostIntenseFragmentScan().getScanNumber()).length());
     hd.endElement("", "", PeakListElementName.FRAGMENT_SCAN.getElementName());
 
     // <ALL_MS2_FRAGMENT_SCANS>
-    fillAllMS2FragmentScanNumbers(feature.getAllMS2FragmentScanNumbers(), hd);
-
-    List<Integer> scanNumbers = feature.getScanNumbers();
+    fillAllMS2FragmentScanNumbers(feature.getAllMS2FragmentScans().stream().map(Scan::getScanNumber)
+        .collect(Collectors.toList()), hd);
 
     // <ISOTOPE_PATTERN>
     IsotopePattern isotopePattern = feature.getIsotopePattern();
@@ -350,7 +346,7 @@ public class PeakListSaveHandler {
 
     // <MZPEAK>
     atts.addAttribute("", "", PeakListElementName.QUANTITY.getElementName(), "CDATA",
-        String.valueOf(scanNumbers.size()));
+        String.valueOf(feature.getScanNumbers().size()));
     hd.startElement("", "", PeakListElementName.MZPEAKS.getElementName(), atts);
     atts.clear();
 
@@ -365,10 +361,11 @@ public class PeakListSaveHandler {
     DataOutputStream dataHeightStream = new DataOutputStream(byteHeightStream);
 
     float mass, height;
-    for (int scan : scanNumbers) {
-      dataScanStream.writeInt(scan);
+    for (int i=0; i<feature.getNumberOfDataPoints(); i++) {
+      Scan scan = feature.getScanAtIndex(i);
+      dataScanStream.writeInt(scan.getScanNumber());
       dataScanStream.flush();
-      DataPoint mzPeak = feature.getDataPoint(scan);
+      DataPoint mzPeak = feature.getDataPointAtIndex(i);
       if (mzPeak != null) {
         mass = (float) mzPeak.getMZ();
         height = (float) mzPeak.getIntensity();

--- a/src/main/java/io/github/mzmine/modules/io/projectsave/RawDataFileSaveHandler.java
+++ b/src/main/java/io/github/mzmine/modules/io/projectsave/RawDataFileSaveHandler.java
@@ -208,14 +208,13 @@ class RawDataFileSaveHandler {
     hd.endElement("", "", RawDataElementName.QUANTITY_SCAN.getElementName());
 
     // <SCAN>
-    for (int scanNumber : rawDataFile.getScanNumbers()) {
+    for (Scan scan : rawDataFile.getScans()) {
 
       if (canceled) {
         return;
       }
 
-      StorableScan scan = (StorableScan) rawDataFile.getScan(scanNumber);
-      int storageID = scan.getStorageID();
+      int storageID = ((StorableScan)scan).getStorageID();
       atts.addAttribute("", "", RawDataElementName.STORAGE_ID.getElementName(), "CDATA",
           String.valueOf(storageID));
       hd.startElement("", "", RawDataElementName.SCAN.getElementName(), atts);
@@ -241,7 +240,7 @@ class RawDataFileSaveHandler {
       hd.endElement("", "", RawDataElementName.QUANTITY_FRAMES.getElementName());
 
       int completedFrames = 0;
-      for (int frameNum : imsFile.getFrameNumbers()) {
+      for (Frame frameNum : imsFile.getFrames()) {
 
         if (canceled) {
           return;

--- a/src/main/java/io/github/mzmine/modules/io/siriusexport/SiriusExportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/siriusexport/SiriusExportTask.java
@@ -201,7 +201,7 @@ public class SiriusExportTask extends AbstractTask {
           if (f.getFeatureStatus() == FeatureStatus.DETECTED
               && f.getMostIntenseFragmentScan() != null) {
             // write correlation spectrum
-            writeHeader(writer, row, f.getRawDataFile(), polarity, MsType.CORRELATED, null, null);
+            writeHeader(writer, row, f.getRawDataFile(), polarity, MsType.CORRELATED, -1, null);
             writeCorrelationSpectrum(writer, f);
             if (mergeMode == MergeMode.CONSECUTIVE_SCANS) {
               // merge MS/MS
@@ -226,7 +226,7 @@ public class SiriusExportTask extends AbstractTask {
         }
       } else {
         // write correlation spectrum
-        writeHeader(writer, row, row.getBestFeature().getRawDataFile(), polarity, MsType.CORRELATED, null, null);
+        writeHeader(writer, row, row.getBestFeature().getRawDataFile(), polarity, MsType.CORRELATED, -1, null);
         writeCorrelationSpectrum(writer, row.getBestFeature());
         // merge everything into one
         MergedSpectrum spectrum = merger.mergeAcrossSamples(mergeParameters, row, massListName)
@@ -292,11 +292,11 @@ public class SiriusExportTask extends AbstractTask {
 
   private void writeHeader(BufferedWriter writer, FeatureListRow row, RawDataFile raw, char polarity,
       MsType msType, Scan scanNumber) throws IOException {
-    writeHeader(writer, row, raw, polarity, msType, scanNumber, null);
+    writeHeader(writer, row, raw, polarity, msType, -1, null);
   }
 
   private void writeHeader(BufferedWriter writer, FeatureListRow row, RawDataFile raw, char polarity,
-      MsType msType, Scan scanNumber, List<String> sources) throws IOException {
+      MsType msType, int scanNumber, List<String> sources) throws IOException {
     final Feature feature = row.getFeature(raw);
     writer.write("BEGIN IONS");
     writer.newLine();
@@ -351,7 +351,7 @@ public class SiriusExportTask extends AbstractTask {
       writer.write(feature.getRawDataFile().getName());
       writer.newLine();
     }
-    if (scanNumber != null) {
+    if (scanNumber != -1) {
       writer.write("SCANS=");
       writer.write(String.valueOf(scanNumber));
       writer.newLine();

--- a/src/main/java/io/github/mzmine/modules/io/sqlexport/SQLExportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/sqlexport/SQLExportTask.java
@@ -276,14 +276,12 @@ class SQLExportTask extends AbstractTask {
               statement.setBlob(i + 1, is);
               break;
             case MSMS:
-              int msmsScanNum = row.getBestFeature().getMostIntenseFragmentScanNumber();
+              Scan msmsScan = row.getBestFeature().getMostIntenseFragmentScan();
               // Check if there is any MS/MS scan
-              if (msmsScanNum <= 0) {
+              if (msmsScan == null) {
                 statement.setNull(i + 1, Types.BLOB);
                 break;
               }
-              RawDataFile dataFile = row.getBestFeature().getRawDataFile();
-              Scan msmsScan = dataFile.getScan(msmsScanNum);
               MassList msmsMassList = msmsScan.getMassList(dataValue);
               // Check if there is a masslist for the scan
               if (msmsMassList == null) {

--- a/src/main/java/io/github/mzmine/modules/tools/msmsspectramerge/Ms2QualityScoreModel.java
+++ b/src/main/java/io/github/mzmine/modules/tools/msmsspectramerge/Ms2QualityScoreModel.java
@@ -53,7 +53,7 @@ public interface Ms2QualityScoreModel {
               : Range.closed(0d, fragmentScan.feature.getMZ() - 20d);
       for (int i = 0; i < scores.length; ++i) {
         double tic = ScanUtils
-            .calculateTIC(fragmentScan.origin.getScan(fragmentScan.ms2ScanNumbers[i]), mzRange);
+            .calculateTIC(fragmentScan.ms2ScanNumbers[i], mzRange);
         scores[i] = tic;
       }
       return scores;
@@ -68,8 +68,7 @@ public interface Ms2QualityScoreModel {
           fragmentScan.feature.getMZ() < 75 ? Range.closed(50d, fragmentScan.feature.getMZ())
               : Range.closed(0d, fragmentScan.feature.getMZ());
       for (int i = 0; i < scores.length; ++i) {
-        DataPoint[] spectrum = fragmentScan.origin.getScan(fragmentScan.ms2ScanNumbers[i])
-            .getMassList(fragmentScan.massList).getDataPoints();
+        DataPoint[] spectrum = fragmentScan.ms2ScanNumbers[i].getMassList(fragmentScan.massList).getDataPoints();
         Arrays.sort(spectrum, (u, v) -> Double.compare(v.getIntensity(), u.getIntensity()));
         for (int j = 0; j < spectrum.length; ++j)
           scores[i] += spectrum[j].getIntensity();

--- a/src/main/java/io/github/mzmine/modules/tools/msmsspectramerge/MsMsSpectraMergeModule.java
+++ b/src/main/java/io/github/mzmine/modules/tools/msmsspectramerge/MsMsSpectraMergeModule.java
@@ -345,7 +345,7 @@ public class MsMsSpectraMergeModule implements MZmineModule {
     if (scores[best] <= 0)
       return MergedSpectrum.empty(totalNumberOfScans);
     final List<Scan> scansToMerge = new ArrayList<>();
-    scansToMerge.add(scans.origin.getScan(scans.ms2ScanNumbers[best]));
+    scansToMerge.add(scans.ms2ScanNumbers[best]);
     final Scan firstScan = scansToMerge.get(0);
     final MassList firstML = firstScan.getMassList(massList);
     if (firstML == null)
@@ -360,11 +360,11 @@ public class MsMsSpectraMergeModule implements MZmineModule {
     for (int i = 1; i < scores.length; ++i) {
       int k = best - i;
       if (k >= 0 && scores[k] > scoreThreshold) {
-        scansToMerge.add(scans.origin.getScan(scans.ms2ScanNumbers[k]));
+        scansToMerge.add(scans.ms2ScanNumbers[k]);
       }
       k = best + i;
       if (k < scores.length && scores[k] > scoreThreshold) {
-        scansToMerge.add(scans.origin.getScan(scans.ms2ScanNumbers[k]));
+        scansToMerge.add(scans.ms2ScanNumbers[k]);
       }
     }
     if (scansToMerge.size() == 1) {

--- a/src/main/java/io/github/mzmine/modules/tools/qualityparameters/QualityParameters.java
+++ b/src/main/java/io/github/mzmine/modules/tools/qualityparameters/QualityParameters.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.modules.tools.qualityparameters;
 
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
 import java.util.List;
 import com.google.common.collect.Range;
@@ -44,7 +45,7 @@ public class QualityParameters {
       Property<Float> height = peak.getHeightProperty();
       Property<Float> rt = peak.getRTProperty();
 
-      List<Integer> scanNumbers = peak.getScanNumbersProperty();
+      List<Scan> scanNumbers = peak.getScanNumbers();
       RawDataFile dataFile = peak.getRawDataFile();
       List<DataPoint> dps = peak.getDataPointsProperty();
       if (height.getValue() == null || rt.getValue() == null || dataFile == null
@@ -97,7 +98,7 @@ public class QualityParameters {
     Float height = feature.getHeight();
     Float rt = feature.getRT();
 
-    List<Integer> scanNumbers = feature.getScanNumbers();
+    List<Scan> scanNumbers = feature.getScanNumbers();
     RawDataFile dataFile = feature.getRawDataFile();
     List<DataPoint> dps = feature.getDataPoints();
     if (height == null || rt == null || dataFile == null
@@ -129,7 +130,7 @@ public class QualityParameters {
     Float height = feature.getHeight();
     Float rt = feature.getRT();
 
-    List<Integer> scanNumbers = feature.getScanNumbers();
+    List<Scan> scanNumbers = feature.getScanNumbers();
     RawDataFile dataFile = feature.getRawDataFile();
     List<DataPoint> dps = feature.getDataPoints();
     if (height == null || rt == null || dataFile == null
@@ -161,7 +162,7 @@ public class QualityParameters {
     Float height = feature.getHeight();
     Float rt = feature.getRT();
 
-    List<Integer> scanNumbers = feature.getScanNumbers();
+    List<Scan> scanNumbers = feature.getScanNumbers();
     RawDataFile dataFile = feature.getRawDataFile();
     List<DataPoint> dps = feature.getDataPoints();
     if (height == null || rt == null || dataFile == null
@@ -187,15 +188,15 @@ public class QualityParameters {
     return (float) af;
   }
 
-  private static double[] peakFindRTs(double intensity, float featureRT, List<Integer> scanNumbers,
+  private static double[] peakFindRTs(double intensity, float featureRT, List<Scan> scanNumbers,
       List<DataPoint> dps, RawDataFile dataFile, Range<Float> rtRange) {
     return peakFindRTs(intensity, featureRT,
-        scanNumbers.stream().mapToInt(i -> i.intValue()).toArray(), dps.toArray(DataPoint[]::new), //
+        scanNumbers, dps.toArray(DataPoint[]::new), //
         dataFile, //
         Range.closed(rtRange.lowerEndpoint().doubleValue(), rtRange.upperEndpoint().doubleValue()));
   }
 
-  private static double[] peakFindRTs(double intensity, double featureRT, int[] scanNumbers,
+  private static double[] peakFindRTs(double intensity, double featureRT, List<Scan> scanNumbers,
       DataPoint[] dps, RawDataFile dataFile, Range<Double> rtRange) {
 
     assert scanNumbers != null;
@@ -212,16 +213,16 @@ public class QualityParameters {
     // Find the data points closet to input intensity on both side of the
     // peak apex
     DataPoint lastDP = dps[0];
-    double lastRT = dataFile.getScan(scanNumbers[0]).getRetentionTime();
+    double lastRT = scanNumbers.get(0).getRetentionTime();
     DataPoint dp = dps[1];
-    double rt = dataFile.getScan(scanNumbers[1]).getRetentionTime();
-    for (int i = 1; i < scanNumbers.length - 1; i++) {
+    double rt = scanNumbers.get(1).getRetentionTime();
+    for (int i = 1; i < scanNumbers.size() - 1; i++) {
       DataPoint nextDP = dps[i + 1];
-      double nextRT = dataFile.getScan(scanNumbers[i + 1]).getRetentionTime();
+      double nextRT = scanNumbers.get(i + 1).getRetentionTime();
 
       if (dp != null) {
         currentDiff = Math.abs(intensity - dp.getIntensity());
-        currentRT = dataFile.getScan(scanNumbers[i]).getRetentionTime();
+        currentRT = scanNumbers.get(i).getRetentionTime();
         if (currentDiff < lastDiff1 && currentDiff > 0 && currentRT <= featureRT
             && nextDP != null) {
           x1 = rt;

--- a/src/main/java/io/github/mzmine/modules/visualization/chromatogram/ChromatogramCursorPosition.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/chromatogram/ChromatogramCursorPosition.java
@@ -18,6 +18,7 @@
 package io.github.mzmine.modules.visualization.chromatogram;
 
 import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.Scan;
 
 /**
  *
@@ -26,22 +27,22 @@ public class ChromatogramCursorPosition {
 
   private double mzValue, retentionTime, intensityValue;
   private RawDataFile dataFile;
-  private int scanNumber;
+  private Scan scan;
 
   /**
    * @param retentionTime
    * @param mzValue
    * @param intensityValue
-   * @param rawDataFile
-   * @param scanNumber
+   * @param dataFile
+   * @param scan
    */
   public ChromatogramCursorPosition(double retentionTime, double mzValue, double intensityValue,
-      RawDataFile dataFile, int scanNumber) {
+      RawDataFile dataFile, Scan scan) {
     this.retentionTime = retentionTime;
     this.mzValue = mzValue;
     this.intensityValue = intensityValue;
     this.dataFile = dataFile;
-    this.scanNumber = scanNumber;
+    this.scan = scan;
   }
 
   /**
@@ -103,15 +104,15 @@ public class ChromatogramCursorPosition {
   /**
    * @return Returns the scanNumber.
    */
-  public int getScanNumber() {
-    return scanNumber;
+  public Scan getScan() {
+    return scan;
   }
 
   /**
-   * @param scanNumber The scanNumber to set.
+   * @param scan The scan to set.
    */
-  public void setScanNumber(int scanNumber) {
-    this.scanNumber = scanNumber;
+  public void setScan(Scan scan) {
+    this.scan = scan;
   }
 
 }

--- a/src/main/java/io/github/mzmine/modules/visualization/chromatogram/FeatureDataSet.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/chromatogram/FeatureDataSet.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.modules.visualization.chromatogram;
 
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.util.FeatureUtils;
 import java.util.Arrays;
@@ -56,9 +57,9 @@ public class FeatureDataSet extends AbstractXYDataset {
     feature = p;
     name = id;
 
-    final ObservableList<Integer> scanNumbers = feature.getScanNumbers();
+    final ObservableList<Scan> scanNumbers = feature.getScanNumbers();
     final RawDataFile dataFile = feature.getRawDataFile();
-    final int peakScanNumber = feature.getRepresentativeScanNumber();
+    final Scan peakScanNumber = feature.getRepresentativeScan();
 
     // Copy peak data.
     final int scanCount = scanNumbers.size();
@@ -69,14 +70,14 @@ public class FeatureDataSet extends AbstractXYDataset {
     for (int i = 0; i < scanCount; i++) {
 
       // Representative scan number?
-      final int scanNumber = scanNumbers.get(i);
-      if (peakIndex < 0 && scanNumber == peakScanNumber) {
+      final Scan scanNumber = scanNumbers.get(i);
+      if (peakIndex < 0 && Objects.equals(scanNumber, peakScanNumber)) {
 
         peakIndex = i;
       }
 
       // Copy RT and m/z.
-      retentionTimes[i] = dataFile.getScan(scanNumber).getRetentionTime();
+      retentionTimes[i] = scanNumber.getRetentionTime();
       final DataPoint dataPoint = feature.getDataPoint(scanNumber);
       if (dataPoint == null) {
 

--- a/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICDataSet.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICDataSet.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import org.jfree.data.xy.AbstractXYZDataset;
 import com.google.common.collect.Range;
 import com.google.common.primitives.Ints;
@@ -64,7 +66,7 @@ public class TICDataSet extends AbstractXYZDataset implements Task {
 
   private final RawDataFile dataFile;
 
-  private final Scan scans[];
+  private final List<Scan> scans;
   private final int totalScans;
   private int processedScans;
 
@@ -89,7 +91,7 @@ public class TICDataSet extends AbstractXYZDataset implements Task {
    * @param rangeMZ range of m/z to plot.
    * @param window visualizer window.
    */
-  public TICDataSet(final RawDataFile file, final Scan scans[], final Range<Double> rangeMZ,
+  public TICDataSet(final RawDataFile file, final ObservableList<Scan> scans, final Range<Double> rangeMZ,
       final TICVisualizerTab window) {
     this(file, scans, rangeMZ, window,
         ((window != null) ? window.getPlotType() : TICPlotType.BASEPEAK));
@@ -105,13 +107,13 @@ public class TICDataSet extends AbstractXYZDataset implements Task {
    * @param window visualizer window.
    * @param plotType plot type.
    */
-  public TICDataSet(final RawDataFile file, final Scan scans[], final Range<Double> rangeMZ,
+  public TICDataSet(final RawDataFile file, final List<Scan> scans, final Range<Double> rangeMZ,
       final TICVisualizerTab window, TICPlotType plotType) {
 
     mzRange = rangeMZ;
     dataFile = file;
     this.scans = scans;
-    totalScans = scans.length;
+    totalScans = scans.size();
     basePeakValues = new double[totalScans];
     intensityValues = new double[totalScans];
     rtValues = new double[totalScans];
@@ -138,15 +140,9 @@ public class TICDataSet extends AbstractXYZDataset implements Task {
     dataFile = feature.getRawDataFile();
     mzRange =  feature.getRawDataPointsMZRange();
     Range<Float> rtRange = feature.getRawDataPointsRTRange();
-    List<Integer> scanNums = feature.getScanNumbers();
+    scans = feature.getScanNumbers();
 
-    scans = new Scan[scanNums.size()];
-
-    for (int i = 0; i < scanNums.size(); i++) {
-      scans[i] = dataFile.getScan(scanNums.get(i));
-    }
-
-    totalScans = scans.length;
+    totalScans = scans.size();
     basePeakValues = new double[totalScans];
     intensityValues = new double[totalScans];
     rtValues = new double[totalScans];
@@ -161,6 +157,10 @@ public class TICDataSet extends AbstractXYZDataset implements Task {
 
     // Start-up the refresh task.
     MZmineCore.getTaskController().addTask(this, TaskPriority.HIGH);
+  }
+
+  public TICDataSet(RawDataFile newFile, Scan[] scans, Range<Double> mzRange, TICVisualizerTab window) {
+    this(newFile, FXCollections.observableArrayList(scans),mzRange, window);
   }
 
   @Override
@@ -265,13 +265,11 @@ public class TICDataSet extends AbstractXYZDataset implements Task {
     return index;
   }
 
-  public int getScanNumber(final int item) {
-
-    return scans[item].getScanNumber();
+  public Scan getScan(final int item) {
+    return scans.get(item);
   }
 
   public RawDataFile getDataFile() {
-
     return dataFile;
   }
 
@@ -364,7 +362,7 @@ public class TICDataSet extends AbstractXYZDataset implements Task {
     for (int index = 0; status != TaskStatus.CANCELED && index < totalScans; index++) {
 
       // Current scan.
-      final Scan scan = scans[index];
+      final Scan scan = scans.get(index);
 
       // Determine base peak value.
       final DataPoint basePeak =
@@ -435,31 +433,31 @@ public class TICDataSet extends AbstractXYZDataset implements Task {
     return TaskPriority.NORMAL;
   }
 
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof TICDataSet)) {
-      return false;
-    }
-    TICDataSet that = (TICDataSet) o;
-    return totalScans == that.totalScans && Double.compare(that.intensityMin, intensityMin) == 0
-        && Double.compare(that.intensityMax, intensityMax) == 0
-        && Objects.equals(dataFile, that.dataFile) && Arrays.equals(scans, that.scans)
-        && Arrays.equals(basePeakValues, that.basePeakValues)
-        && Arrays.equals(intensityValues, that.intensityValues)
-        && Arrays.equals(rtValues, that.rtValues) && Objects.equals(mzRange, that.mzRange)
-        && plotType == that.plotType;
-  }
-
-  @Override
-  public int hashCode() {
-    int result = Objects.hash(dataFile, totalScans, mzRange, intensityMin, intensityMax, plotType);
-    result = 31 * result + Arrays.hashCode(scans);
-    result = 31 * result + Arrays.hashCode(basePeakValues);
-    result = 31 * result + Arrays.hashCode(intensityValues);
-    result = 31 * result + Arrays.hashCode(rtValues);
-    return result;
-  }
+//  @Override
+//  public boolean equals(Object o) {
+//    if (this == o) {
+//      return true;
+//    }
+//    if (!(o instanceof TICDataSet)) {
+//      return false;
+//    }
+//    TICDataSet that = (TICDataSet) o;
+//    return totalScans == that.totalScans && Double.compare(that.intensityMin, intensityMin) == 0
+//        && Double.compare(that.intensityMax, intensityMax) == 0
+//        && Objects.equals(dataFile, that.dataFile) && Arrays.equals(scans, that.scans)
+//        && Arrays.equals(basePeakValues, that.basePeakValues)
+//        && Arrays.equals(intensityValues, that.intensityValues)
+//        && Arrays.equals(rtValues, that.rtValues) && Objects.equals(mzRange, that.mzRange)
+//        && plotType == that.plotType;
+//  }
+//
+//  @Override
+//  public int hashCode() {
+//    int result = Objects.hash(dataFile, totalScans, mzRange, intensityMin, intensityMax, plotType);
+//    result = 31 * result + Arrays.hashCode(scans);
+//    result = 31 * result + Arrays.hashCode(basePeakValues);
+//    result = 31 * result + Arrays.hashCode(intensityValues);
+//    result = 31 * result + Arrays.hashCode(rtValues);
+//    return result;
+//  }
 }

--- a/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICPlot.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICPlot.java
@@ -786,7 +786,7 @@ public class TICPlot extends EChartViewer implements LabelColorMatch {
           mz = dataSet.getZValue(0, index);
         }
         return new ChromatogramCursorPosition(selectedRT, mz, selectedIT, dataSet.getDataFile(),
-            dataSet.getScanNumber(index));
+            dataSet.getScan(index));
       }
     }
     return null;

--- a/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICSumDataSet.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICSumDataSet.java
@@ -77,8 +77,7 @@ public class TICSumDataSet extends AbstractXYZDataset implements Task {
   /**
    * Create the data set.
    *
-   * @param file           data file to plot.
-   * @param theScanNumbers scans to plot.
+   * @param files           data file to plot.
    * @param rangeMZ        range of m/z to plot.
    * @param window         visualizer window.
    */
@@ -92,8 +91,7 @@ public class TICSumDataSet extends AbstractXYZDataset implements Task {
    * Create the data set + possibility to specify a plot type, even outside a "TICVisualizerWindow"
    * context.
    *
-   * @param file           data file to plot.
-   * @param theScanNumbers scans to plot.
+   * @param files           data file to plot.
    * @param rangeMZ        range of m/z to plot.
    * @param window         visualizer window.
    * @param plotType       plot type.
@@ -121,7 +119,7 @@ public class TICSumDataSet extends AbstractXYZDataset implements Task {
   private void calcTotalScans() {
     totalScans = 0;
     for (RawDataFile raw : dataFiles) {
-      int[] scans = raw.getScanNumbers(1, rangeRT);
+      Scan[] scans = raw.getScanNumbers(1, rangeRT);
       totalScans += scans.length;
     }
   }
@@ -225,11 +223,11 @@ public class TICSumDataSet extends AbstractXYZDataset implements Task {
     // all raw data files
     for (int r = 0; r < dataFiles.length; r++) {
       RawDataFile raw = dataFiles[r];
-      int[] scans = raw.getScanNumbers(1, rangeRT);
+      Scan[] scans = raw.getScanNumbers(1, rangeRT);
       // Process each scan.
       for (int index = 0; status != TaskStatus.CANCELED && index < scans.length; index++) {
         // Current scan.
-        final Scan scan = raw.getScan(scans[index]);
+        final Scan scan = scans[index];
         float rt = scan.getRetentionTime();
         double mzBasePeak = 0;
         double intensityBasePeak = 0;

--- a/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICToolTipGenerator.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICToolTipGenerator.java
@@ -49,7 +49,7 @@ public class TICToolTipGenerator implements XYToolTipGenerator {
 
       final TICDataSet ticDataSet = (TICDataSet) dataSet;
 
-      toolTip = "Scan #" + ticDataSet.getScanNumber(item) + "\nRetention time: "
+      toolTip = "Scan #" + ticDataSet.getScan(item).getScanNumber() + "\nRetention time: "
           + rtFormat.format(rtValue) + "\nBase peak m/z: "
           + mzFormat.format(ticDataSet.getZValue(series, item)) + "\nIntensity: "
           + intensityFormat.format(intValue);

--- a/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICVisualizerTab.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICVisualizerTab.java
@@ -152,7 +152,7 @@ public class TICVisualizerTab extends MZmineTab {
     showSpectrumBtn.setOnAction(e -> {
       ChromatogramCursorPosition pos = getCursorPosition();
       if (pos != null) {
-        SpectraVisualizerModule.addNewSpectrumTab(pos.getDataFile(), pos.getScanNumber());
+        SpectraVisualizerModule.addNewSpectrumTab(pos.getDataFile(), pos.getScan());
       }
     });
 
@@ -336,7 +336,7 @@ public class TICVisualizerTab extends MZmineTab {
 
     if (pos != null) {
       subTitle.append("Selected scan #");
-      subTitle.append(pos.getScanNumber());
+      subTitle.append(pos.getScan().getScanNumber());
       if (ticDataSets.size() > 1) {
         subTitle.append(" (" + pos.getDataFile() + ")");
       }
@@ -504,7 +504,7 @@ public class TICVisualizerTab extends MZmineTab {
         }
         ChromatogramCursorPosition pos = new ChromatogramCursorPosition(selectedRT, mz, selectedIT,
             dataSet.getDataFile(),
-            dataSet.getScanNumber(index));
+            dataSet.getScan(index));
         return pos;
       }
     }

--- a/src/main/java/io/github/mzmine/modules/visualization/chromatogramandspectra/ChromatogramAndSpectraVisualizer.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/chromatogramandspectra/ChromatogramAndSpectraVisualizer.java
@@ -26,6 +26,7 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.Objects;
 import java.util.logging.Logger;
+import javafx.collections.ObservableList;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.jfree.chart.plot.ValueMarker;
@@ -245,8 +246,7 @@ public class ChromatogramAndSpectraVisualizer extends SplitPane {
     // update feature data sets if the tolerance for the extraction changes
     chromMzToleranceProperty().addListener((obs, old, val) -> {
       if (getChromPosition() != null) {
-        updateFeatureDataSets(getChromPosition().getDataFile()
-            .getScan(getChromPosition().getScanNumber()).getHighestDataPoint().getMZ());
+        updateFeatureDataSets(getChromPosition().getScan().getHighestDataPoint().getMZ());
       }
     });
 
@@ -272,16 +272,34 @@ public class ChromatogramAndSpectraVisualizer extends SplitPane {
     setOnKeyPressed(e -> {
       if (e.getCode() == KeyCode.LEFT && e.isControlDown() && getChromPosition() != null) {
         logger.finest("Loading previous scan");
-        setFocusedScan(getChromPosition().getDataFile(), getChromPosition().getScanNumber() - 1);
+        Scan scan = getScan(getChromPosition().getDataFile(), getChromPosition().getScan(), -1);
+        setFocusedScan(getChromPosition().getDataFile(), scan);
         requestFocus();
         e.consume();
       } else if (e.getCode() == KeyCode.RIGHT && e.isControlDown() && getChromPosition() != null) {
         logger.finest("Loading next scan");
-        setFocusedScan(getChromPosition().getDataFile(), getChromPosition().getScanNumber() + 1);
+        Scan scan = getScan(getChromPosition().getDataFile(), getChromPosition().getScan(), +1);
+        setFocusedScan(getChromPosition().getDataFile(), scan);
         requestFocus();
         e.consume();
       }
     });
+  }
+
+  private Scan getScan(RawDataFile dataFile, Scan scan, int shift) {
+    if(!Objects.equals(scan.getDataFile(), dataFile)) {
+      throw new IllegalArgumentException("data file and the scan data file need to be the same");
+    }
+    ObservableList<Scan> scans = dataFile.getScans();
+    int index = scans.indexOf(scan);
+    if(index==-1)
+      return null;
+    else if(shift>0){
+      return scans.get(Math.min(index+shift, scans.size()-1));
+    }
+    else {
+      return scans.get(Math.max(index+shift, 0));
+    }
   }
 
   private void updateAllChromatogramDataSets() {
@@ -351,7 +369,7 @@ public class ChromatogramAndSpectraVisualizer extends SplitPane {
         (getMzRange() != null && pnChromControls.cbXIC.isSelected()) ? getMzRange()
             : rawDataFile.getDataMZRange();
 
-    TICDataSet ticDataset = new TICDataSet(rawDataFile, scans, rawMZRange, null, getPlotType());
+    TICDataSet ticDataset = new TICDataSet(rawDataFile, List.of(scans), rawMZRange, null, getPlotType());
     filesAndDataSets.put(rawDataFile, ticDataset);
     chromPlot.addTICDataSet(ticDataset, rawDataFile.getColorAWT());
 
@@ -383,7 +401,7 @@ public class ChromatogramAndSpectraVisualizer extends SplitPane {
 
     updateChromatogramDomainMarker(pos);
     // update feature data sets
-    updateFeatureDataSets(file.getScan(pos.getScanNumber()).getHighestDataPoint().getMZ());
+    updateFeatureDataSets(pos.getScan().getHighestDataPoint().getMZ());
     // update spectrum plots
     updateSpectraPlot(filesAndDataSets.keySet(), pos);
   }
@@ -412,10 +430,10 @@ public class ChromatogramAndSpectraVisualizer extends SplitPane {
     chromPlot.getXYPlot().clearDomainMarkers();
 
     if (rtMarker == null) {
-      rtMarker = new ValueMarker(pos.getDataFile().getScan(pos.getScanNumber()).getRetentionTime());
+      rtMarker = new ValueMarker(pos.getScan().getRetentionTime());
       rtMarker.setStroke(MARKER_STROKE);
     } else {
-      rtMarker.setValue(pos.getDataFile().getScan(pos.getScanNumber()).getRetentionTime());
+      rtMarker.setValue(pos.getScan().getRetentionTime());
     }
     rtMarker.setPaint(MZmineCore.getConfiguration().getDefaultColorPalette().getNeutralColorAWT());
 
@@ -443,12 +461,12 @@ public class ChromatogramAndSpectraVisualizer extends SplitPane {
    * @param rawDataFile The rawDataFile to focus.
    * @param scanNum The scan number.
    */
-  public void setFocusedScan(@Nonnull RawDataFile rawDataFile, int scanNum) {
-    if (!filesAndDataSets.keySet().contains(rawDataFile) || rawDataFile.getScan(scanNum) == null) {
+  public void setFocusedScan(@Nonnull RawDataFile rawDataFile, Scan scanNum) {
+    if (!filesAndDataSets.keySet().contains(rawDataFile) || scanNum == null) {
       return;
     }
     ChromatogramCursorPosition pos = new ChromatogramCursorPosition(
-        rawDataFile.getScan(scanNum).getRetentionTime(), 0, 0, rawDataFile, scanNum);
+        scanNum.getRetentionTime(), 0, 0, rawDataFile, scanNum);
     setChromPosition(pos);
   }
 
@@ -459,9 +477,9 @@ public class ChromatogramAndSpectraVisualizer extends SplitPane {
    * @param rawDataFile The raw data file
    * @param scanNum The number of the scan
    */
-  private void forceScanDataSet(@Nonnull RawDataFile rawDataFile, int scanNum) {
+  private void forceScanDataSet(@Nonnull RawDataFile rawDataFile, Scan scanNum) {
     spectrumPlot.removeAllDataSets();
-    ScanDataSet dataSet = new ScanDataSet(rawDataFile.getScan(scanNum));
+    ScanDataSet dataSet = new ScanDataSet(scanNum);
     spectrumPlot.addDataSet(dataSet, rawDataFile.getColorAWT(), false);
     spectrumPlot.setTitle(rawDataFile.getName() + "(#" + scanNum + ")", "");
   }
@@ -473,12 +491,12 @@ public class ChromatogramAndSpectraVisualizer extends SplitPane {
    * @param rawDataFile The rawDataFile to focus.
    * @param scanNum The scan number.
    */
-  public void setFocusedScanSilent(@Nonnull RawDataFile rawDataFile, int scanNum) {
-    if (!filesAndDataSets.keySet().contains(rawDataFile) || rawDataFile.getScan(scanNum) == null) {
+  public void setFocusedScanSilent(@Nonnull RawDataFile rawDataFile, Scan scanNum) {
+    if (!filesAndDataSets.keySet().contains(rawDataFile) || scanNum == null) {
       return;
     }
     ChromatogramCursorPosition pos = new ChromatogramCursorPosition(
-        rawDataFile.getScan(scanNum).getRetentionTime(), 0, 0, rawDataFile, scanNum);
+        scanNum.getRetentionTime(), 0, 0, rawDataFile, scanNum);
     updateChromatogramDomainMarker(pos);
     forceScanDataSet(rawDataFile, scanNum);
   }

--- a/src/main/java/io/github/mzmine/modules/visualization/chromatogramandspectra/SpectraDataSetCalc.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/chromatogramandspectra/SpectraDataSetCalc.java
@@ -71,14 +71,13 @@ public class SpectraDataSetCalc extends AbstractTask {
     if (showSpectraOfEveryRawFile) {
       double rt = pos.getRetentionTime();
       rawDataFiles.forEach(rawDataFile -> {
-        int num = -1;
+        Scan scan = null;
         if (scanSelection.getMsLevel() != null) {
-          num = rawDataFile.getScanNumberAtRT((float) rt, scanSelection.getMsLevel());
+          scan = rawDataFile.getScanNumberAtRT((float) rt, scanSelection.getMsLevel());
         } else {
-          num = rawDataFile.getScanNumberAtRT((float) rt);
+          scan = rawDataFile.getScanNumberAtRT((float) rt);
         }
-        if (num != -1) {
-          Scan scan = rawDataFile.getScan(num);
+        if (scan != null) {
           ScanDataSet dataSet = new ScanDataSet(scan);
           filesAndDataSets.put(rawDataFile, dataSet);
         }
@@ -90,7 +89,7 @@ public class SpectraDataSetCalc extends AbstractTask {
 
       });
     } else {
-      ScanDataSet dataSet = new ScanDataSet(pos.getDataFile().getScan(pos.getScanNumber()));
+      ScanDataSet dataSet = new ScanDataSet(pos.getScan());
       filesAndDataSets.put(pos.getDataFile(), dataSet);
       doneFiles++;
     }

--- a/src/main/java/io/github/mzmine/modules/visualization/combinedmodule/CombinedModuleDataset.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/combinedmodule/CombinedModuleDataset.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Vector;
 import javafx.application.Platform;
+import javafx.collections.ObservableList;
 import org.jfree.chart.labels.XYToolTipGenerator;
 import org.jfree.data.xy.AbstractXYDataset;
 import org.jfree.data.xy.XYDataset;
@@ -43,7 +44,8 @@ public class CombinedModuleDataset extends AbstractXYDataset implements Task, XY
   private Range<Float> totalRTRange;
   private CombinedModuleVisualizerTabController visualizer;
   private TaskStatus status = TaskStatus.WAITING;
-  private int processedScans, scanNumbers[];
+  private int processedScans;
+  private ObservableList<Scan> scanNumbers;
   private HashMap<Integer, Vector<CombinedModuleDataPoint>> dataSeries;
   int totalScans;
   private AxisType xAxisType, yAxisType;
@@ -67,8 +69,8 @@ public class CombinedModuleDataset extends AbstractXYDataset implements Task, XY
     this.colorScale = colorScale;
     this.massListName = massList;
 
-    scanNumbers = rawDataFile.getScanNumbers();
-    totalScans = scanNumbers.length;
+    scanNumbers = rawDataFile.getScans();
+    totalScans = scanNumbers.size();
     dataSeries = new HashMap<Integer, Vector<CombinedModuleDataPoint>>();
     dataSeries.put(RAW_LEVEL, new Vector<CombinedModuleDataPoint>(totalScans));
     dataSeries.put(PRECURSOR_LEVEL, new Vector<CombinedModuleDataPoint>(totalScans));
@@ -85,11 +87,10 @@ public class CombinedModuleDataset extends AbstractXYDataset implements Task, XY
 
     ArrayList<Float> retentionList = new ArrayList<Float>();
     ArrayList<Double> precursorList = new ArrayList<Double>();
-    for (int scanNumber : scanNumbers) {
+    for (Scan scan : scanNumbers) {
       if (status == TaskStatus.CANCELED) {
         return;
       }
-      Scan scan = rawDataFile.getScan(scanNumber);
 
       //ignore scans of MS level 1
       if (scan.getMSLevel() == 1) {

--- a/src/main/java/io/github/mzmine/modules/visualization/mobilogram/MobilogramVisualizerController.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/mobilogram/MobilogramVisualizerController.java
@@ -98,8 +98,9 @@ public class MobilogramVisualizerController {
         MobilityDataPoint selectedDp =
             mobilogramSelector.getValue().getDataPoints().get(valueIndex);
         Frame frame = frameSelector.getValue();
-        SpectraVisualizerModule.addNewSpectrumTab(frame.getDataFile(),
-            selectedDp.getScanNum());
+        // todo check correct?
+        SpectraVisualizerModule.addNewSpectrumTab(frame.getDataFile(), frame);
+//            selectedDp.getScanNum());
       }
     });
     mobilogramChart.getContextMenu().getItems().add(showSpectrum);

--- a/src/main/java/io/github/mzmine/modules/visualization/mobilogram/MobilogramVisualizerController.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/mobilogram/MobilogramVisualizerController.java
@@ -97,7 +97,8 @@ public class MobilogramVisualizerController {
       if (valueIndex != -1) {
         MobilityDataPoint selectedDp =
             mobilogramSelector.getValue().getDataPoints().get(valueIndex);
-        SpectraVisualizerModule.addNewSpectrumTab(frameSelector.getValue().getDataFile(),
+        Frame frame = frameSelector.getValue();
+        SpectraVisualizerModule.addNewSpectrumTab(frame.getDataFile(),
             selectedDp.getScanNum());
       }
     });

--- a/src/main/java/io/github/mzmine/modules/visualization/msms/FeatureDataPoint.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/msms/FeatureDataPoint.java
@@ -19,25 +19,26 @@
 package io.github.mzmine.modules.visualization.msms;
 
 import io.github.mzmine.datamodel.DataPoint;
+import io.github.mzmine.datamodel.Scan;
 
 /**
  * This class represents one feature datapoint (retention time and m/z)
  */
 class FeatureDataPoint {
 
-  private int scanNumber;
+  private Scan scanNumber;
   private double rt;
   private DataPoint dataPoint;
 
   /**
    */
-  FeatureDataPoint(int scanNumber, double rt, DataPoint dataPoint) {
+  FeatureDataPoint(Scan scanNumber, double rt, DataPoint dataPoint) {
     this.scanNumber = scanNumber;
     this.rt = rt;
     this.dataPoint = dataPoint;
   }
 
-  int getScanNumber() {
+  Scan getScan() {
     return scanNumber;
   }
 

--- a/src/main/java/io/github/mzmine/modules/visualization/msms/FeatureDataSet.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/msms/FeatureDataSet.java
@@ -51,16 +51,12 @@ class FeatureDataSet extends AbstractXYDataset {
     Feature allFeatures[] = featureList.getFeatures(dataFile).toArray(Feature[]::new);
 
     for (Feature feature : allFeatures) {
-
-      int scanNumbers[] = feature.getScanNumbers().stream().mapToInt(n -> n).toArray();
-
-      for (int scan : scanNumbers) {
-
-        float rt = dataFile.getScan(scan).getRetentionTime();
-        DataPoint dp = feature.getDataPoint(scan);
+      for (int i=0; i<feature.getNumberOfDataPoints(); i++) {
+        float rt = feature.getRetentionTimeAtIndex(i);
+        DataPoint dp = feature.getDataPointAtIndex(i);
         if (dp != null) {
           if (rtRange.contains(rt) && mzRange.contains(dp.getMZ())) {
-            FeatureDataPoint newDP = new FeatureDataPoint(scan, rt, dp);
+            FeatureDataPoint newDP = new FeatureDataPoint(feature.getScanAtIndex(i), rt, dp);
             thisFeatureDataPoints.add(newDP);
           }
         }

--- a/src/main/java/io/github/mzmine/modules/visualization/msms/FeatureToolTipGenerator.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/msms/FeatureToolTipGenerator.java
@@ -52,7 +52,7 @@ class FeatureToolTipGenerator implements XYToolTipGenerator {
     double rtValue = dataPoint.getRT();
     double intValue = dataPoint.getIntensity();
     double mzValue = dataPoint.getMZ();
-    int scanNumber = dataPoint.getScanNumber();
+    int scanNumber = dataPoint.getScan().getScanNumber();
 
     String toolTip =
         "Peak: " + feature + "\nStatus: " + feature.getFeatureStatus() + "\nFeature list row: " + row

--- a/src/main/java/io/github/mzmine/modules/visualization/msms/MsMsVisualizerTab.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/msms/MsMsVisualizerTab.java
@@ -233,7 +233,7 @@ public class MsMsVisualizerTab extends MZmineTab {
       double intensity = (double) dataset.getZ(0, index);
       ChromatogramCursorPosition pos = new ChromatogramCursorPosition(selectedRT, selectedMZ,
           intensity,
-          dataset.getDataFile(), dataset.getScanNumber(index));
+          dataset.getDataFile(), dataset.getScan(index));
       return pos;
     }
 

--- a/src/main/java/io/github/mzmine/modules/visualization/neutralloss/NeutralLossDataPoint.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/neutralloss/NeutralLossDataPoint.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.modules.visualization.neutralloss;
 
+import io.github.mzmine.datamodel.Scan;
 import java.text.NumberFormat;
 
 import io.github.mzmine.main.MZmineCore;
@@ -28,7 +29,7 @@ import io.github.mzmine.main.MZmineCore;
 class NeutralLossDataPoint {
 
   private double mzValue;
-  private int scanNumber;
+  private Scan scan;
   private double precursorMZ;
   private int precursorCharge;
   private double retentionTime;
@@ -44,14 +45,14 @@ class NeutralLossDataPoint {
    * @param precursorCharge
    * @param retentionTime
    */
-  NeutralLossDataPoint(double mzValue, int scanNumber, double precursorMZ, int precursorCharge,
+  NeutralLossDataPoint(double mzValue, Scan scan, double precursorMZ, int precursorCharge,
       double retentionTime) {
 
     NumberFormat rtFormat = MZmineCore.getConfiguration().getRTFormat();
     NumberFormat mzFormat = MZmineCore.getConfiguration().getMZFormat();
 
     this.mzValue = mzValue;
-    this.scanNumber = scanNumber;
+    this.scan = scan;
     this.precursorMZ = precursorMZ;
     this.precursorCharge = precursorCharge;
     this.retentionTime = retentionTime;
@@ -70,7 +71,7 @@ class NeutralLossDataPoint {
     sb.append(mzFormat.format(neutralLoss));
     sb.append(", m/z ");
     sb.append(mzFormat.format(mzValue));
-    sb.append(", scan #" + scanNumber + ", RT ");
+    sb.append(", scan #" + scan.getScanNumber() + ", RT ");
     sb.append(rtFormat.format(retentionTime));
     sb.append(", m/z ");
     sb.append(mzFormat.format(precursorMZ));
@@ -118,8 +119,8 @@ class NeutralLossDataPoint {
   /**
    * @return Returns the scanNumber.
    */
-  int getScanNumber() {
-    return scanNumber;
+  Scan getScan() {
+    return scan;
   }
 
   double getNeutralLoss() {

--- a/src/main/java/io/github/mzmine/modules/visualization/neutralloss/NeutralLossDataSet.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/neutralloss/NeutralLossDataSet.java
@@ -47,7 +47,9 @@ class NeutralLossDataSet extends AbstractXYDataset implements Task, XYToolTipGen
   private Range<Double> totalMZRange;
   private int numOfFragments;
   private Object xAxisType;
-  private int scanNumbers[], totalScans, processedScans;
+  private Scan[] scanNumbers;
+  private int totalScans;
+  private int processedScans;
 
   private TaskStatus status = TaskStatus.WAITING;
 
@@ -88,13 +90,11 @@ class NeutralLossDataSet extends AbstractXYDataset implements Task, XYToolTipGen
     setStatus(TaskStatus.PROCESSING);
     processedScans = 0;
 
-    for (int scanNumber : scanNumbers) {
+    for (Scan scan : scanNumbers) {
 
       // Cancel?
       if (status == TaskStatus.CANCELED)
         return;
-
-      Scan scan = rawDataFile.getScan(scanNumber);
 
       // check parent m/z
       if (!totalMZRange.contains(scan.getPrecursorMZ())) {
@@ -148,7 +148,7 @@ class NeutralLossDataSet extends AbstractXYDataset implements Task, XYToolTipGen
           break;
 
         NeutralLossDataPoint newPoint =
-            new NeutralLossDataPoint(scanDataPoints[featureIndex].getMZ(), scan.getScanNumber(),
+            new NeutralLossDataPoint(scanDataPoints[featureIndex].getMZ(), scan,
                 scan.getPrecursorMZ(), scan.getPrecursorCharge(), scan.getRetentionTime());
 
         dataSeries.get(0).add(newPoint);
@@ -308,9 +308,6 @@ class NeutralLossDataSet extends AbstractXYDataset implements Task, XYToolTipGen
     return "Updating neutral loss visualizer of " + rawDataFile;
   }
 
-  /**
-   * @see io.github.mzmine.taskcontrol.Task#setStatus()
-   */
   public void setStatus(TaskStatus newStatus) {
     this.status = newStatus;
   }

--- a/src/main/java/io/github/mzmine/modules/visualization/neutralloss/NeutralLossPlot.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/neutralloss/NeutralLossPlot.java
@@ -168,7 +168,7 @@ class NeutralLossPlot extends EChartViewer {
     NeutralLossDataPoint pos = dataset.getDataPoint(xValue, yValue);
     RawDataFile dataFile = visualizer.getDataFile();
     if (pos != null) {
-      SpectraVisualizerModule.addNewSpectrumTab(dataFile, pos.getScanNumber());
+      SpectraVisualizerModule.addNewSpectrumTab(dataFile, pos.getScan());
     }
 
     resetZoomHistory();

--- a/src/main/java/io/github/mzmine/modules/visualization/productionfilter/ProductIonFilterDataPoint.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/productionfilter/ProductIonFilterDataPoint.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.modules.visualization.productionfilter;
 
+import io.github.mzmine.datamodel.Scan;
 import java.text.NumberFormat;
 
 import io.github.mzmine.main.MZmineCore;
@@ -28,7 +29,7 @@ import io.github.mzmine.main.MZmineCore;
 class ProductIonFilterDataPoint {
 
   private double mzValue;
-  private int scanNumber;
+  private Scan scanNumber;
   private double precursorMZ;
   private int precursorCharge;
   private double retentionTime;
@@ -39,12 +40,11 @@ class ProductIonFilterDataPoint {
 
   /**
    * @param scanNumber
-   * @param precursorScanNumber
    * @param precursorMZ
    * @param precursorCharge
    * @param retentionTime
    */
-  ProductIonFilterDataPoint(double mzValue, int scanNumber, double precursorMZ, int precursorCharge,
+  ProductIonFilterDataPoint(double mzValue, Scan scanNumber, double precursorMZ, int precursorCharge,
       double retentionTime) {
 
     NumberFormat rtFormat = MZmineCore.getConfiguration().getRTFormat();
@@ -118,7 +118,7 @@ class ProductIonFilterDataPoint {
   /**
    * @return Returns the scanNumber.
    */
-  int getScanNumber() {
+  Scan getScan() {
     return scanNumber;
   }
 

--- a/src/main/java/io/github/mzmine/modules/visualization/productionfilter/ProductIonFilterDataSet.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/productionfilter/ProductIonFilterDataSet.java
@@ -51,7 +51,9 @@ class ProductIonFilterDataSet extends AbstractXYDataset implements Task, XYToolT
   private Range<Double> totalMZRange;
 
   private Object xAxisType;
-  private int scanNumbers[], totalScans, processedScans;
+  private Scan[] scanNumbers;
+  private int totalScans;
+  private int processedScans;
 
   private MZTolerance mzDifference;
   private List<Double> targetedMZ_List;
@@ -122,14 +124,12 @@ class ProductIonFilterDataSet extends AbstractXYDataset implements Task, XYToolT
     // m/z for plotting in R
     List<String> dataListVisual = new ArrayList<String>();
 
-    for (int scanNumber : scanNumbers) {
+    for (Scan scan : scanNumbers) {
 
       // Cancel?
       if (status == TaskStatus.CANCELED) {
         return;
       }
-
-      Scan scan = rawDataFile.getScan(scanNumber);
 
       // check parent m/z
       if (!totalMZRange.contains(scan.getPrecursorMZ())) {
@@ -318,7 +318,7 @@ class ProductIonFilterDataSet extends AbstractXYDataset implements Task, XYToolT
           }
 
           ProductIonFilterDataPoint newPoint =
-              new ProductIonFilterDataPoint(scanDataPoints[featureIndex].getMZ(), scan.getScanNumber(),
+              new ProductIonFilterDataPoint(scanDataPoints[featureIndex].getMZ(), scan,
                   scan.getPrecursorMZ(), scan.getPrecursorCharge(), scan.getRetentionTime());
 
           dataSeries.get(0).add(newPoint);

--- a/src/main/java/io/github/mzmine/modules/visualization/productionfilter/ProductIonFilterPlot.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/productionfilter/ProductIonFilterPlot.java
@@ -165,7 +165,7 @@ class ProductIonFilterPlot extends EChartViewer {
     ProductIonFilterDataPoint pos = dataset.getDataPoint(xValue, yValue);
     RawDataFile dataFile = visualizer.getDataFile();
     if (pos != null) {
-      SpectraVisualizerModule.addNewSpectrumTab(dataFile, pos.getScanNumber());
+      SpectraVisualizerModule.addNewSpectrumTab(dataFile, pos.getScan());
     }
 
     resetZoomHistory();

--- a/src/main/java/io/github/mzmine/modules/visualization/rawdataoverview/RawDataFileInfoPaneController.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/rawdataoverview/RawDataFileInfoPaneController.java
@@ -123,8 +123,9 @@ public class RawDataFileInfoPaneController {
 
     String scansMSLevel = "Total scans (" + rawDataFile.getNumOfScans() + ") ";
     for (int i = 0; i < rawDataFile.getMSLevels().length; i++) {
-      scansMSLevel = scansMSLevel + "MS" + rawDataFile.getMSLevels()[i] + " level ("
-          + rawDataFile.getScanNumbers(i + 1).length + ") ";
+      int level = rawDataFile.getMSLevels()[i];
+      scansMSLevel = scansMSLevel + "MS" + level + " level ("
+          + rawDataFile.getScanNumbers(level).size() + ") ";
       lblNumScans.setText(scansMSLevel);
     }
 
@@ -236,8 +237,8 @@ public class RawDataFileInfoPaneController {
 
       tableData.clear();
 
-      final int[] scanNumbers = rawDataFile.getScanNumbers();
-      if (scanNumbers.length > 5E5) {
+      final ObservableList<Scan> scanNumbers = rawDataFile.getScans();
+      if (scanNumbers.size() > 5E5) {
         status = TaskStatus.FINISHED;
         // it's not the computation that takes long, it's putting the data into the table.
         // This bricks the MZmine window
@@ -249,9 +250,8 @@ public class RawDataFileInfoPaneController {
       }
 
       // add raw data to table
-      for (int i = 1; i < scanNumbers.length; i++) {
-        Scan scan = rawDataFile.getScan(scanNumbers[i]);
-
+      for (int i = 1; i < scanNumbers.size(); i++) {
+        Scan scan  = scanNumbers.get(i);
         if (scan == null) {
           continue;
         }
@@ -277,7 +277,7 @@ public class RawDataFileInfoPaneController {
           basePeakIntensity = itFormat.format(scan.getHighestDataPoint().getIntensity());
         }
 
-        tableData.add(new ScanDescription(Integer.toString(scan.getScanNumber()), // scan number
+        tableData.add(new ScanDescription(scan, Integer.toString(scan.getScanNumber()), // scan number
             rtFormat.format(scan.getRetentionTime()), // rt
             Integer.toString(scan.getMSLevel()), // MS level
             precursor, // precursor mz
@@ -289,7 +289,7 @@ public class RawDataFileInfoPaneController {
             basePeakIntensity) // base peak intensity
         );
 
-        perc = i / (scanNumbers.length + 1);
+        perc = i / (scanNumbers.size() + 1);
         if (isCanceled) {
           status = TaskStatus.CANCELED;
           return;

--- a/src/main/java/io/github/mzmine/modules/visualization/rawdataoverview/RawDataOverviewWindowController.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/rawdataoverview/RawDataOverviewWindowController.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.modules.visualization.rawdataoverview;
 
+import io.github.mzmine.datamodel.Scan;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -142,8 +143,7 @@ public class RawDataOverviewWindowController {
               // in that case we just select the table.
               return;
             }
-            Integer scanNum = Integer.valueOf(newValue.getScanNumber());
-            visualizer.setFocusedScan(raw, scanNum);
+            visualizer.setFocusedScan(raw, newValue.getScan());
           }));
 
       Tab rawDataFileTab = new Tab(raw.getName());
@@ -204,15 +204,14 @@ public class RawDataOverviewWindowController {
 
       if (rawDataTableView.getItems() != null) {
         try {
-          String scanNumberString = String.valueOf(pos.getScanNumber());
+          Scan scan = pos.getScan();
           rawDataTableView.getItems().stream()
-              .filter(item -> item.getScanNumber().equals(scanNumberString)).findFirst()
+              .filter(item -> item.getScan().equals(scan)).findFirst()
               .ifPresent(item -> {
                 rawDataTableView.getSelectionModel().select(item);
                 if (!con.getVisibleRange().contains(rawDataTableView.getItems().indexOf(item))) {
                   rawDataTableView.scrollTo(item);
                 }
-
               });
         } catch (Exception e) {
           e.getStackTrace();

--- a/src/main/java/io/github/mzmine/modules/visualization/rawdataoverview/ScanDescription.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/rawdataoverview/ScanDescription.java
@@ -18,6 +18,8 @@
 
 package io.github.mzmine.modules.visualization.rawdataoverview;
 
+import io.github.mzmine.datamodel.Scan;
+
 /*
  * Raw data overview raw data table model class class
  * 
@@ -25,6 +27,7 @@ package io.github.mzmine.modules.visualization.rawdataoverview;
  */
 public class ScanDescription {
 
+  private Scan scan;
   private String scanNumber;
   private String retentionTime;
   private String msLevel;
@@ -37,8 +40,11 @@ public class ScanDescription {
   private String basePeakIntensity;
 
 
-  public ScanDescription(String scanNumber, String retentionTime, String msLevel, String precursorMz,
-      String mzRange, String scanType, String polarity, String definition, String basePeak, String basePeakIntensity) {
+  public ScanDescription(Scan scan, String scanNumber,
+      String retentionTime, String msLevel, String precursorMz,
+      String mzRange, String scanType, String polarity, String definition, String basePeak,
+      String basePeakIntensity) {
+    this.scan = scan;
     this.scanNumber = scanNumber;
     this.retentionTime = retentionTime;
     this.msLevel = msLevel;
@@ -51,6 +57,10 @@ public class ScanDescription {
     this.basePeakIntensity = basePeakIntensity;
   }
 
+
+  public Scan getScan() {
+    return scan;
+  }
 
   public String getScanNumber() {
     return scanNumber;

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/multimsms/MultiMSMSWindow.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/multimsms/MultiMSMSWindow.java
@@ -200,7 +200,7 @@ public class MultiMSMSWindow extends JFrame {
   private boolean rawContainsFragmentation(RawDataFile raw) {
     for (FeatureListRow row : rows) {
       Feature peak = row.getFeature(raw);
-      if (peak != null && peak.getMostIntenseFragmentScanNumber() > 0) {
+      if (peak != null && peak.getMostIntenseFragmentScan() != null) {
         return true;
       }
     }
@@ -376,7 +376,7 @@ public class MultiMSMSWindow extends JFrame {
         }
       }
       if (best != null) {
-        scan = best.getRawDataFile().getScan(best.getRepresentativeScanNumber());
+        scan = best.getRepresentativeScan();
         EChartPanel cp = SpectrumChartFactory.createScanChartPanel(scan, showTitle, showLegend);
         if (cp != null)
           msone = new ChartViewWrapper(cp);

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/MultiSpectraVisualizerWindow.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/MultiSpectraVisualizerWindow.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.modules.visualization.spectra.simplespectra;
 
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.FeatureListRow;
 import java.awt.BasicStroke;
@@ -112,7 +113,7 @@ public class MultiSpectraVisualizerWindow extends JFrame {
 
     int n = 0;
     for (Feature f : row.getFeatures()) {
-      if (f.getMostIntenseFragmentScanNumber() > 0)
+      if (f.getMostIntenseFragmentScan() != null)
         n++;
     }
     lbRawTotalWithFragmentation.setText("(total raw:" + n + ")");
@@ -172,16 +173,16 @@ public class MultiSpectraVisualizerWindow extends JFrame {
   public boolean setRawFileAndShow(RawDataFile raw) {
     Feature peak = row.getFeature(raw);
     // no peak / no ms2 - return false
-    if (peak == null || peak.getAllMS2FragmentScanNumbers() == null
-        || peak.getAllMS2FragmentScanNumbers().size() == 0)
+    if (peak == null || peak.getAllMS2FragmentScans() == null
+        || peak.getAllMS2FragmentScans().size() == 0)
       return false;
 
     this.activeRaw = raw;
     // clear
     pnGrid.removeAll();
 
-    ObservableList<Integer> numbers = peak.getAllMS2FragmentScanNumbers();
-    for (int scan : numbers) {
+    ObservableList<Scan> numbers = peak.getAllMS2FragmentScans();
+    for (Scan scan : numbers) {
       pnGrid.add(addSpectra(scan));
     }
 
@@ -199,7 +200,7 @@ public class MultiSpectraVisualizerWindow extends JFrame {
     return Arrays.asList(rawFiles).indexOf(raw);
   }
 
-  private JPanel addSpectra(int scan) {
+  private JPanel addSpectra(Scan scan) {
     JPanel panel = new JPanel(new BorderLayout());
     // Split pane for eic plot (top) and spectrum (bottom)
     JSplitPane bottomPane = new JSplitPane(JSplitPane.VERTICAL_SPLIT);
@@ -240,7 +241,7 @@ public class MultiSpectraVisualizerWindow extends JFrame {
     ticPlot.getChart().getLegend().setVisible(false);
 
     // add a retention time Marker to the EIC
-    ValueMarker marker = new ValueMarker(activeRaw.getScan(scan).getRetentionTime());
+    ValueMarker marker = new ValueMarker(scan.getRetentionTime());
     marker.setPaint(Color.RED);
     marker.setStroke(new BasicStroke(3.0f));
 
@@ -256,7 +257,7 @@ public class MultiSpectraVisualizerWindow extends JFrame {
 
     // get MS/MS spectra window
     SpectraVisualizerTab spectraTab = new SpectraVisualizerTab(activeRaw);
-    spectraTab.loadRawData(activeRaw.getScan(scan));
+    spectraTab.loadRawData(scan);
 
     // get MS/MS spectra plot
     SpectraPlot spectrumPlot = spectraTab.getSpectrumPlot();

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/SpectraBottomPanel.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/SpectraBottomPanel.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.modules.visualization.spectra.simplespectra;
 
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.FeatureList;
 import java.awt.Font;
 import java.util.logging.Logger;
@@ -46,7 +47,7 @@ class SpectraBottomPanel extends BorderPane {
   public static final Font smallFont = new Font("SansSerif", Font.PLAIN, 10);
 
   private FlowPane topPanel, bottomPanel;
-  private ComboBox<String> msmsSelector;
+  private ComboBox<Scan> msmsSelector;
   private ComboBox<FeatureList> peakListSelector;
   private CheckBox processingCbx;
   private Button processingParametersBtn;
@@ -124,7 +125,7 @@ class SpectraBottomPanel extends BorderPane {
 
     Label msmsLabel = new Label("MS/MS: ");
 
-    msmsSelector = new ComboBox<String>();
+    msmsSelector = new ComboBox<>();
     // msmsSelector.setBackground(Color.white);
     // msmsSelector.setFont(smallFont);
 
@@ -133,14 +134,9 @@ class SpectraBottomPanel extends BorderPane {
 
     // showButton.setBackground(Color.white);
     showButton.setOnAction(e -> {
-      String selectedScanString = msmsSelector.getSelectionModel().getSelectedItem();
-      if (selectedScanString == null)
+      Scan selectedScan = msmsSelector.getSelectionModel().getSelectedItem();
+      if (selectedScan == null)
         return;
-
-      int sharpIndex = selectedScanString.indexOf('#');
-      int commaIndex = selectedScanString.indexOf(',');
-      selectedScanString = selectedScanString.substring(sharpIndex + 1, commaIndex);
-      int selectedScan = Integer.valueOf(selectedScanString);
 
       SpectraVisualizerModule.addNewSpectrumTab(dataFile, selectedScan);
     });
@@ -150,7 +146,7 @@ class SpectraBottomPanel extends BorderPane {
 
   }
 
-  ComboBox<String> getMSMSSelector() {
+  ComboBox<Scan> getMSMSSelector() {
     return msmsSelector;
   }
 

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/SpectraVisualizerModule.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/SpectraVisualizerModule.java
@@ -57,53 +57,49 @@ public class SpectraVisualizerModule implements MZmineRunnableModule {
 
     int scanNumber = parameters.getParameter(SpectraVisualizerParameters.scanNumber).getValue();
     String massList = parameters.getParameter(SpectraVisualizerParameters.massList).getValue();
-
-    addNewSpectrumTab(dataFiles[0], scanNumber, massList);
-
+    addNewSpectrumTab(dataFiles[0], dataFiles[0].getScanAtNumber(scanNumber), massList);
     return ExitCode.OK;
   }
 
   public static SpectraVisualizerTab addNewSpectrumTab(RawDataFile dataFile,
-      int scanNumber) {
-    return addNewSpectrumTab(dataFile, scanNumber, null, null, null, null);
+      Scan scan) {
+    return addNewSpectrumTab(dataFile, scan, null, null, null, null);
   }
 
   public static SpectraVisualizerTab addNewSpectrumTab(RawDataFile dataFile,
-      int scanNumber, String massList) {
-    return addNewSpectrumTab(dataFile, scanNumber, null, null, null, null, massList);
+      Scan scan, String massList) {
+    return addNewSpectrumTab(dataFile, scan, null, null, null, null, massList);
   }
 
-  public static SpectraVisualizerTab addNewSpectrumTab(RawDataFile dataFile, int scanNumber,
+  public static SpectraVisualizerTab addNewSpectrumTab(RawDataFile dataFile, Scan scan,
       Feature peak) {
-    return addNewSpectrumTab(dataFile, scanNumber, peak, null, null, null);
+    return addNewSpectrumTab(dataFile, scan, peak, null, null, null);
   }
 
-  public static SpectraVisualizerTab addNewSpectrumTab(RawDataFile dataFile, int scanNumber,
+  public static SpectraVisualizerTab addNewSpectrumTab(RawDataFile dataFile, Scan scan,
       IsotopePattern detectedPattern) {
-    return addNewSpectrumTab(dataFile, scanNumber, null, detectedPattern, null, null);
+    return addNewSpectrumTab(dataFile, scan, null, detectedPattern, null, null);
   }
 
-  public static SpectraVisualizerTab addNewSpectrumTab(RawDataFile dataFile, int scanNumber,
+  public static SpectraVisualizerTab addNewSpectrumTab(RawDataFile dataFile, Scan scan,
       Feature peak, IsotopePattern detectedPattern, IsotopePattern predictedPattern) {
-    return addNewSpectrumTab(dataFile, scanNumber, peak, detectedPattern, predictedPattern,
+    return addNewSpectrumTab(dataFile, scan, peak, detectedPattern, predictedPattern,
         null);
   }
 
-  public static SpectraVisualizerTab addNewSpectrumTab(RawDataFile dataFile, int scanNumber,
+  public static SpectraVisualizerTab addNewSpectrumTab(RawDataFile dataFile, Scan scan,
       Feature peak, IsotopePattern detectedPattern, IsotopePattern predictedPattern,
       IsotopePattern spectrum){
-    return addNewSpectrumTab(dataFile, scanNumber, peak, detectedPattern, predictedPattern, spectrum, null);
+    return addNewSpectrumTab(dataFile, scan, peak, detectedPattern, predictedPattern, spectrum, null);
   }
 
-  public static SpectraVisualizerTab addNewSpectrumTab(RawDataFile dataFile, int scanNumber,
+  public static SpectraVisualizerTab addNewSpectrumTab(RawDataFile dataFile, Scan scan,
       Feature peak, IsotopePattern detectedPattern, IsotopePattern predictedPattern,
       IsotopePattern spectrum, String massList) {
 
-    Scan scan = dataFile.getScan(scanNumber);
-
     if (scan == null) {
       MZmineCore.getDesktop().displayErrorMessage(
-          "Raw data file " + dataFile + " does not contain scan #" + scanNumber);
+          "Raw data file " + dataFile + " does not contain scan #" + scan);
       return null;
     }
 
@@ -116,12 +112,12 @@ public class SpectraVisualizerModule implements MZmineRunnableModule {
       MassList massListObject = scan.getMassList(massList);
       if (massListObject == null) {
         MZmineCore.getDesktop().displayErrorMessage(
-          "Raw data file " + dataFile + " scan #" + scanNumber + " does not contain mass list " + massList);
+          "Raw data file " + dataFile + " scan #" + scan + " does not contain mass list " + massList);
         return null;
       }
     }
 
-    SpectraVisualizerTab newTab = new SpectraVisualizerTab(dataFile, scanNumber, massList, true);
+    SpectraVisualizerTab newTab = new SpectraVisualizerTab(dataFile, scan, massList, true);
     newTab.loadRawData(scan);
 
     if (peak != null)

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/datasets/PeakListDataSet.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/datasets/PeakListDataSet.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.modules.visualization.spectra.simplespectra.datasets;
 
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.FeatureList;
 import java.util.Vector;
@@ -42,8 +43,8 @@ public class PeakListDataSet extends AbstractXYDataset implements IntervalXYData
   private double mzValues[], intensityValues[];
   private String label;
 
-  public PeakListDataSet(RawDataFile dataFile, int scanNumber, FeatureList featureList) {
-
+  public PeakListDataSet(RawDataFile dataFile, Scan scanNumber, FeatureList featureList) {
+    // TODO why do we show
     this.featureList = featureList;
 
     Feature features[] = featureList.getFeatures(dataFile).toArray(Feature[]::new);

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/datasets/SinglePeakDataSet.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/datasets/SinglePeakDataSet.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.modules.visualization.spectra.simplespectra.datasets;
 
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
 import org.jfree.data.xy.AbstractXYDataset;
 import org.jfree.data.xy.IntervalXYDataset;
@@ -36,7 +37,7 @@ public class SinglePeakDataSet extends AbstractXYDataset implements IntervalXYDa
   private DataPoint dataPoint;
   private String label;
 
-  public SinglePeakDataSet(int scanNumber, Feature peak) {
+  public SinglePeakDataSet(Scan scanNumber, Feature peak) {
     this.label = peak.toString();
     this.dataPoint = peak.getDataPoint(scanNumber);
   }

--- a/src/main/java/io/github/mzmine/modules/visualization/twod/FeatureDataPoint.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/twod/FeatureDataPoint.java
@@ -19,25 +19,26 @@
 package io.github.mzmine.modules.visualization.twod;
 
 import io.github.mzmine.datamodel.DataPoint;
+import io.github.mzmine.datamodel.Scan;
 
 /**
  * This class represents one peak datapoint (retention time and m/z)
  */
 class FeatureDataPoint {
 
-  private int scanNumber;
+  private Scan scanNumber;
   private float rt;
   private DataPoint dataPoint;
 
   /**
    */
-  FeatureDataPoint(int scanNumber, float rt, DataPoint dataPoint) {
+  FeatureDataPoint(Scan scanNumber, float rt, DataPoint dataPoint) {
     this.scanNumber = scanNumber;
     this.rt = rt;
     this.dataPoint = dataPoint;
   }
 
-  int getScanNumber() {
+  Scan getScan() {
     return scanNumber;
   }
 

--- a/src/main/java/io/github/mzmine/modules/visualization/twod/FeatureDataSet.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/twod/FeatureDataSet.java
@@ -52,20 +52,16 @@ class FeatureDataSet extends AbstractXYDataset {
 
     for (Feature feature : allFeatures) {
 
-      int scanNumbers[] = feature.getScanNumbers().stream().mapToInt(i->i).toArray();
-
-      for (int scan : scanNumbers) {
-
-        float rt = dataFile.getScan(scan).getRetentionTime();
-        DataPoint dp = feature.getDataPoint(scan);
-        if (dp != null) {
-          if (rtRange.contains(rt) && mzRange.contains(dp.getMZ())) {
-            FeatureDataPoint newDP = new FeatureDataPoint(scan, rt, dp);
-            thisFeatureDataPoints.add(newDP);
+      feature.getScanNumbers().forEach(scan -> {
+          DataPoint dp = feature.getDataPoint(scan);
+          if (dp != null) {
+            float rt = scan.getRetentionTime();
+            if (rtRange.contains(rt) && mzRange.contains(dp.getMZ())) {
+              FeatureDataPoint newDP = new FeatureDataPoint(scan, rt, dp);
+              thisFeatureDataPoints.add(newDP);
+            }
           }
-        }
-
-      }
+      });
 
       if (thisFeatureDataPoints.size() > 0) {
         FeatureDataPoint dpArray[] = thisFeatureDataPoints.toArray(new FeatureDataPoint[0]);
@@ -73,7 +69,6 @@ class FeatureDataSet extends AbstractXYDataset {
         processedFeatureDataPoints.add(dpArray);
         thisFeatureDataPoints.clear();
       }
-
     }
 
     features = processedFeatures.toArray(new Feature[0]);

--- a/src/main/java/io/github/mzmine/modules/visualization/twod/FeatureToolTipGenerator.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/twod/FeatureToolTipGenerator.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.modules.visualization.twod;
 
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
@@ -51,7 +52,7 @@ class FeatureToolTipGenerator implements XYToolTipGenerator {
     float rtValue = dataPoint.getRT();
     double intValue = dataPoint.getIntensity();
     double mzValue = dataPoint.getMZ();
-    int scanNumber = dataPoint.getScanNumber();
+    Scan scanNumber = dataPoint.getScan();
 
     String toolTip =
         "Feature: " + feature + "\nStatus: " + feature.getFeatureStatus() + "\nFeature list row: " + row

--- a/src/main/java/io/github/mzmine/parameters/dialogs/ParameterSetupDialogWithScanPreview.java
+++ b/src/main/java/io/github/mzmine/parameters/dialogs/ParameterSetupDialogWithScanPreview.java
@@ -46,7 +46,7 @@ public abstract class ParameterSetupDialogWithScanPreview extends ParameterSetup
   private final FlowPane pnlDataFile, pnlScanArrows, pnlScanNumber;
   private final VBox pnlControls;
   private final ComboBox<RawDataFile> comboDataFileName;
-  private final ComboBox<Integer> comboScanNumber;
+  private final ComboBox<Scan> comboScanNumber;
   // XYPlot
   private final SpectraPlot spectrumPlot;
   private RawDataFile[] dataFiles;
@@ -87,10 +87,8 @@ public abstract class ParameterSetupDialogWithScanPreview extends ParameterSetup
     pnlScanNumber = new FlowPane();
     pnlScanNumber.getChildren().add(new Label("Scan number "));
 
-    int scanNumbers[] = previewDataFile.getScanNumbers();
-    ObservableList<Integer> scanNums =
-        FXCollections.observableArrayList(CollectionUtils.toIntegerArray(scanNumbers));
-    comboScanNumber = new ComboBox<Integer>(scanNums);
+    ObservableList<Scan> scanNumbers = previewDataFile.getScans();
+    comboScanNumber = new ComboBox<>(scanNumbers);
     comboScanNumber.getSelectionModel().select(0);
     comboScanNumber.getSelectionModel().selectedItemProperty().addListener((obs, old, newIndex) -> {
       parametersChanged();
@@ -104,11 +102,8 @@ public abstract class ParameterSetupDialogWithScanPreview extends ParameterSetup
       if (previewDataFile == null) {
         return;
       }
-      int scanNumbers2[] = previewDataFile.getScanNumbers();
-      ObservableList<Integer> scanNums2 =
-          FXCollections.observableArrayList(CollectionUtils.toIntegerArray(scanNumbers2));
-
-      comboScanNumber.setItems(scanNums2);
+      ObservableList<Scan> scanNumbers2 = previewDataFile.getScans();
+      comboScanNumber.setItems(scanNumbers2);
       comboScanNumber.getSelectionModel().select(0);
       parametersChanged();
     });
@@ -193,14 +188,13 @@ public abstract class ParameterSetupDialogWithScanPreview extends ParameterSetup
       return;
     }
 
-    Integer scanNumber = comboScanNumber.getSelectionModel().getSelectedItem();
-    if (scanNumber == null) {
+    Scan scan = comboScanNumber.getSelectionModel().getSelectedItem();
+    if (scan == null) {
       return;
     }
 
-    Scan currentScan = previewDataFile.getScan(scanNumber);
     updateParameterSetFromComponents();
-    loadPreview(spectrumPlot, currentScan);
-    updateTitle(currentScan);
+    loadPreview(spectrumPlot, scan);
+    updateTitle(scan);
   }
 }

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/MassListComponent.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/MassListComponent.java
@@ -89,9 +89,7 @@ public class MassListComponent extends FlowPane {
     ArrayList<String> names = new ArrayList<>();
     RawDataFile dataFiles[] = MZmineCore.getProjectManager().getCurrentProject().getDataFiles();
     for (RawDataFile dataFile : dataFiles) {
-      int scanNums[] = dataFile.getScanNumbers();
-      for (int scanNum : scanNums) {
-        Scan scan = dataFile.getScan(scanNum);
+      for(Scan scan : dataFile.getScans()) {
         MassList massLists[] = scan.getMassLists();
         for (MassList massList : massLists) {
           String name = massList.getName();
@@ -104,8 +102,4 @@ public class MassListComponent extends FlowPane {
     return names;
   }
 
-  /*
-   * public void addDocumentListener(DocumentListener dl) {
-   * nameField.getDocument().addDocumentListener(dl); }
-   */
 }

--- a/src/main/java/io/github/mzmine/project/impl/ImagingRawDataFileImpl.java
+++ b/src/main/java/io/github/mzmine/project/impl/ImagingRawDataFileImpl.java
@@ -8,6 +8,7 @@ import io.github.mzmine.datamodel.ImagingScan;
 import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.modules.io.rawdataimport.fileformats.imzmlimport.Coordinates;
 import io.github.mzmine.modules.io.rawdataimport.fileformats.imzmlimport.ImagingParameters;
+import javafx.collections.ObservableList;
 
 
 public class ImagingRawDataFileImpl extends RawDataFileImpl implements ImagingRawDataFile {
@@ -19,7 +20,7 @@ public class ImagingRawDataFileImpl extends RawDataFileImpl implements ImagingRa
 
   // scan numbers
   // TODO add ms level - one array for each level
-  private int[][][] xyzScanNumbers;
+  private Scan[][][] xyzScanNumbers;
 
 
   public ImagingRawDataFileImpl(String dataFileName) throws IOException {
@@ -39,14 +40,14 @@ public class ImagingRawDataFileImpl extends RawDataFileImpl implements ImagingRa
   @Override
   public Scan getScan(double x, double y) {
     //
-    int[][][] numbers = getXYZScanNumbers();
+    Scan[][][] numbers = getXYZScanNumbers();
     // yline:
     int iy = (int) ((y) / param.getPixelShape());
     int ix = (int) (x / param.getPixelWidth());
 
     if (ix >= 0 && ix < numbers.length && iy >= 0 && iy < numbers[ix].length
-        && numbers[ix][iy][0] != -1)
-      return getScan(numbers[ix][iy][0]);
+        && numbers[ix][iy][0] != null)
+      return numbers[ix][iy][0];
     else
       return null;
   }
@@ -61,7 +62,7 @@ public class ImagingRawDataFileImpl extends RawDataFileImpl implements ImagingRa
     y = Math.min(y, y2);
     y2 = Math.max(tmp, y2);
 
-    int[][][] numbers = getXYZScanNumbers();
+    Scan[][][] numbers = getXYZScanNumbers();
     int iy = (int) ((y) / param.getPixelShape());
     int ix = (int) (x / param.getPixelWidth());
 
@@ -73,8 +74,8 @@ public class ImagingRawDataFileImpl extends RawDataFileImpl implements ImagingRa
     if (ix >= 0 && ix2 < numbers.length && iy >= 0 && iy2 < numbers[ix2].length) {
       for (int i = ix; i <= ix2; i++) {
         for (int k = iy; k <= iy2; k++) {
-          if (numbers[i][k][0] != -1)
-            list.add(getScan(numbers[i][k][0]));
+          if (numbers[i][k][0] != null)
+            list.add(numbers[i][k][0]);
         }
       }
     }
@@ -86,26 +87,26 @@ public class ImagingRawDataFileImpl extends RawDataFileImpl implements ImagingRa
    * 
    * @return
    */
-  public int[][][] getXYZScanNumbers() {
+  public Scan[][][] getXYZScanNumbers() {
     if (xyzScanNumbers == null) {
       // sort all scan numbers to xyz location
-      xyzScanNumbers = new int[param.getMaxNumberOfPixelX()][param.getMaxNumberOfPixelY()][param
+      xyzScanNumbers = new Scan[param.getMaxNumberOfPixelX()][param.getMaxNumberOfPixelY()][param
           .getMaxNumberOfPixelZ()];
       for (int x = 0; x < xyzScanNumbers.length; x++) {
         for (int y = 0; y < xyzScanNumbers[x].length; y++) {
           for (int z = 0; z < xyzScanNumbers[x][y].length; z++) {
-            xyzScanNumbers[x][y][z] = -1;
+            xyzScanNumbers[x][y][z] = null;
           }
         }
       }
       // add all scans
-      int[] numbers = getScanNumbers();
-      for (int i = 0; i < numbers.length; i++) {
-        if (getScan(numbers[i]) instanceof ImagingScan) {
-          Coordinates c = ((ImagingScan) getScan(numbers[i])).getCoordinates();
+      ObservableList<Scan> numbers = getScans();
+      for (int i = 0; i < numbers.size(); i++) {
+        if (numbers.get(i) instanceof ImagingScan) {
+          Coordinates c = ((ImagingScan) numbers.get(i)).getCoordinates();
           if (c.getX() < param.getMaxNumberOfPixelX() && c.getY() < param.getMaxNumberOfPixelY()
               && c.getZ() < param.getMaxNumberOfPixelZ())
-            xyzScanNumbers[c.getX()][c.getY()][c.getZ()] = numbers[i];
+            xyzScanNumbers[c.getX()][c.getY()][c.getZ()] = numbers.get(i);
         }
       }
     }

--- a/src/main/java/io/github/mzmine/project/impl/ProjectManagerImpl.java
+++ b/src/main/java/io/github/mzmine/project/impl/ProjectManagerImpl.java
@@ -37,9 +37,6 @@ public class ProjectManagerImpl implements ProjectManager {
 
   MZmineProject currentProject;
 
-  /**
-   * @see io.github.mzmine.modules.MZmineModule#initModule(io.github.mzmine.main.MZmineCore)
-   */
   public void initModule() {
     currentProject = new MZmineProjectImpl();
     myInstance = this;

--- a/src/main/java/io/github/mzmine/project/impl/RawDataFileImpl.java
+++ b/src/main/java/io/github/mzmine/project/impl/RawDataFileImpl.java
@@ -27,6 +27,7 @@ import java.nio.DoubleBuffer;
 import java.nio.channels.FileChannel;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.Enumeration;
 import java.util.HashSet;
@@ -37,8 +38,9 @@ import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import com.google.common.collect.Range;
 import com.google.common.primitives.Ints;
 import io.github.mzmine.datamodel.DataPoint;
@@ -78,7 +80,8 @@ public class RawDataFileImpl implements RawDataFile, RawDataFileWriter {
   private final Hashtable<Integer, Range<Double>> dataMZRange;
   private final Hashtable<Integer, Range<Float>> dataRTRange;
   private final Hashtable<Integer, Double> dataMaxBasePeakIntensity, dataMaxTIC;
-  private final Hashtable<Integer, int[]> scanNumbersCache;
+  // cache for MS level. key=0
+  private final Hashtable<Integer, ObservableList<Scan>> scanNumbersCache;
 
   private ByteBuffer buffer = ByteBuffer.allocate(20000);
   private final TreeMap<Integer, Long> dataPointsOffsets;
@@ -95,22 +98,24 @@ public class RawDataFileImpl implements RawDataFile, RawDataFileWriter {
   // notifyUpdatedMassLists() method
   private final List<MassList> newMassLists = new ArrayList<>();
 
-  /**
-   * Scans
-   */
-  protected final Hashtable<Integer, Scan> scans;
+  protected final ObservableList<Scan> scans;
 
   public RawDataFileImpl(String dataFileName) throws IOException {
 
     this.dataFileName = dataFileName;
 
+    scans = FXCollections.observableArrayList();
+
     // Prepare the hashtables for scan numbers and data limits.
     scanNumbersCache = new Hashtable<>();
+    // msLevel 0 contains all scans
+    scanNumbersCache.put(0, scans);
+
+
     dataMZRange = new Hashtable<>();
     dataRTRange = new Hashtable<>();
     dataMaxBasePeakIntensity = new Hashtable<>();
     dataMaxTIC = new Hashtable<>();
-    scans = new Hashtable<>();
     dataPointsOffsets = new TreeMap<>();
     dataPointsLengths = new TreeMap<>();
 
@@ -179,13 +184,11 @@ public class RawDataFileImpl implements RawDataFile, RawDataFileWriter {
     return scans.size();
   }
 
-  /**
-   * @see io.github.mzmine.datamodel.RawDataFile#getScan(int)
-   */
-  @Override
-  public @Nullable Scan getScan(int scanNumber) {
-    return scans.get(scanNumber);
-  }
+//  @Deprecated
+//  @Override
+//  public @Nullable Scan getScan(int scanNumber) {
+//    return scans.get(scanNumber);
+//  }
 
   /**
    * @param rt The rt
@@ -194,109 +197,72 @@ public class RawDataFileImpl implements RawDataFile, RawDataFileWriter {
    *         scan can be found.
    */
   @Override
-  public int getScanNumberAtRT(float rt, int mslevel) {
+  public Scan getScanNumberAtRT(float rt, int mslevel) {
     if (rt > getDataRTRange(mslevel).upperEndpoint()) {
-      return -1;
+      return null;
     }
     Range<Float> range = Range.closed(rt - 2, rt + 2);
-    int[] scanNumbers = getScanNumbers(mslevel, range);
+    Scan[] scanNumbers = getScanNumbers(mslevel, range);
     double minDiff = 10E6;
 
     for (int i = 0; i < scanNumbers.length; i++) {
-      int scanNum = scanNumbers[i];
-      double diff = Math.abs(rt - getScan(scanNum).getRetentionTime());
+      Scan scanNum = scanNumbers[i];
+      double diff = Math.abs(rt - scanNum.getRetentionTime());
       if (diff < minDiff) {
         minDiff = diff;
       } else if (diff > minDiff) { // not triggered in first run
         return scanNumbers[i - 1]; // the previous one was better
       }
     }
-    return -1;
+    return null;
   }
 
   /**
    * @param rt The rt
-   * @return The scan number at a given retention time within a range of 2 (min/sec?) or -1 if no
+   * @return The scan at a given retention time within a range of 2 (min/sec?) or null if no
    *         scan can be found.
    */
   @Override
-  public int getScanNumberAtRT(float rt) {
+  public Scan getScanNumberAtRT(float rt) {
     if (rt > getDataRTRange().upperEndpoint()) {
-      return -1;
+      return null;
     }
-    int[] scanNumbers = getScanNumbers();
     double minDiff = 10E10;
-
-    for (int i = 0; i < scanNumbers.length; i++) {
-      int scanNum = scanNumbers[i];
-      double diff = Math.abs(rt - getScan(scanNum).getRetentionTime());
+    for (Scan scan : scans) {
+      double diff = Math.abs(rt - scan.getRetentionTime());
       if (diff < minDiff) {
         minDiff = diff;
       } else if (diff > minDiff) { // not triggered in first run
-        return scanNumbers[i - 1]; // the previous one was better
+        return scan;
       }
     }
-    return -1;
+    return null;
   }
 
   /**
    * @see io.github.mzmine.datamodel.RawDataFile#getScanNumbers(int)
    */
   @Override
-  public @Nonnull int[] getScanNumbers(int msLevel) {
+  @Nonnull
+  public ObservableList<Scan> getScanNumbers(int msLevel) {
     if (scanNumbersCache.containsKey(msLevel)) {
-      return scanNumbersCache.get(msLevel);
+      return FXCollections.unmodifiableObservableList(scanNumbersCache.get(msLevel));
     }
-    Range<Float> all = Range.all();
-    int scanNumbers[] = getScanNumbers(msLevel, all);
-    scanNumbersCache.put(msLevel, scanNumbers);
-    return scanNumbers;
+    else {
+      return FXCollections.unmodifiableObservableList(FXCollections.emptyObservableList());
+    }
   }
 
   /**
    * @see io.github.mzmine.datamodel.RawDataFile#getScanNumbers(int, Range)
    */
   @Override
-  public @Nonnull int[] getScanNumbers(int msLevel, @Nonnull Range<Float> rtRange) {
-
+  public @Nonnull Scan[] getScanNumbers(int msLevel, @Nonnull Range<Float> rtRange) {
     assert rtRange != null;
-
-    ArrayList<Integer> eligibleScanNumbers = new ArrayList<Integer>();
-
-    Enumeration<? extends Scan> scansEnum = scans.elements();
-    while (scansEnum.hasMoreElements()) {
-      Scan scan = scansEnum.nextElement();
-
-      if ((scan.getMSLevel() == msLevel) && (rtRange.contains(scan.getRetentionTime()))) {
-        eligibleScanNumbers.add(scan.getScanNumber());
-      }
-    }
-
-    int[] numbersArray = Ints.toArray(eligibleScanNumbers);
-    Arrays.sort(numbersArray);
-
-    return numbersArray;
-  }
-
-  /**
-   * @see io.github.mzmine.datamodel.RawDataFile#getScanNumbers()
-   */
-  @Override
-  @Nonnull
-  public int[] getScanNumbers() {
-
-    if (scanNumbersCache.containsKey(0) && scanNumbersCache.get(0).length == scans.size()) {
-      return scanNumbersCache.get(0);
-    }
-
-    Set<Integer> allScanNumbers = scans.keySet();
-    int[] numbersArray = Ints.toArray(allScanNumbers);
-    Arrays.sort(numbersArray);
-
-    scanNumbersCache.put(0, numbersArray);
-
-    return numbersArray;
-
+    // TODO why do we sort by scan number? scans should already be sorted?
+    return scans.stream()
+        .filter(s -> s.getMSLevel() == msLevel && rtRange.contains(s.getRetentionTime()))
+        .sorted(Comparator.comparingInt(Scan::getScanNumber)).toArray(Scan[]::new);
   }
 
   /**
@@ -305,19 +271,8 @@ public class RawDataFileImpl implements RawDataFile, RawDataFileWriter {
   @Override
   @Nonnull
   public int[] getMSLevels() {
-
-    Set<Integer> msLevelsSet = new HashSet<Integer>();
-
-    Enumeration<? extends Scan> scansEnum = scans.elements();
-    while (scansEnum.hasMoreElements()) {
-      Scan scan = scansEnum.nextElement();
-      msLevelsSet.add(scan.getMSLevel());
-    }
-
-    int[] msLevels = Ints.toArray(msLevelsSet);
-    Arrays.sort(msLevels);
-    return msLevels;
-
+    return scanNumbersCache.keySet().stream().filter(level -> level!=0).mapToInt(Integer::intValue)
+        .sorted().toArray();
   }
 
   /**
@@ -325,7 +280,6 @@ public class RawDataFileImpl implements RawDataFile, RawDataFileWriter {
    */
   @Override
   public double getDataMaxBasePeakIntensity(int msLevel) {
-
     // check if we have this value already cached
     Double maxBasePeak = dataMaxBasePeakIntensity.get(msLevel);
     if (maxBasePeak != null) {
@@ -333,10 +287,7 @@ public class RawDataFileImpl implements RawDataFile, RawDataFileWriter {
     }
 
     // find the value
-    Enumeration<? extends Scan> scansEnum = scans.elements();
-    while (scansEnum.hasMoreElements()) {
-      Scan scan = scansEnum.nextElement();
-
+    for(Scan scan : scans) {
       // ignore scans of other ms levels
       if (scan.getMSLevel() != msLevel) {
         continue;
@@ -350,7 +301,6 @@ public class RawDataFileImpl implements RawDataFile, RawDataFileWriter {
       if ((maxBasePeak == null) || (scanBasePeak.getIntensity() > maxBasePeak)) {
         maxBasePeak = scanBasePeak.getIntensity();
       }
-
     }
 
     // return -1 if no scan at this MS level
@@ -362,7 +312,6 @@ public class RawDataFileImpl implements RawDataFile, RawDataFileWriter {
     dataMaxBasePeakIntensity.put(msLevel, maxBasePeak);
 
     return maxBasePeak;
-
   }
 
   /**
@@ -378,10 +327,7 @@ public class RawDataFileImpl implements RawDataFile, RawDataFileWriter {
     }
 
     // find the value
-    Enumeration<? extends Scan> scansEnum = scans.elements();
-    while (scansEnum.hasMoreElements()) {
-      Scan scan = scansEnum.nextElement();
-
+    for(Scan scan : scans) {
       // ignore scans of other ms levels
       if (scan.getMSLevel() != msLevel) {
         continue;
@@ -494,32 +440,38 @@ public class RawDataFileImpl implements RawDataFile, RawDataFileWriter {
 
   @Override
   public synchronized Scan addScan(Scan newScan) throws IOException {
-
     // When we are loading the project, scan data file is already prepare
     // and we just need store the reference
+    final Scan addedScan;
     if (newScan instanceof StorableScan) {
-      scans.put(newScan.getScanNumber(), newScan);
-      return newScan;
+      scans.add(newScan);
+      addedScan = newScan;
     }
-    if (newScan instanceof SimpleImagingScan) {
+    else if (newScan instanceof SimpleImagingScan) {
       DataPoint[] dataPoints = newScan.getDataPoints();
       final int storageID = storeDataPoints(dataPoints);
       StorableImagingScan storedScan =
           new StorableImagingScan(newScan, this, dataPoints.length, storageID);
-      if (scans.put(newScan.getScanNumber(), storedScan) != null) {
-        logger.info("scan " + newScan.getScanNumber() + " already existed");
-      }
-      return storedScan;
+      scans.add(newScan);
+      addedScan = storedScan;
     } else if (newScan instanceof SimpleScan) {
       DataPoint[] dataPoints = newScan.getDataPoints();
       final int storageID = storeDataPoints(dataPoints);
       StorableScan storedScan = new StorableScan(newScan, this, dataPoints.length, storageID);
-      if (scans.put(newScan.getScanNumber(), storedScan) != null) {
-        logger.info("scan " + newScan.getScanNumber() + " already existed");
-      }
-      return storedScan;
+      scans.add(newScan);
+      addedScan = storedScan;
     }
-    return newScan;
+    else {
+      throw new IllegalArgumentException("Class of scan is not handled in addScan method");
+    }
+    // cached lists for each MS level
+    ObservableList<Scan> msLevelScans = scanNumbersCache.get(addedScan.getMSLevel());
+    if(msLevelScans==null) {
+      msLevelScans = FXCollections.observableArrayList();
+      scanNumbersCache.put(addedScan.getMSLevel(), msLevelScans);
+    }
+    msLevelScans.add(addedScan);
+    return addedScan;
   }
 
 
@@ -528,7 +480,7 @@ public class RawDataFileImpl implements RawDataFile, RawDataFileWriter {
    */
   @Override
   public synchronized RawDataFile finishWriting() throws IOException {
-    for (Scan scan : scans.values()) {
+    for (Scan scan : scans) {
       ((StorableScan) scan).updateValues();
     }
     logger.finest("Writing of scans to file " + dataPointsFileName + " finished");
@@ -552,7 +504,7 @@ public class RawDataFileImpl implements RawDataFile, RawDataFileWriter {
     }
 
     // find the value
-    for (Scan scan : scans.values()) {
+    for (Scan scan : scans) {
 
       // ignore scans of other ms levels
       if ((msLevel != 0) && (scan.getMSLevel() != msLevel)) {
@@ -603,7 +555,7 @@ public class RawDataFileImpl implements RawDataFile, RawDataFileWriter {
     }
 
     // find the value
-    for (Scan scan : scans.values()) {
+    for (Scan scan : scans) {
 
       // ignore scans of other ms levels
       if ((msLevel != 0) && (scan.getMSLevel() != msLevel)) {
@@ -650,7 +602,7 @@ public class RawDataFileImpl implements RawDataFile, RawDataFileWriter {
 
   @Override
   public int getNumOfScans(int msLevel) {
-    return getScanNumbers(msLevel).length;
+    return getScanNumbers(msLevel).size();
   }
 
   public synchronized TreeMap<Integer, Long> getDataPointsOffsets() {
@@ -663,15 +615,7 @@ public class RawDataFileImpl implements RawDataFile, RawDataFileWriter {
 
   @Override
   public List<PolarityType> getDataPolarity() {
-    Enumeration<Scan> scansEnum = scans.elements();
-    // create an enum set to store different polarity types encountered within the file
-    EnumSet<PolarityType> polarityTypes = EnumSet.noneOf(PolarityType.class);
-    while (scansEnum.hasMoreElements()) {
-      Scan scan = scansEnum.nextElement();
-      polarityTypes.add(scan.getPolarity());
-    }
-    // return as list
-    return polarityTypes.stream().collect(Collectors.toList());
+    return scans.stream().map(Scan::getPolarity).collect(Collectors.toList());
   }
 
   @Override
@@ -720,6 +664,11 @@ public class RawDataFileImpl implements RawDataFile, RawDataFileWriter {
   @Override
   public String toString() {
     return dataFileName;
+  }
+
+  @Override
+  public ObservableList<Scan> getScans() {
+    return scans;
   }
 
   // TODO make sure that equals and hashCode() works

--- a/src/main/java/io/github/mzmine/project/impl/RawDataFileImpl.java
+++ b/src/main/java/io/github/mzmine/project/impl/RawDataFileImpl.java
@@ -452,13 +452,13 @@ public class RawDataFileImpl implements RawDataFile, RawDataFileWriter {
       final int storageID = storeDataPoints(dataPoints);
       StorableImagingScan storedScan =
           new StorableImagingScan(newScan, this, dataPoints.length, storageID);
-      scans.add(newScan);
+      scans.add(storedScan);
       addedScan = storedScan;
     } else if (newScan instanceof SimpleScan) {
       DataPoint[] dataPoints = newScan.getDataPoints();
       final int storageID = storeDataPoints(dataPoints);
       StorableScan storedScan = new StorableScan(newScan, this, dataPoints.length, storageID);
-      scans.add(newScan);
+      scans.add(storedScan);
       addedScan = storedScan;
     }
     else {

--- a/src/main/java/io/github/mzmine/project/impl/StorableMobilogram.java
+++ b/src/main/java/io/github/mzmine/project/impl/StorableMobilogram.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Range;
 import io.github.mzmine.datamodel.IMSRawDataFile;
 import io.github.mzmine.datamodel.MobilityType;
 import io.github.mzmine.datamodel.Mobilogram;
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.impl.MobilityDataPoint;
 import io.github.mzmine.main.MZmineCore;
 import java.io.IOException;
@@ -110,8 +111,7 @@ public class StorableMobilogram implements Mobilogram {
   @Nonnull
   @Override
   public List<Integer> getMobilityScanNumbers() {
-    return getDataPoints().stream().mapToInt(MobilityDataPoint::getScanNum).boxed()
-        .collect(Collectors.toList());
+    return getDataPoints().stream().map(MobilityDataPoint::getScanNum).collect(Collectors.toList());
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/util/FeatureConvertorIonMobility.java
+++ b/src/main/java/io/github/mzmine/util/FeatureConvertorIonMobility.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Range;
 import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.IMSRawDataFile;
 import io.github.mzmine.datamodel.ImsMsMsInfo;
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
@@ -38,6 +39,7 @@ import io.github.mzmine.util.maths.CenterFunction;
 import io.github.mzmine.util.scans.ScanUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -53,7 +55,7 @@ import javax.annotation.Nullable;
 public class FeatureConvertorIonMobility {
 
   private static final FixedSizeHashMap
-      <ModularFeature, Map<Integer, Set<RetentionTimeMobilityDataPoint>>> cache =
+      <ModularFeature, Map<Scan, Set<RetentionTimeMobilityDataPoint>>> cache =
       new FixedSizeHashMap<>();
 
   /**
@@ -70,13 +72,13 @@ public class FeatureConvertorIonMobility {
 
     ModularFeature newFeature = new ModularFeature(flist);
     newFeature.set(RawFileType.class, originalFeature.getRawDataFile());
-    Map<Integer, Set<RetentionTimeMobilityDataPoint>> sortedDataPoints = groupDataPointsByFrameId(
+    Map<Scan, Set<RetentionTimeMobilityDataPoint>> sortedDataPoints = groupDataPointsByFrameId(
         originalFeature);
 
     double maxIntensity = 0;
     // sum intensity over mobility dimension
-    for (Entry<Integer, Set<RetentionTimeMobilityDataPoint>> entry : sortedDataPoints.entrySet()) {
-      int frameNumber = entry.getKey();
+    for (Entry<Scan, Set<RetentionTimeMobilityDataPoint>> entry : sortedDataPoints.entrySet()) {
+      Scan frame = entry.getKey();
       double mz = 0;
       double intensity = 0;
       for (RetentionTimeMobilityDataPoint dp : entry.getValue()) {
@@ -87,7 +89,7 @@ public class FeatureConvertorIonMobility {
         }
       }
       DataPoint summedDataPoint = new SimpleDataPoint(mz / entry.getValue().size(), intensity);
-      newFeature.getScanNumbers().add(frameNumber);
+      newFeature.getScanNumbers().add(frame);
       newFeature.getDataPoints().add(summedDataPoint);
     }
     newFeature.setHeight((float) maxIntensity);
@@ -127,7 +129,7 @@ public class FeatureConvertorIonMobility {
      */
 
     // replace datapoints in mobility-collapsed resolved feature with original data points
-    Map<Integer, Set<RetentionTimeMobilityDataPoint>> originalDataPoints = groupDataPointsByFrameId(
+    Map<Scan, Set<RetentionTimeMobilityDataPoint>> originalDataPoints = groupDataPointsByFrameId(
         originalFeature);
     for (ModularFeature processedFeature : processedFeatures) {
       processedFeature.getDataPoints().clear();
@@ -186,7 +188,7 @@ public class FeatureConvertorIonMobility {
    * @param originalFeature The original feature
    * @return Mapping of frame id -> set of {@link RetentionTimeMobilityDataPoint}.
    */
-  public static Map<Integer, Set<RetentionTimeMobilityDataPoint>> groupDataPointsByFrameId(
+  public static Map<Scan, Set<RetentionTimeMobilityDataPoint>> groupDataPointsByFrameId(
       @Nonnull final ModularFeature originalFeature) {
     if (!(originalFeature.getRawDataFile() instanceof IMSRawDataFile)) {
       throw new IllegalArgumentException(
@@ -194,7 +196,7 @@ public class FeatureConvertorIonMobility {
     }
 
     // I'm not using computeIfAbsent here because it might lead to a concurrent modification
-    Map<Integer, Set<RetentionTimeMobilityDataPoint>> val = cache.get(originalFeature);
+    Map<Scan, Set<RetentionTimeMobilityDataPoint>> val = cache.get(originalFeature);
     if (val != null) {
       return val;
     }
@@ -209,7 +211,7 @@ public class FeatureConvertorIonMobility {
    * @return
    */
   @Nonnull
-  private static Map<Integer, Set<RetentionTimeMobilityDataPoint>> groupByFrameIdAndCacheDataPoints(
+  private static Map<Scan, Set<RetentionTimeMobilityDataPoint>> groupByFrameIdAndCacheDataPoints(
       @Nonnull final ModularFeature originalFeature) {
 
     List<? extends DataPoint> originalDataPoints = originalFeature.getDataPoints();
@@ -224,11 +226,10 @@ public class FeatureConvertorIonMobility {
     }
 
     // group by frame & sort ascending
-    Map<Integer, Set<RetentionTimeMobilityDataPoint>> sortedDataPoints = new TreeMap<>(
-        Integer::compareTo);
+    Map<Integer, Set<RetentionTimeMobilityDataPoint>> sortedDataPoints = new TreeMap<>(Integer::compareTo);
     for (RetentionTimeMobilityDataPoint dp : mobilityDataPoints) {
       Set<RetentionTimeMobilityDataPoint> entry = sortedDataPoints
-          .computeIfAbsent(dp.getFrameNumber(), HashSet::new);
+          .computeIfAbsent(dp.getFrame(), HashSet::new);
       entry.add(dp);
     }
 

--- a/src/main/java/io/github/mzmine/util/FeatureConvertorIonMobility.java
+++ b/src/main/java/io/github/mzmine/util/FeatureConvertorIonMobility.java
@@ -226,10 +226,11 @@ public class FeatureConvertorIonMobility {
     }
 
     // group by frame & sort ascending
-    Map<Integer, Set<RetentionTimeMobilityDataPoint>> sortedDataPoints = new TreeMap<>(Integer::compareTo);
+    Map<Scan, Set<RetentionTimeMobilityDataPoint>> sortedDataPoints = new TreeMap<>(
+        Comparator.comparingInt(Scan::getScanNumber));
     for (RetentionTimeMobilityDataPoint dp : mobilityDataPoints) {
       Set<RetentionTimeMobilityDataPoint> entry = sortedDataPoints
-          .computeIfAbsent(dp.getFrame(), HashSet::new);
+          .computeIfAbsent(dp.getFrame(), scan -> new HashSet<>());
       entry.add(dp);
     }
 

--- a/src/main/java/io/github/mzmine/util/FeatureConvertors.java
+++ b/src/main/java/io/github/mzmine/util/FeatureConvertors.java
@@ -89,8 +89,8 @@ public class FeatureConvertors {
     ModularFeature modularFeature =
         new ModularFeature((ModularFeatureList) chromatogram.getFeatureList());
 
-    modularFeature.set(FragmentScanNumbersType.class, chromatogram.getAllMS2FragmentScanNumbers());
-    modularFeature.set(ScanNumbersType.class, chromatogram.getScanNumbers());
+    modularFeature.set(FragmentScanNumbersType.class, List.of(chromatogram.getAllMS2FragmentScanNumbers()));
+    modularFeature.set(ScanNumbersType.class, List.of(chromatogram.getScanNumbers()));
 
     modularFeature
         .set(BestFragmentScanNumberType.class, chromatogram.getMostIntenseFragmentScanNumber());
@@ -308,8 +308,8 @@ public class FeatureConvertors {
     modularFeature.setRepresentativeScan(manualFeature.getRepresentativeScanNumber());
     // Add values to feature
 
-    modularFeature.set(FragmentScanNumbersType.class, manualFeature.getAllMS2FragmentScanNumbers());
-    modularFeature.set(ScanNumbersType.class, manualFeature.getScanNumbers());
+    modularFeature.set(FragmentScanNumbersType.class, List.of(manualFeature.getAllMS2FragmentScanNumbers()));
+    modularFeature.set(ScanNumbersType.class, List.of(manualFeature.getScanNumbers()));
 
     modularFeature.set(RawFileType.class, manualFeature.getRawDataFile());
     modularFeature.set(DetectionType.class, manualFeature.getFeatureStatus());
@@ -378,8 +378,8 @@ public class FeatureConvertors {
     ModularFeature modularFeature = new ModularFeature(featureList);
 
 
-    modularFeature.set(FragmentScanNumbersType.class, sameRangePeak.getAllMS2FragmentScanNumbers());
-    modularFeature.set(ScanNumbersType.class, sameRangePeak.getScanNumbers());
+    modularFeature.set(FragmentScanNumbersType.class, List.of(sameRangePeak.getAllMS2FragmentScanNumbers()));
+    modularFeature.set(ScanNumbersType.class, List.of(sameRangePeak.getScanNumbers()));
 
     modularFeature
         .set(BestFragmentScanNumberType.class, sameRangePeak.getMostIntenseFragmentScanNumber());
@@ -449,8 +449,8 @@ public class FeatureConvertors {
         new ModularFeature(featureList);
 
 
-    modularFeature.set(FragmentScanNumbersType.class, sameRangePeak.getAllMS2FragmentScanNumbers());
-    modularFeature.set(ScanNumbersType.class, sameRangePeak.getScanNumbers());
+    modularFeature.set(FragmentScanNumbersType.class, List.of(sameRangePeak.getAllMS2FragmentScanNumbers()));
+    modularFeature.set(ScanNumbersType.class, List.of(sameRangePeak.getScanNumbers()));
 
     modularFeature
         .set(BestFragmentScanNumberType.class, sameRangePeak.getMostIntenseFragmentScanNumber());
@@ -520,8 +520,8 @@ public class FeatureConvertors {
         new ModularFeature(featureList);
 
     // Add values to feature
-    modularFeature.set(FragmentScanNumbersType.class, resolvedPeak.getAllMS2FragmentScanNumbers());
-    modularFeature.set(ScanNumbersType.class, resolvedPeak.getScanNumbers());
+    modularFeature.set(FragmentScanNumbersType.class, List.of(resolvedPeak.getAllMS2FragmentScanNumbers()));
+    modularFeature.set(ScanNumbersType.class, List.of(resolvedPeak.getScanNumbers()));
 
     modularFeature
         .set(BestFragmentScanNumberType.class, resolvedPeak.getMostIntenseFragmentScanNumber());

--- a/src/main/java/io/github/mzmine/util/ManualFeatureUtils.java
+++ b/src/main/java/io/github/mzmine/util/ManualFeatureUtils.java
@@ -42,13 +42,9 @@ public class ManualFeatureUtils {
     ManualFeature newFeature = new ManualFeature(dataFile);
     boolean dataPointFound = false;
 
-    int[] scanNumbers = dataFile.getScanNumbers(1, rtRange);
+    Scan[] scanNumbers = dataFile.getScanNumbers(1, rtRange);
 
-    for (int scanNumber : scanNumbers) {
-
-      // Get next scan
-      Scan scan = dataFile.getScan(scanNumber);
-
+    for (Scan scan : scanNumbers) {
       // Find most intense m/z feature
       DataPoint basePeak = ScanUtils.findBasePeak(scan, mzRange);
 
@@ -56,11 +52,11 @@ public class ManualFeatureUtils {
         if (basePeak.getIntensity() > 0) {
           dataPointFound = true;
         }
-        newFeature.addDatapoint(scan.getScanNumber(), basePeak);
+        newFeature.addDatapoint(scan, basePeak);
       } else {
         final double mzCenter = (mzRange.lowerEndpoint() + mzRange.upperEndpoint()) / 2.0;
         DataPoint fakeDataPoint = new SimpleDataPoint(mzCenter, 0);
-        newFeature.addDatapoint(scan.getScanNumber(), fakeDataPoint);
+        newFeature.addDatapoint(scan, fakeDataPoint);
       }
     }
 

--- a/src/main/java/io/github/mzmine/util/MirrorChartFactory.java
+++ b/src/main/java/io/github/mzmine/util/MirrorChartFactory.java
@@ -234,7 +234,7 @@ public class MirrorChartFactory {
     } else if (raw != null) {
       Feature peak = row.getFeature(raw);
       if (peak != null) {
-        scan = raw.getScan(peak.getMostIntenseFragmentScanNumber());
+        scan = peak.getMostIntenseFragmentScan();
       }
     }
     if (scan == null && useBestForMissingRaw) {

--- a/src/main/java/io/github/mzmine/util/RawDataFileUtils.java
+++ b/src/main/java/io/github/mzmine/util/RawDataFileUtils.java
@@ -18,11 +18,11 @@
 
 package io.github.mzmine.util;
 
+import javafx.collections.ObservableList;
 import javax.annotation.Nonnull;
 
 import com.google.common.collect.Range;
 
-import io.github.msdk.util.RawDataFileUtil;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.Scan;
 
@@ -68,29 +68,28 @@ public class RawDataFileUtils {
    * 
    */
   public static boolean hasMassLists(RawDataFile dataFile) {
-    for (int scanNum : dataFile.getScanNumbers(1)) {
-      Scan scan = dataFile.getScan(scanNum);
+    for (Scan scan : dataFile.getScanNumbers(1)) {
       if (scan.getMassLists().length == 0)
         return false;
     }
     return true;
   }
 
-  public static int getClosestScanNumber(RawDataFile dataFile, double rt) {
+  public static Scan getClosestScanNumber(RawDataFile dataFile, double rt) {
 
-    int scanNums[] = dataFile.getScanNumbers();
-    if (scanNums.length == 0)
-      return -1;
+    ObservableList<Scan> scanNums = dataFile.getScans();
+    if (scanNums.size() == 0)
+      return null;
     int best = 0;
-    double bestRt = dataFile.getScan(scanNums[0]).getRetentionTime();
+    double bestRt = scanNums.get(0).getRetentionTime();
 
-    for (int i = 1; i < scanNums.length; i++) {
-      double thisRt = dataFile.getScan(scanNums[i]).getRetentionTime();
+    for (int i = 1; i < scanNums.size(); i++) {
+      double thisRt = scanNums.get(i).getRetentionTime();
       if (Math.abs(bestRt - rt) > Math.abs(thisRt - rt)) {
         best = i;
         bestRt = thisRt;
       }
     }
-    return scanNums[best];
+    return scanNums.get(best);
   }
 }

--- a/src/main/java/io/github/mzmine/util/adap/ADAPInterface.java
+++ b/src/main/java/io/github/mzmine/util/adap/ADAPInterface.java
@@ -15,12 +15,15 @@
  */
 package io.github.mzmine.util.adap;
 
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.datamodel.features.ModularFeature;
+import java.util.List;
 import java.util.Map.Entry;
 import java.util.NavigableMap;
 import java.util.TreeMap;
+import javafx.collections.ObservableList;
 import javax.annotation.Nonnull;
 import com.google.common.collect.Range;
 import dulab.adap.datamodel.BetterPeak;
@@ -60,10 +63,13 @@ public class ADAPInterface {
 
     NavigableMap<Double, Double> chromatogram = new TreeMap<>();
 
-    for (final int scan : peak.getScanNumbers()) {
-      final DataPoint dataPoint = peak.getDataPoint(scan);
-      if (dataPoint != null)
-        chromatogram.put((double) dataFile.getScan(scan).getRetentionTime(), dataPoint.getIntensity());
+    ObservableList<DataPoint> dataPoints = peak.getDataPoints();
+    for (int i = 0; i < dataPoints.size(); i++) {
+      final DataPoint dataPoint = dataPoints.get(i);
+      if (dataPoint != null) {
+        float rt = peak.getRetentionTimeAtIndex(i);
+        chromatogram.put(Double.valueOf(String.valueOf(rt)), dataPoint.getIntensity());
+      }
     }
 
     return new Component(null,
@@ -77,11 +83,11 @@ public class ADAPInterface {
     Chromatogram chromatogram = peak.chromatogram;
 
     // Retrieve scan numbers
-    int representativeScan = 0;
-    int[] scanNumbers = new int[chromatogram.length];
+    Scan representativeScan = null;
+    Scan[] scanNumbers = new Scan[chromatogram.length];
     int count = 0;
-    for (int num : file.getScanNumbers()) {
-      double retTime = file.getScan(num).getRetentionTime();
+    for (Scan num : file.getScans()) {
+      double retTime = num.getRetentionTime();
       Double intensity = chromatogram.getIntensity(retTime, false);
       if (intensity != null)
         scanNumbers[count++] = num;
@@ -105,7 +111,7 @@ public class ADAPInterface {
 
     return new ModularFeature(featureList, file, peak.getMZ(), (float) peak.getRetTime(), (float) peak.getIntensity(),
         (float) area, scanNumbers, dataPoints, FeatureStatus.ESTIMATED, representativeScan, representativeScan,
-        new int[] {}, Range.closed((float) peak.getFirstRetTime(), (float) peak.getLastRetTime()),
+        new Scan[] {}, Range.closed((float) peak.getFirstRetTime(), (float) peak.getLastRetTime()),
         Range.closed(peak.getMZ() - 0.01, peak.getMZ() + 0.01),
         Range.closed(0.f, (float) peak.getIntensity()));
   }

--- a/src/main/java/io/github/mzmine/util/components/CombinedXICComponent.java
+++ b/src/main/java/io/github/mzmine/util/components/CombinedXICComponent.java
@@ -18,10 +18,12 @@
 
 package io.github.mzmine.util.components;
 
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
+import javafx.collections.ObservableList;
 import org.jfree.fx.FXGraphics2D;
 import com.google.common.collect.Range;
 import io.github.mzmine.datamodel.DataPoint;
@@ -47,7 +49,7 @@ public class CombinedXICComponent extends Canvas {
   private double maxIntensity;
 
   /**
-   * @param ChromatographicPeak [] Picked peaks to plot
+   * @param peaks [] Picked peaks to plot
    */
   public CombinedXICComponent(Feature[] peaks, int id) {
 
@@ -107,24 +109,25 @@ public class CombinedXICComponent extends Canvas {
         continue;
 
       // get scan numbers, one data point per each scan
-      Integer scanNumbers[] = peak.getScanNumbers().toArray(new Integer[0]);
+      ObservableList<Scan> scans = peak.getScanNumbers();
+      int numberOfScans = scans.size();
 
       // for each datapoint, find [X:Y] coordinates of its point in
       // painted image
-      int xValues[] = new int[scanNumbers.length + 2];
-      int yValues[] = new int[scanNumbers.length + 2];
+      int xValues[] = new int[numberOfScans + 2];
+      int yValues[] = new int[numberOfScans + 2];
 
       // find one datapoint with maximum intensity in each scan
-      for (int i = 0; i < scanNumbers.length; i++) {
+      for (int i = 0; i < numberOfScans; i++) {
 
         double dataPointIntensity = 0;
-        DataPoint dataPoint = peak.getDataPoint(scanNumbers[i]);
+        DataPoint dataPoint = peak.getDataPointAtIndex(i);
 
         if (dataPoint != null)
           dataPointIntensity = dataPoint.getIntensity();
 
         // get retention time (X value)
-        float retentionTime = peak.getRawDataFile().getScan(scanNumbers[i]).getRetentionTime();
+        float retentionTime = scans.get(i).getRetentionTime();
 
         // calculate [X:Y] coordinates
         xValues[i + 1] = (int) Math.floor((retentionTime - rtRange.lowerEndpoint())

--- a/src/main/java/io/github/mzmine/util/components/PeakXICComponent.java
+++ b/src/main/java/io/github/mzmine/util/components/PeakXICComponent.java
@@ -97,7 +97,7 @@ public class PeakXICComponent extends Canvas {
     for (int i = 0; i < scanNumbers.length; i++) {
 
       double dataPointIntensity = 0;
-      DataPoint dataPoint = peak.getDataPoint(scanNumbers[i]);
+      DataPoint dataPoint = peak.getDataPointAtIndex(i);
 
       if (dataPoint != null)
         dataPointIntensity = dataPoint.getIntensity();

--- a/src/main/java/io/github/mzmine/util/dialogs/FeatureOverviewWindow.java
+++ b/src/main/java/io/github/mzmine/util/dialogs/FeatureOverviewWindow.java
@@ -92,7 +92,7 @@ public class FeatureOverviewWindow extends Stage {
     splitPaneRight.getItems().add(addSpectraMS1());
 
     // add Spectra MS2
-    if (feature.getMostIntenseFragmentScanNumber() > 0) {
+    if (feature.getMostIntenseFragmentScan() != null) {
       splitPaneRight.getItems().add(addSpectraMS2());
     } else {
       FlowPane noMSMSPanel = new FlowPane();
@@ -174,7 +174,7 @@ public class FeatureOverviewWindow extends Stage {
     SplitPane pane = new SplitPane();
     pane.setOrientation(Orientation.HORIZONTAL);
     SpectraVisualizerTab spectraWindowMS1 = new SpectraVisualizerTab(rawFiles[0]);
-    spectraWindowMS1.loadRawData(rawFiles[0].getScan(feature.getRepresentativeScanNumber()));
+    spectraWindowMS1.loadRawData(feature.getRepresentativeScan());
     pane.getItems().add(spectraWindowMS1.getContent());
     return pane;
   }
@@ -183,7 +183,7 @@ public class FeatureOverviewWindow extends Stage {
     SplitPane pane = new SplitPane();
     pane.setOrientation(Orientation.HORIZONTAL);
     SpectraVisualizerTab spectraWindowMS2 = new SpectraVisualizerTab(rawFiles[0]);
-    spectraWindowMS2.loadRawData(rawFiles[0].getScan(feature.getMostIntenseFragmentScanNumber()));
+    spectraWindowMS2.loadRawData(feature.getMostIntenseFragmentScan());
     pane.getItems().add(spectraWindowMS2.getContent());
     return pane;
   }


### PR DESCRIPTION
Praise the lord as he has taken the burden of boxing and unboxing scan numbers from us.

This PR removes the use of scan numbers - we use references to scans now.
Tested:
- Raw data import
- project import
- mass detection, chromatogram building, deconvolution

Chromatogram building feels way faster now. Not tested though

This is the memory difference when we run Chromatogram building on 3 files with around 8000 features total: (I will upload a comparison to the old scan numbers mzmine later):
![image](https://user-images.githubusercontent.com/10366914/103482619-1bd7b080-4de2-11eb-9924-9cf14d5ad03f.png)
