### PR TITLE
fix concurrent modification exception in task controller

### DIFF
--- a/src/main/java/io/github/mzmine/taskcontrol/impl/TaskQueue.java
+++ b/src/main/java/io/github/mzmine/taskcontrol/impl/TaskQueue.java
@@ -18,9 +18,9 @@
 
 package io.github.mzmine.taskcontrol.impl;
 
+import io.github.mzmine.taskcontrol.TaskStatus;
 import java.util.Arrays;
 import java.util.logging.Logger;
-import io.github.mzmine.taskcontrol.TaskStatus;
 import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -31,12 +31,12 @@ import javafx.collections.ObservableList;
  */
 public class TaskQueue {
 
-  private Logger logger = Logger.getLogger(this.getClass().getName());
-
   /**
    * This observable list stores the actual tasks
    */
-  private final ObservableList<WrappedTask> queue = FXCollections.observableArrayList();
+  private final ObservableList<WrappedTask> queue = FXCollections
+      .synchronizedObservableList(FXCollections.observableArrayList());
+  private Logger logger = Logger.getLogger(this.getClass().getName());
 
   public int getNumOfWaitingTasks() {
     final WrappedTask snapshot[] = getQueueSnapshot();


### PR DESCRIPTION
Hi, this fixes an exception in the task controller:

`[16:25:34|FINEST|io.github.mzmine.taskcontrol.impl.TaskQueue]: Clearing the task controller queue
[16:25:34|FINEST|io.github.mzmine.taskcontrol.impl.TaskQueue]: Clearing the task controller queue
Exception in thread "Task controller thread" java.util.ConcurrentModificationException
	at java.base/java.util.AbstractList$Itr.checkForComodification(AbstractList.java:399)
	at java.base/java.util.AbstractList$Itr.next(AbstractList.java:376)
	at java.base/java.util.AbstractCollection.toArray(AbstractCollection.java:202)
	at io.github.mzmine.taskcontrol.impl.TaskQueue.getQueueSnapshot(TaskQueue.java:83)
	at io.github.mzmine.taskcontrol.impl.TaskQueue.getNumOfWaitingTasks(TaskQueue.java:42)
	at io.github.mzmine.taskcontrol.impl.TaskControllerImpl.run(TaskControllerImpl.java:142)
	at java.base/java.lang.Thread.run(Thread.java:832)`