### PR TITLE
Imsvisualiserfix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,7 @@ group = "io.github.mzmine"
 version = "3.0"
 description = "MZmine"
 
-// JDK 14+ is needed for jpackage, but we maintain Java 11 source/target
-// compatibility to avoid problems with JavaFX Scene Builder
+// JDK 14+ is needed for jpackage
 sourceCompatibility = "15"
 targetCompatibility = "15"
 defaultTasks "jpackage"

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/FeatureDataUtils.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/FeatureDataUtils.java
@@ -1,0 +1,144 @@
+/*
+ *  Copyright 2006-2020 The MZmine Development Team
+ *
+ *  This file is part of MZmine.
+ *
+ *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ *  General Public License as published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
+ *
+ *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ *  Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with MZmine; if not,
+ *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ *  USA
+ */
+
+package io.github.mzmine.datamodel.featuredata;
+
+import com.google.common.collect.Range;
+import io.github.mzmine.datamodel.MassSpectrum;
+import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.datamodel.features.ModularFeature;
+import io.github.mzmine.datamodel.features.types.numbers.AreaType;
+import io.github.mzmine.datamodel.features.types.numbers.IntensityRangeType;
+import io.github.mzmine.datamodel.features.types.numbers.MZRangeType;
+import io.github.mzmine.datamodel.features.types.numbers.RTRangeType;
+import java.nio.DoubleBuffer;
+import java.util.List;
+import javax.annotation.Nullable;
+
+public class FeatureDataUtils {
+
+  public static Range<Float> getRtRange(IonTimeSeries<? extends Scan> series) {
+    final List<? extends Scan> scans = series.getSpectra();
+    return Range
+        .closed(scans.get(0).getRetentionTime(), scans.get(scans.size() - 1).getRetentionTime());
+  }
+
+  public static Range<Double> getMzRange(MzSeries series) {
+    double min = Double.MAX_VALUE;
+    double max = Double.MIN_VALUE;
+
+    for (int i = 0; i < series.getNumberOfValues(); i++) {
+      final double mz = series.getMZ(i);
+      if (mz < min) {
+        min = mz;
+      }
+      if (mz > max) {
+        max = mz;
+      }
+    }
+    return Range.closed(min, max);
+  }
+
+  public static Range<Float> getIntensityRange(IntensitySeries series) {
+    double min = Double.MAX_VALUE;
+    double max = Double.MIN_VALUE;
+
+    for (int i = 0; i < series.getNumberOfValues(); i++) {
+      final double mz = series.getIntensity(i);
+      if (mz < min) {
+        min = mz;
+      }
+      if (mz > max) {
+        max = mz;
+      }
+    }
+    return Range.closed((float) min, (float) max);
+  }
+
+  public static Range<Float> getMobilityRange(MobilitySeries series) {
+    double min = Double.MAX_VALUE;
+    double max = Double.MIN_VALUE;
+
+    for (int i = 0; i < series.getNumberOfValues(); i++) {
+      final double mz = series.getMobility(i);
+      if (mz < min) {
+        min = mz;
+      }
+      if (mz > max) {
+        max = mz;
+      }
+    }
+    return Range.closed((float) min, (float) max);
+  }
+
+  @Nullable
+  public static MassSpectrum getMostIntenseSpectrum(
+      IonSpectrumSeries<? extends MassSpectrum> series) {
+    int maxIndex = -1;
+    double maxIntensity = Double.MIN_VALUE;
+
+    for (int i = 0; i < series.getNumberOfValues(); i++) {
+      final double intensity = series.getIntensity(i);
+      if (intensity > maxIntensity) {
+        maxIndex = i;
+        maxIntensity = intensity;
+      }
+    }
+    return maxIndex != -1 ? series.getSpectrum(maxIndex) : null;
+  }
+
+  @Nullable
+  public static Scan getMostIntenseScan(IonTimeSeries<? extends Scan> series) {
+    return (Scan) getMostIntenseSpectrum(series);
+  }
+
+  public static float calculateArea(IonTimeSeries<? extends Scan> series) {
+    if (series.getNumberOfValues() <= 1) {
+      return 0f;
+    }
+    float area = 0f;
+    DoubleBuffer intensities = series.getIntensityValues();
+    List<? extends Scan> scans = series.getSpectra();
+    for (int i = 1; i < series.getNumberOfValues(); i++) {
+      final double lastIntensity = intensities.get(i - 1);
+      final double thisIntensity = intensities.get(i);
+      final float lastRT = scans.get(i - 1).getRetentionTime();
+      final float thisRT = scans.get(i).getRetentionTime();
+      area += (thisRT - lastRT) * (thisIntensity + lastIntensity) / 2.0 /* 60d*/;
+    }
+    return area;
+  }
+
+  public static void recalculateIonSeriesDependingTypes(ModularFeature feature) {
+    IonTimeSeries<? extends Scan> featureData = feature.getFeatureData();
+    Range<Float> intensityRange = FeatureDataUtils.getIntensityRange(featureData);
+    Range<Double> mzRange = FeatureDataUtils.getMzRange(featureData);
+    Range<Float> rtRange = FeatureDataUtils.getRtRange(featureData);
+    Scan mostIntenseSpectrum = FeatureDataUtils.getMostIntenseScan(featureData);
+    float area = FeatureDataUtils.calculateArea(featureData);
+
+    feature.set(AreaType.class, area);
+    feature.set(MZRangeType.class, mzRange);
+    feature.set(RTRangeType.class, rtRange);
+    feature.set(IntensityRangeType.class, intensityRange);
+    feature.setRepresentativeScan(mostIntenseSpectrum);
+    feature.setHeight(intensityRange.upperEndpoint());
+
+    // todo recalc quality parameters
+  }
+}

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/IntensitySeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/IntensitySeries.java
@@ -27,12 +27,25 @@ import java.nio.DoubleBuffer;
  */
 public interface IntensitySeries extends SeriesValueCount {
 
+  /**
+   *
+   * @return All non-zero intensities.
+   */
   DoubleBuffer getIntensityValues();
 
+  /**
+   *
+   * @param index
+   * @return The intensity at the index position. Note that this
+   */
   default double getIntensity(int index) {
     return getIntensityValues().get(index);
   }
 
+  /**
+   *
+   * @return The number of non-zero intensity values in this series.
+   */
   default int getNumberOfValues() {
     return getIntensityValues().capacity();
   }

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/IonMobilogramTimeSeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/IonMobilogramTimeSeries.java
@@ -43,4 +43,31 @@ public interface IonMobilogramTimeSeries extends IonTimeSeries<Frame> {
   }
 
   SummedIntensityMobilitySeries getSummedMobilogram();
+
+  /**
+   * @param scan
+   * @return The intensity value for the given scan or 0 if the no intensity was measured at that
+   * scan.
+   */
+  @Override
+  default double getIntensityForSpectrum(Frame scan) {
+    int index = getSpectra().indexOf(scan);
+    if (index != -1) {
+      return getIntensity(index);
+    }
+    return 0;
+  }
+
+  /**
+   * @param scan
+   * @return The mz for the given scan or 0 if no intensity was measured at that scan.
+   */
+  @Override
+  default double getMzForSpectrum(Frame scan) {
+    int index = getSpectra().indexOf(scan);
+    if (index != -1) {
+      return getMZ(index);
+    }
+    return 0;
+  }
 }

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/IonMobilogramTimeSeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/IonMobilogramTimeSeries.java
@@ -21,6 +21,7 @@ package io.github.mzmine.datamodel.featuredata;
 import io.github.mzmine.datamodel.Frame;
 import io.github.mzmine.datamodel.featuredata.impl.SimpleIonMobilitySeries;
 import io.github.mzmine.datamodel.featuredata.impl.SummedIntensityMobilitySeries;
+import io.github.mzmine.util.MemoryMapStorage;
 import java.util.List;
 
 /**
@@ -43,6 +44,19 @@ public interface IonMobilogramTimeSeries extends IonTimeSeries<Frame> {
   }
 
   SummedIntensityMobilitySeries getSummedMobilogram();
+
+  /**
+   * Creates a copy of this series using the same frame list, but with new mz/intensities and new
+   * mobilograms, e.g. after smoothing.
+   *
+   * @param storage
+   * @param newMzValues
+   * @param newIntensityValues
+   * @param newMobilograms
+   * @return
+   */
+  IonMobilogramTimeSeries copyAndReplace(MemoryMapStorage storage, double[] newMzValues,
+      double[] newIntensityValues, List<SimpleIonMobilitySeries> newMobilograms);
 
   /**
    * @param scan

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/IonSpectrumSeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/IonSpectrumSeries.java
@@ -35,4 +35,22 @@ public interface IonSpectrumSeries<T extends MassSpectrum> extends IonSeries {
     return getSpectra().get(index);
   }
 
+  /**
+   * @param spectrum
+   * @return The intensity value for the given spectrum or 0 if the no intensity was measured at
+   * that spectrum.
+   */
+  double getIntensityForSpectrum(T spectrum);
+
+  /**
+   * @param spectrum
+   * @return The mz for the given spectrum or 0 if no intensity was measured at that spectrum.
+   */
+  default double getMzForSpectrum(T spectrum) {
+    int index = getSpectra().indexOf(spectrum);
+    if (index != -1) {
+      return getMZ(index);
+    }
+    return 0;
+  }
 }

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/IonTimeSeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/IonTimeSeries.java
@@ -33,7 +33,7 @@ public interface IonTimeSeries<T extends Scan> extends IonSpectrumSeries<T>, Tim
    * @return The intensity value for the given scan or 0 if the no intensity was measured at that
    * scan.
    */
-  default double getIntensityForScan(T scan) {
+  default double getIntensityForScan(Scan scan) {
     int index = getSpectra().indexOf(scan);
     if (index != -1) {
       return getIntensity(index);
@@ -45,7 +45,7 @@ public interface IonTimeSeries<T extends Scan> extends IonSpectrumSeries<T>, Tim
    * @param scan
    * @return The mz for the given scan or 0 if no intensity was measured at that scan.
    */
-  default double getMzForScan(T scan) {
+  default double getMzForScan(Scan scan) {
     int index = getSpectra().indexOf(scan);
     if (index != -1) {
       return getMZ(index);

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/IonTimeSeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/IonTimeSeries.java
@@ -19,6 +19,8 @@
 package io.github.mzmine.datamodel.featuredata;
 
 import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.util.MemoryMapStorage;
+import java.util.List;
 
 /**
  * Used to store a consecutive number of data points (mz and intensity values).
@@ -33,7 +35,8 @@ public interface IonTimeSeries<T extends Scan> extends IonSpectrumSeries<T>, Tim
    * @return The intensity value for the given scan or 0 if the no intensity was measured at that
    * scan.
    */
-  default double getIntensityForScan(Scan scan) {
+  @Override
+  default double getIntensityForSpectrum(Scan scan) {
     int index = getSpectra().indexOf(scan);
     if (index != -1) {
       return getIntensity(index);
@@ -45,11 +48,15 @@ public interface IonTimeSeries<T extends Scan> extends IonSpectrumSeries<T>, Tim
    * @param scan
    * @return The mz for the given scan or 0 if no intensity was measured at that scan.
    */
-  default double getMzForScan(Scan scan) {
+  @Override
+  default double getMzForSpectrum(Scan scan) {
     int index = getSpectra().indexOf(scan);
     if (index != -1) {
       return getMZ(index);
     }
     return 0;
   }
+
+  IonTimeSeries<T> copyAndReplace(MemoryMapStorage storage, double[] newMzValues,
+      double[] newIntensityValues, List<T> newScans);
 }

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/IonTimeSeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/IonTimeSeries.java
@@ -20,7 +20,6 @@ package io.github.mzmine.datamodel.featuredata;
 
 import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.util.MemoryMapStorage;
-import java.util.List;
 
 /**
  * Used to store a consecutive number of data points (mz and intensity values).
@@ -57,6 +56,15 @@ public interface IonTimeSeries<T extends Scan> extends IonSpectrumSeries<T>, Tim
     return 0;
   }
 
+  /**
+   * Creates a copy of this series using the same list of scans but possibly new mz/intensity
+   * values.
+   *
+   * @param storage
+   * @param newMzValues
+   * @param newIntensityValues
+   * @return
+   */
   IonTimeSeries<T> copyAndReplace(MemoryMapStorage storage, double[] newMzValues,
-      double[] newIntensityValues, List<T> newScans);
+      double[] newIntensityValues);
 }

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/IonTimeSeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/IonTimeSeries.java
@@ -28,4 +28,28 @@ import io.github.mzmine.datamodel.Scan;
  */
 public interface IonTimeSeries<T extends Scan> extends IonSpectrumSeries<T>, TimeSeries {
 
+  /**
+   * @param scan
+   * @return The intensity value for the given scan or 0 if the no intensity was measured at that
+   * scan.
+   */
+  default double getIntensityForScan(T scan) {
+    int index = getSpectra().indexOf(scan);
+    if (index != -1) {
+      return getIntensity(index);
+    }
+    return 0;
+  }
+
+  /**
+   * @param scan
+   * @return The mz for the given scan or 0 if no intensity was measured at that scan.
+   */
+  default double getMzForScan(T scan) {
+    int index = getSpectra().indexOf(scan);
+    if (index != -1) {
+      return getMZ(index);
+    }
+    return 0;
+  }
 }

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/MobilitySeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/MobilitySeries.java
@@ -28,5 +28,17 @@ public interface MobilitySeries extends SeriesValueCount {
   // no FloatBuffer getMobilityValues(), because this usually occurs with scans and
   // thus mobility is stored in the scan/rawdatafile object and present in ram
 
+  /**
+   * Note that the index does not correspond to scan numbers. Usually, {@link
+   * io.github.mzmine.datamodel.Scan} are associated with series, making {@link
+   * io.github.mzmine.datamodel.featuredata.impl.SimpleIonMobilitySeries#getSpectra()} or {@link
+   * io.github.mzmine.datamodel.featuredata.impl.SimpleIonMobilitySeries#getSpectrum(int)} more
+   * convenient.
+   *
+   * @param index
+   * @return The mobility value at the index position.
+   * @see io.github.mzmine.datamodel.featuredata.impl.SimpleIonMobilitySeries#getSpectrum(int)
+   * @see io.github.mzmine.datamodel.featuredata.impl.SimpleIonMobilitySeries#getSpectra()
+   */
   double getMobility(int index);
 }

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/MzSeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/MzSeries.java
@@ -36,7 +36,7 @@ public interface MzSeries extends SeriesValueCount {
   /**
    * @param index
    * @return The value at the index position. Note the index does not correspond to scan numbers.
-   * @see IonTimeSeries#getMzForScan(Scan)
+   * @see IonTimeSeries#getMzForSpectrum(Scan)
    */
   default double getMZ(int index) {
     return getMZValues().get(index);

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/MzSeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/MzSeries.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.datamodel.featuredata;
 
+import io.github.mzmine.datamodel.Scan;
 import java.nio.DoubleBuffer;
 
 /**
@@ -27,12 +28,23 @@ import java.nio.DoubleBuffer;
  */
 public interface MzSeries extends SeriesValueCount {
 
+  /**
+   * @return All mz values corresponding to non-0 intensities.
+   */
   DoubleBuffer getMZValues();
 
+  /**
+   * @param index
+   * @return The value at the index position. Note the index does not correspond to scan numbers.
+   * @see IonTimeSeries#getMzForScan(Scan)
+   */
   default double getMZ(int index) {
     return getMZValues().get(index);
   }
 
+  /**
+   * @return The number of mz values corresponding to non-0 intensities.
+   */
   default int getNumberOfValues() {
     return getMZValues().capacity();
   }

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/SeriesValueCount.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/SeriesValueCount.java
@@ -26,5 +26,9 @@ package io.github.mzmine.datamodel.featuredata;
  */
 interface SeriesValueCount {
 
+  /**
+   *
+   * @return The number of non-zero values in this series.
+   */
   int getNumberOfValues();
 }

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/TimeSeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/TimeSeries.java
@@ -27,6 +27,14 @@ public interface TimeSeries extends SeriesValueCount {
   // no FloatBuffer getRetentionTimeValues(), because this usually occurs with scans and
   // thus rt is stored in the scan object and present in ram
 
+  /**
+   * Note that the index does not correspond to scan numbers. Usually, {@link
+   * io.github.mzmine.datamodel.Scan} are associated with series, making {@link
+   * IonSpectrumSeries#getSpectra()} or {@link IonSpectrumSeries#getSpectrum(int)} more convenient.
+   *
+   * @param index
+   * @return The rt value at the index position.
+   */
   float getRetentionTime(int index);
 
 }

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonMobilitySeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonMobilitySeries.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.datamodel.featuredata.impl;
 
+import io.github.mzmine.datamodel.Frame;
 import io.github.mzmine.datamodel.MobilityScan;
 import io.github.mzmine.datamodel.featuredata.IonSpectrumSeries;
 import io.github.mzmine.util.DataPointUtils;
@@ -50,7 +51,14 @@ public class SimpleIonMobilitySeries implements IonSpectrumSeries<MobilityScan> 
       throw new IllegalArgumentException("Length of mz, intensity and/or scans does not match.");
     }
 
-    this.scans = Collections.unmodifiableList(scans);
+    final Frame frame = scans.get(0).getFrame();
+    for (MobilityScan scan : scans) {
+      if (frame != scan.getFrame()) {
+        throw new IllegalArgumentException("All mobility scans must belong to the same frame.");
+      }
+    }
+
+    this.scans = scans;
     try {
       this.mzValues = storage.storeData(mzValues);
       this.intensityValues = storage.storeData(intensityValues);
@@ -97,7 +105,7 @@ public class SimpleIonMobilitySeries implements IonSpectrumSeries<MobilityScan> 
 
   @Override
   public List<MobilityScan> getSpectra() {
-    return scans;
+    return Collections.unmodifiableList(scans);
   }
 
   @Override
@@ -105,6 +113,6 @@ public class SimpleIonMobilitySeries implements IonSpectrumSeries<MobilityScan> 
     double[][] data = DataPointUtils
         .getDataPointsAsDoubleArray(getMZValues(), getIntensityValues());
 
-    return new SimpleIonMobilitySeries(storage, data[0], data[1], getSpectra());
+    return new SimpleIonMobilitySeries(storage, data[0], data[1], scans);
   }
 }

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonMobilitySeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonMobilitySeries.java
@@ -64,6 +64,24 @@ public class SimpleIonMobilitySeries implements IonSpectrumSeries<MobilityScan> 
   }
 
   @Override
+  public double getIntensityForSpectrum(MobilityScan spectrum) {
+    int index = scans.indexOf(spectrum);
+    if (index != -1) {
+      return getIntensity(index);
+    }
+    return 0d;
+  }
+
+  @Override
+  public double getMzForSpectrum(MobilityScan spectrum) {
+    int index = scans.indexOf(spectrum);
+    if (index != -1) {
+      return getMZ(index);
+    }
+    return 0d;
+  }
+
+  @Override
   public DoubleBuffer getIntensityValues() {
     return intensityValues;
   }

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonMobilogramTimeSeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonMobilogramTimeSeries.java
@@ -19,6 +19,7 @@
 package io.github.mzmine.datamodel.featuredata.impl;
 
 import io.github.mzmine.datamodel.Frame;
+import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.featuredata.IonMobilogramTimeSeries;
 import io.github.mzmine.datamodel.featuredata.IonSpectrumSeries;
 import io.github.mzmine.datamodel.featuredata.IonTimeSeries;
@@ -33,7 +34,7 @@ import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 
 /**
- * Used to store ion mobility-LC-MS data
+ * Used to store ion mobility-LC-MS data.
  *
  * @author https://github.com/SteffenHeu
  */
@@ -41,27 +42,43 @@ public class SimpleIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
 
   private static final Logger logger = Logger.getLogger(SimpleIonTimeSeries.class.getName());
 
-  protected final List<SimpleIonMobilitySeries> simpleIonMobilitySeries;
+  protected final List<SimpleIonMobilitySeries> mobilograms;
   protected final List<Frame> frames;
-  protected SummedIntensityMobilitySeries summedMobilogram;
-  protected DoubleBuffer intensityValues;
-  protected DoubleBuffer mzValues;
+  protected final DoubleBuffer intensityValues;
+  protected final DoubleBuffer mzValues;
+  protected final SummedIntensityMobilitySeries summedMobilogram;
 
+  /**
+   * Stores a list of mobilograms. A summed intensity of each mobilogram is automatically calculated
+   * and represents this series when plotted as a 2D intensity-vs time chart (accessed via {@link
+   * SimpleIonMobilogramTimeSeries#getMZ(int)} and {@link SimpleIonMobilogramTimeSeries#getIntensity(int)}).
+   * The mz representing a mobilogram is calculated by a weighted average based on the mzs in eah
+   * mobility scan.
+   *
+   * @param storage
+   * @param mobilograms
+   * @see IonMobilogramTimeSeries#copyAndReplace(MemoryMapStorage, double[], double[])
+   * @see IonMobilogramTimeSeries#copyAndReplace(MemoryMapStorage, double[], double[], List)
+   */
   public SimpleIonMobilogramTimeSeries(@Nonnull MemoryMapStorage storage,
-      @Nonnull List<SimpleIonMobilitySeries> simpleIonMobilitySeries) {
+      @Nonnull List<SimpleIonMobilitySeries> mobilograms) {
 
-    List<Frame> tempFrames = new ArrayList<Frame>(simpleIonMobilitySeries.size());
-    this.simpleIonMobilitySeries = simpleIonMobilitySeries;
+    frames = new ArrayList<>(mobilograms.size());
+    this.mobilograms = mobilograms;
 
-    double[] summedIntensities = new double[simpleIonMobilitySeries.size()];
-    double[] weightedMzs = new double[simpleIonMobilitySeries.size()];
+    double[] summedIntensities = new double[mobilograms.size()];
+    double[] weightedMzs = new double[mobilograms.size()];
 
-    summedMobilogram = new SummedIntensityMobilitySeries(storage,
-        simpleIonMobilitySeries, summedIntensities[0]);
-
-    for (int i = 0; i < simpleIonMobilitySeries.size(); i++) {
-      SimpleIonMobilitySeries ims = simpleIonMobilitySeries.get(i);
-      tempFrames.add(ims.getSpectra().get(0).getFrame());
+    // calc summed intensities for each mobilogram
+    final RawDataFile file = mobilograms.get(0).getSpectrum(0).getDataFile();
+    for (int i = 0; i < mobilograms.size(); i++) {
+      SimpleIonMobilitySeries ims = mobilograms.get(i);
+      final Frame frame = ims.getSpectra().get(0).getFrame();
+      if (frame.getDataFile() != file) {
+        throw new IllegalArgumentException(
+            "Cannot combine mobilograms of different raw data files.");
+      }
+      frames.add(frame);
 
       DoubleBuffer intensities = ims.getIntensityValues();
       DoubleBuffer mzValues = ims.getMZValues();
@@ -77,37 +94,109 @@ public class SimpleIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
       weightedMzs[i] = weightedMz;
     }
 
+    summedMobilogram = new SummedIntensityMobilitySeries(storage,
+        mobilograms, weightedMzs[((int) weightedMzs.length / 2)]);
+
+    DoubleBuffer tempMzs;
+    DoubleBuffer tempIntensities;
     try {
-      mzValues = storage.storeData(weightedMzs);
-      intensityValues = storage.storeData(summedIntensities);
+      tempMzs = storage.storeData(weightedMzs);
+      tempIntensities = storage.storeData(summedIntensities);
     } catch (IOException e) {
       e.printStackTrace();
-      intensityValues = DoubleBuffer.wrap(summedIntensities);
-      mzValues = DoubleBuffer.wrap(weightedMzs);
+      tempMzs = DoubleBuffer.wrap(weightedMzs);
+      tempIntensities = DoubleBuffer.wrap(summedIntensities);
     }
-
-    frames = Collections.unmodifiableList(tempFrames);
+    mzValues = tempMzs;
+    intensityValues = tempIntensities;
   }
 
+  /**
+   * Constructor with custom mzs and intensities. Use with care. After feature creation, {@link
+   * SimpleIonMobilogramTimeSeries#SimpleIonMobilogramTimeSeries(MemoryMapStorage, List)} might be
+   * more applicable, to automatically calculate summed intensities for each mobilogram. This
+   * constructor is meant to be used, when intensities have been altered, e.g. by smoothing.
+   *
+   * @param storage
+   * @param mzs
+   * @param intensities
+   * @param mobilograms
+   * @param frames
+   * @see IonMobilogramTimeSeries#copyAndReplace(MemoryMapStorage, double[], double[])
+   * @see IonMobilogramTimeSeries#copyAndReplace(MemoryMapStorage, double[], double[], List)
+   */
+  private SimpleIonMobilogramTimeSeries(@Nonnull MemoryMapStorage storage, @Nonnull double[] mzs,
+      @Nonnull double[] intensities, List<SimpleIonMobilitySeries> mobilograms,
+      List<Frame> frames) {
+
+    if (mzs.length != intensities.length || mobilograms.size() != intensities.length) {
+      throw new IllegalArgumentException(
+          "Length of mz, intensity and/or mobilograms does not match.");
+    }
+
+    this.mobilograms = mobilograms;
+    this.frames = frames;
+    final RawDataFile file = mobilograms.get(0).getSpectrum(0).getDataFile();
+    for (SimpleIonMobilitySeries mobilogram : mobilograms) {
+      if (mobilogram.getSpectrum(0).getDataFile() != file) {
+        throw new IllegalArgumentException(
+            "Cannot combine mobilograms of different raw data files.");
+      }
+    }
+
+    summedMobilogram = new SummedIntensityMobilitySeries(storage,
+        mobilograms, mzs[((int) mzs.length / 2)]);
+
+    DoubleBuffer tempMzs;
+    DoubleBuffer tempIntensities;
+    try {
+      tempMzs = storage.storeData(mzs);
+      tempIntensities = storage.storeData(intensities);
+    } catch (IOException e) {
+      e.printStackTrace();
+      tempMzs = DoubleBuffer.wrap(mzs);
+      tempIntensities = DoubleBuffer.wrap(intensities);
+    }
+    mzValues = tempMzs;
+    intensityValues = tempIntensities;
+  }
+
+  /**
+   * Private copy constructor.
+   *
+   * @param storage
+   * @param series
+   * @param frames  to be passed directly, sicne getSpectra wraps in a unmodifiable list. ->
+   *                wrapping over and over
+   * @see IonMobilogramTimeSeries#copyAndReplace(MemoryMapStorage, double[], double[])
+   * @see IonMobilogramTimeSeries#copyAndReplace(MemoryMapStorage, double[], double[], List)
+   */
   private SimpleIonMobilogramTimeSeries(@Nonnull MemoryMapStorage storage,
-      @Nonnull IonMobilogramTimeSeries series) {
-    this.frames = series.getSpectra();
-    this.simpleIonMobilitySeries = new ArrayList<>();
+      @Nonnull IonMobilogramTimeSeries series, List<Frame> frames) {
+    this.frames = frames;
+
+    this.mobilograms = new ArrayList<>();
+    series.getMobilograms().forEach(m -> mobilograms.add(
+        (SimpleIonMobilitySeries) m.copy(storage)));
 
     double[][] data = DataPointUtils
         .getDataPointsAsDoubleArray(series.getMZValues(), series.getIntensityValues());
 
+    summedMobilogram = new SummedIntensityMobilitySeries(storage,
+        mobilograms, data[0][((int) data[0].length / 2)]);
+
+    DoubleBuffer tempMzs;
+    DoubleBuffer tempIntensities;
     try {
-      mzValues = storage.storeData(data[0]);
-      intensityValues = storage.storeData(data[1]);
+      tempMzs = storage.storeData(data[0]);
+      tempIntensities = storage.storeData(data[1]);
     } catch (IOException e) {
       e.printStackTrace();
-      mzValues = DoubleBuffer.wrap(data[0]);
-      intensityValues = DoubleBuffer.wrap(data[1]);
+      tempMzs = DoubleBuffer.wrap(data[0]);
+      tempIntensities = DoubleBuffer.wrap(data[1]);
     }
-
-    series.getMobilograms().forEach(m -> simpleIonMobilitySeries.add(
-        (SimpleIonMobilitySeries) m.copy(storage)));
+    mzValues = tempMzs;
+    intensityValues = tempIntensities;
   }
 
   @Override
@@ -125,17 +214,17 @@ public class SimpleIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
    */
   @Override
   public List<Frame> getSpectra() {
-    return frames;
+    return Collections.unmodifiableList(frames);
   }
 
   @Override
   public List<SimpleIonMobilitySeries> getMobilograms() {
-    return simpleIonMobilitySeries;
+    return Collections.unmodifiableList(mobilograms);
   }
 
   @Override
   public IonSpectrumSeries<Frame> copy(MemoryMapStorage storage) {
-    return new SimpleIonMobilogramTimeSeries(storage, this);
+    return new SimpleIonMobilogramTimeSeries(storage, this, frames);
   }
 
   @Override
@@ -145,7 +234,15 @@ public class SimpleIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
 
   @Override
   public IonTimeSeries<Frame> copyAndReplace(MemoryMapStorage storage, double[] newMzValues,
-      double[] newIntensityValues, List<Frame> newScans) {
-    return null;
+      double[] newIntensityValues) {
+    return new SimpleIonMobilogramTimeSeries(storage, newMzValues, newIntensityValues,
+        this.getMobilograms(), this.frames);
+  }
+
+  public IonMobilogramTimeSeries copyAndReplace(MemoryMapStorage storage, double[] newMzValues,
+      double[] newIntensityValues, List<SimpleIonMobilitySeries> newMobilograms) {
+    return new SimpleIonMobilogramTimeSeries(storage, newMzValues, newIntensityValues,
+        newMobilograms,
+        this.frames);
   }
 }

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonMobilogramTimeSeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonMobilogramTimeSeries.java
@@ -21,6 +21,7 @@ package io.github.mzmine.datamodel.featuredata.impl;
 import io.github.mzmine.datamodel.Frame;
 import io.github.mzmine.datamodel.featuredata.IonMobilogramTimeSeries;
 import io.github.mzmine.datamodel.featuredata.IonSpectrumSeries;
+import io.github.mzmine.datamodel.featuredata.IonTimeSeries;
 import io.github.mzmine.util.DataPointUtils;
 import io.github.mzmine.util.MemoryMapStorage;
 import java.io.IOException;
@@ -89,7 +90,7 @@ public class SimpleIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
   }
 
   private SimpleIonMobilogramTimeSeries(@Nonnull MemoryMapStorage storage,
-      IonMobilogramTimeSeries series) {
+      @Nonnull IonMobilogramTimeSeries series) {
     this.frames = series.getSpectra();
     this.simpleIonMobilitySeries = new ArrayList<>();
 
@@ -142,4 +143,9 @@ public class SimpleIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
     return summedMobilogram;
   }
 
+  @Override
+  public IonTimeSeries<Frame> copyAndReplace(MemoryMapStorage storage, double[] newMzValues,
+      double[] newIntensityValues, List<Frame> newScans) {
+    return null;
+  }
 }

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonTimeSeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonTimeSeries.java
@@ -87,6 +87,13 @@ public class SimpleIonTimeSeries implements IonTimeSeries<Scan> {
     double[][] data = DataPointUtils
         .getDataPointsAsDoubleArray(getMZValues(), getIntensityValues());
 
-    return new SimpleIonTimeSeries(storage, data[0], data[1], getSpectra());
+    return copyAndReplace(storage, data[0], data[1], getSpectra());
+  }
+
+  @Override
+  public IonTimeSeries<Scan> copyAndReplace(MemoryMapStorage storage, double[] newMzValues,
+      double[] newIntensityValues, List<Scan> newScans) {
+
+    return new SimpleIonTimeSeries(storage, newMzValues, newIntensityValues, newScans);
   }
 }

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SummedIntensityMobilitySeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SummedIntensityMobilitySeries.java
@@ -64,8 +64,10 @@ public class SummedIntensityMobilitySeries implements IntensitySeries, MobilityS
     }
 
     try {
-      intensityValues = storage.storeData(intensities.values().stream().mapToDouble(Double::doubleValue).toArray());
-      mobilityValues = storage.storeData(mobilities.values().stream().mapToDouble(Double::doubleValue).toArray());
+      intensityValues = storage
+          .storeData(intensities.values().stream().mapToDouble(Double::doubleValue).toArray());
+      mobilityValues = storage
+          .storeData(mobilities.values().stream().mapToDouble(Double::doubleValue).toArray());
     } catch (IOException e) {
       e.printStackTrace();
     }
@@ -79,6 +81,13 @@ public class SummedIntensityMobilitySeries implements IntensitySeries, MobilityS
     return getIntensityValues().get(index);
   }
 
+  /**
+   * Note: Since this is a summed mobilogram, the data points were summed at a given mobility, not
+   * necessarily at the same mobility scan number. Therefore, a list of scans is not provided.
+   *
+   * @param index
+   * @return
+   */
   public double getMobility(int index) {
     return getMobilityValues().get(index);
   }

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SummedIntensityMobilitySeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SummedIntensityMobilitySeries.java
@@ -30,14 +30,15 @@ import java.util.Map;
 import java.util.TreeMap;
 
 /**
- * Stores a summed mobilogram of a feature.
+ * Stores a summed mobilogram based on the intesities of the frame-specific mobilograms in the
+ * constructor.
  *
  * @author https://github.com/SteffenHeu
  */
 public class SummedIntensityMobilitySeries implements IntensitySeries, MobilitySeries {
 
-  DoubleBuffer intensityValues;
   final double mz;
+  DoubleBuffer intensityValues;
   DoubleBuffer mobilityValues;
 
   SummedIntensityMobilitySeries(MemoryMapStorage storage, List<SimpleIonMobilitySeries> mobilograms,

--- a/src/main/java/io/github/mzmine/datamodel/features/Feature.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/Feature.java
@@ -104,6 +104,7 @@ public interface Feature {
    * @param i
    * @return
    */
+  @Deprecated
   @Nullable
   default DataPoint getDataPointAtIndex(int i) {
     List<DataPoint> dataPoints = getDataPoints();

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeature.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeature.java
@@ -46,6 +46,7 @@ import io.github.mzmine.datamodel.features.types.numbers.MZType;
 import io.github.mzmine.datamodel.features.types.numbers.RTRangeType;
 import io.github.mzmine.datamodel.features.types.numbers.RTType;
 import io.github.mzmine.datamodel.features.types.numbers.TailingFactorType;
+import io.github.mzmine.datamodel.impl.SimpleDataPoint;
 import io.github.mzmine.datamodel.impl.SimpleFeatureInformation;
 import io.github.mzmine.modules.tools.qualityparameters.QualityParameters;
 import io.github.mzmine.util.DataPointUtils;
@@ -272,7 +273,7 @@ public class ModularFeature implements Feature, ModularDataModel {
     if (index < 0) {
       return null;
     }
-    return getDataPoints().get(index);
+    return new SimpleDataPoint(getFeatureData().getMZ(index), getFeatureData().getIntensity(index));
   }
 
   @Nonnull

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureList.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureList.java
@@ -508,6 +508,21 @@ public class ModularFeatureList implements FeatureList {
     return flist;
   }
 
+  public ModularFeatureList createEmptyCopyWithSameTypes(String title) {
+    ModularFeatureList flist = new ModularFeatureList(title, getRawDataFiles());
+
+    // Load previous applied methods
+    for (FeatureListAppliedMethod proc : this.getAppliedMethods()) {
+      flist.addDescriptionOfAppliedTask(proc);
+    }
+
+    rowTypes.values().forEach(flist::addRowType);
+    featureTypes.values().forEach(flist::addFeatureType);
+
+    selectedScans.forEach(flist::setSelectedScans);
+    return flist;
+  }
+
   public List<RowBinding> getRowBindings() {
     return rowBindings;
   }

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureList.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureList.java
@@ -2,6 +2,7 @@ package io.github.mzmine.datamodel.features;
 
 import com.google.common.collect.Range;
 import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.types.DataType;
 import io.github.mzmine.datamodel.features.types.ManualAnnotationType;
 import io.github.mzmine.datamodel.features.types.numbers.IDType;
@@ -12,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.DoubleSummaryStatistics;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
@@ -21,6 +23,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.ObservableMap;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 
 public class ModularFeatureList implements FeatureList {
@@ -32,11 +35,11 @@ public class ModularFeatureList implements FeatureList {
   // using LinkedHashMaps to save columns order according to the constructor
   // TODO do we need two maps? We could have ObservableMap of LinkedHashMap
   private ObservableMap<Class<? extends DataType>, DataType> rowTypes =
-          FXCollections.observableMap(new LinkedHashMap<>());
+      FXCollections.observableMap(new LinkedHashMap<>());
 
   // TODO do we need two maps? We could have ObservableMap of LinkedHashMap
   private ObservableMap<Class<? extends DataType>, DataType> featureTypes =
-          FXCollections.observableMap(new LinkedHashMap<>());
+      FXCollections.observableMap(new LinkedHashMap<>());
 
   // bindings for values
   private final List<RowBinding> rowBindings = new ArrayList<>();
@@ -45,6 +48,7 @@ public class ModularFeatureList implements FeatureList {
 
   // unmodifiable list
   private final ObservableList<RawDataFile> dataFiles;
+  private final ObservableMap<RawDataFile, List<? extends Scan>> selectedScans;
   private ObservableList<FeatureListRow> featureListRows;
   private String name;
   private ObservableList<FeatureListAppliedMethod> descriptionOfAppliedTasks;
@@ -66,6 +70,7 @@ public class ModularFeatureList implements FeatureList {
     featureListRows = FXCollections.observableArrayList();
     descriptionOfAppliedTasks = FXCollections.observableArrayList();
     dateCreated = DATA_FORMAT.format(new Date());
+    selectedScans = FXCollections.observableMap(new HashMap<>());
 
     // only a few standard types
     addRowType(new IDType());
@@ -82,9 +87,23 @@ public class ModularFeatureList implements FeatureList {
     return name;
   }
 
+  public void setSelectedScans(@Nonnull RawDataFile file, @Nullable List<? extends Scan> scans) {
+    selectedScans.put(file, scans);
+  }
+
+  /**
+   * @param file
+   * @return The scans used to build this feature list. For ion mobility data, the frames are
+   * returned.
+   */
+  @Nullable
+  public List<? extends Scan> getSeletedScans(@Nonnull RawDataFile file) {
+    return selectedScans.get(file);
+  }
+
   /**
    * Bind row types to feature types to calculate averages, sums, min, max, counts.
-   * 
+   *
    * @param bindings list of bindings
    */
   public void addRowBinding(@Nonnull List<RowBinding> bindings) {
@@ -103,7 +122,7 @@ public class ModularFeatureList implements FeatureList {
 
   /**
    * Apply all bindings to all this row
-   * 
+   *
    * @param row
    */
   private void applyRowBindings(ModularFeatureListRow row) {
@@ -112,7 +131,7 @@ public class ModularFeatureList implements FeatureList {
 
   /**
    * Summary of all feature type columns
-   * 
+   *
    * @return
    */
   public ObservableMap<Class<? extends DataType>, DataType> getFeatureTypes() {
@@ -150,7 +169,7 @@ public class ModularFeatureList implements FeatureList {
 
   /**
    * Row type columns
-   * 
+   *
    * @return
    */
   public ObservableMap<Class<? extends DataType>, DataType> getRowTypes() {
@@ -167,6 +186,7 @@ public class ModularFeatureList implements FeatureList {
 
   /**
    * Returns all raw data files participating in the alignment
+   *
    * @return
    */
   @Override
@@ -176,10 +196,11 @@ public class ModularFeatureList implements FeatureList {
 
   @Override
   public RawDataFile getRawDataFile(int i) {
-    if (i >= 0 && i < dataFiles.size())
+    if (i >= 0 && i < dataFiles.size()) {
       return dataFiles.get(i);
-    else
+    } else {
       return null;
+    }
   }
 
   /**
@@ -192,7 +213,7 @@ public class ModularFeatureList implements FeatureList {
 
   /**
    * Returns the feature of a given raw data file on a give row of the alignment result
-   * 
+   *
    * @param row Row of the alignment result
    * @param raw Raw data file where the feature is detected/estimated
    */
@@ -209,8 +230,9 @@ public class ModularFeatureList implements FeatureList {
     ObservableList<Feature> features = FXCollections.observableArrayList();
     for (int row = 0; row < getNumberOfRows(); row++) {
       ModularFeature f = getFeature(row, raw);
-      if (f != null)
+      if (f != null) {
         features.add(f);
+      }
     }
     return features;
   }
@@ -251,16 +273,18 @@ public class ModularFeatureList implements FeatureList {
 
   @Override
   public void addRow(FeatureListRow row) {
-    if(!(row instanceof ModularFeatureListRow)) {
-      throw new IllegalArgumentException("Can not add non-modular feature list row to modular feature list");
+    if (!(row instanceof ModularFeatureListRow)) {
+      throw new IllegalArgumentException(
+          "Can not add non-modular feature list row to modular feature list");
     }
     ModularFeatureListRow modularRow = (ModularFeatureListRow) row;
 
     ObservableList<RawDataFile> myFiles = this.getRawDataFiles();
     for (RawDataFile testFile : modularRow.getRawDataFiles()) {
-      if (!myFiles.contains(testFile))
+      if (!myFiles.contains(testFile)) {
         throw (new IllegalArgumentException(
             "Data file " + testFile + " is not in this feature list"));
+      }
     }
 
     featureListRows.add(modularRow);
@@ -274,7 +298,7 @@ public class ModularFeatureList implements FeatureList {
 
   /**
    * Returns all features overlapping with a retention time range
-   * 
+   *
    * @param rtRange Retention time range
    * @return List of features
    */
@@ -297,7 +321,8 @@ public class ModularFeatureList implements FeatureList {
    * @see io.github.mzmine.datamodel.features.FeatureList#getFeaturesInsideScanAndMZRange
    */
   @Override
-  public ObservableList<Feature> getFeaturesInsideScanAndMZRange(RawDataFile raw, Range<Float> rtRange,
+  public ObservableList<Feature> getFeaturesInsideScanAndMZRange(RawDataFile raw,
+      Range<Float> rtRange,
       Range<Double> mzRange) {
     // TODO solve with bindings and check for rt or mz presence in row
     return modularStream().map(ModularFeatureListRow::getFilesFeatures).map(map -> map.get(raw))
@@ -372,8 +397,9 @@ public class ModularFeatureList implements FeatureList {
   @Override
   public int getFeatureListRowNum(Feature feature) {
     for (int i = 0; i < featureListRows.size(); i++) {
-      if (featureListRows.get(i).hasFeature(feature))
+      if (featureListRows.get(i).hasFeature(feature)) {
         return i;
+      }
     }
     return -1;
   }
@@ -431,8 +457,9 @@ public class ModularFeatureList implements FeatureList {
   //  a private variable during rows initialization
   @Override
   public Range<Double> getRowsMZRange() {
-    if(getRows().isEmpty())
+    if (getRows().isEmpty()) {
       return Range.singleton(0d);
+    }
 
     updateMaxIntensity(); // Update range before returning value
 
@@ -447,8 +474,9 @@ public class ModularFeatureList implements FeatureList {
   //  a private variable during rows initialization
   @Override
   public Range<Float> getRowsRTRange() {
-    if(getRows().isEmpty())
+    if (getRows().isEmpty()) {
       return Range.singleton(0f);
+    }
 
     updateMaxIntensity(); // Update range before returning value
 
@@ -461,28 +489,31 @@ public class ModularFeatureList implements FeatureList {
 
   /**
    * create copy of all feature list rows and features
+   *
    * @param title
    * @return
    */
-    public ModularFeatureList createCopy(String title) {
-      ModularFeatureList flist = new ModularFeatureList(title, this.getRawDataFiles());
-      // copy all rows and features
-      this.stream().map(row -> new ModularFeatureListRow(flist, (ModularFeatureListRow) row, true))
-          .forEach(newRow -> flist.addRow(newRow));
+  public ModularFeatureList createCopy(String title) {
+    ModularFeatureList flist = new ModularFeatureList(title, this.getRawDataFiles());
+    // copy all rows and features
+    this.stream().map(row -> new ModularFeatureListRow(flist, (ModularFeatureListRow) row, true))
+        .forEach(newRow -> flist.addRow(newRow));
 
-      // Load previous applied methods
-      for (FeatureListAppliedMethod proc : this.getAppliedMethods()) {
-        flist.addDescriptionOfAppliedTask(proc);
-      }
-      return flist;
+    // Load previous applied methods
+    for (FeatureListAppliedMethod proc : this.getAppliedMethods()) {
+      flist.addDescriptionOfAppliedTask(proc);
     }
+
+    selectedScans.forEach(flist::setSelectedScans);
+    return flist;
+  }
 
   public List<RowBinding> getRowBindings() {
     return rowBindings;
   }
 
   public MemoryMapStorage getMemoryMapStorage() {
-    if(memoryMapStorage == null) {
+    if (memoryMapStorage == null) {
       memoryMapStorage = new MemoryMapStorage();
     }
     return memoryMapStorage;

--- a/src/main/java/io/github/mzmine/datamodel/features/types/graphicalnodes/FeatureShapeIonMobilityRetentionTimeHeatMapChart.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/graphicalnodes/FeatureShapeIonMobilityRetentionTimeHeatMapChart.java
@@ -57,6 +57,7 @@ public class FeatureShapeIonMobilityRetentionTimeHeatMapChart extends StackPane 
     axis.setAutoRangeMinimumSize(0.05);
     axis.setAutoRangeIncludesZero(false);
     axis.setAutoRangeStickyZero(false);
+    axis.setAutoRange(true);
     setPrefHeight(GraphicalColumType.DEFAULT_GRAPHICAL_CELL_HEIGHT);
     setPrefWidth(GraphicalColumType.DEFAULT_GRAPHICAL_CELL_WIDTH);
     getChildren().add(chart);

--- a/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/ExampleXYZProvider.java
+++ b/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/ExampleXYZProvider.java
@@ -192,7 +192,6 @@ public class ExampleXYZProvider implements PlotXYZDataProvider {
     for (RetentionTimeMobilityDataPoint dp : dataPointsSortedByRt) {
       if (dpA == null) {
         dpA = dp;
-        dataPointHeight = Math.abs(dp.getMobilityWidth());
       } else if (!(Float.compare(dpA.getRetentionTime(), dp.getRetentionTime()) == 0)) {
         rtDeltas.add(dpA.getRetentionTime() - dp.getRetentionTime());
         dpA = dp;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_ransac/RansacAlignerTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_ransac/RansacAlignerTask.java
@@ -22,7 +22,6 @@ import com.google.common.collect.Range;
 import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.datamodel.RawDataFile;
-import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
@@ -124,7 +123,7 @@ class RansacAlignerTask extends AbstractTask {
     // Collect all data files
     List<RawDataFile> allDataFiles = new ArrayList<RawDataFile>();
 
-    for (FeatureList featureList : featureLists) {
+    for (ModularFeatureList featureList : featureLists) {
 
       for (RawDataFile dataFile : featureList.getRawDataFiles()) {
 
@@ -138,6 +137,9 @@ class RansacAlignerTask extends AbstractTask {
         }
 
         allDataFiles.add(dataFile);
+
+        featureList.getRawDataFiles().forEach(
+            file -> alignedFeatureList.setSelectedScans(file, featureList.getSeletedScans(file)));
       }
     }
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ModularADAPChromatogramBuilderTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ModularADAPChromatogramBuilderTask.java
@@ -398,6 +398,8 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
       newFeatureID++;
     }
 
+    newFeatureList.setSelectedScans(dataFile, Arrays.asList(scans));
+
     // Add new feature list to the project
     project.addFeatureList(newFeatureList);
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_ionmobilitytracebuilder/IonMobilityTraceBuilderModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_ionmobilitytracebuilder/IonMobilityTraceBuilderModule.java
@@ -18,12 +18,6 @@
 
 package io.github.mzmine.modules.dataprocessing.featdet_ionmobilitytracebuilder;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.Set;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import io.github.mzmine.datamodel.Frame;
 import io.github.mzmine.datamodel.IMSRawDataFile;
 import io.github.mzmine.datamodel.MZmineProject;
@@ -34,6 +28,11 @@ import io.github.mzmine.modules.MZmineRunnableModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public class IonMobilityTraceBuilderModule implements MZmineRunnableModule {
 
@@ -56,9 +55,9 @@ public class IonMobilityTraceBuilderModule implements MZmineRunnableModule {
         continue;
       }
 
-      Set<Frame> frames = new LinkedHashSet<>(((IMSRawDataFile) file).getFrames());
+      List<Frame> frames = (List<Frame>) ((IMSRawDataFile) file).getFrames();
       IonMobilityTraceBuilderTask task =
-          new IonMobilityTraceBuilderTask(project, file, new HashSet<>(frames), parameters);
+          new IonMobilityTraceBuilderTask(project, file, frames, parameters);
       MZmineCore.getTaskController().addTask(task);
     }
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_ionmobilitytracebuilder/IonMobilityTraceBuilderTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_ionmobilitytracebuilder/IonMobilityTraceBuilderTask.java
@@ -561,6 +561,7 @@ public class IonMobilityTraceBuilderTask extends AbstractTask {
     // ensure that the default columns are available
     DataTypeUtils.addDefaultChromatographicTypeColumns(featureList);
     DataTypeUtils.addDefaultIonMobilityTypeColumns(featureList);
+    featureList.setSelectedScans(rawDataFile, frames);
 
     int featureId = 1;
     for (IIonMobilityTrace ionTrace : ionMobilityTraces) {

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_ionmobilitytracebuilder/RetentionTimeMobilityDataPoint.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_ionmobilitytracebuilder/RetentionTimeMobilityDataPoint.java
@@ -21,22 +21,16 @@ package io.github.mzmine.modules.dataprocessing.featdet_ionmobilitytracebuilder;
 import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.Frame;
 import io.github.mzmine.datamodel.MobilityScan;
-import io.github.mzmine.gui.chartbasics.chartutils.paintscales.PaintScale;
 
 public class RetentionTimeMobilityDataPoint implements DataPoint {
 
   private final double mz;
   private final double intensity;
   private final MobilityScan mobilityScan;
-  private final double mobilityWidth;
-  private final PaintScale paintScale;
 
-  public RetentionTimeMobilityDataPoint(MobilityScan mobilityScan, double mz, double intensity,
-      Frame frame, double mobilityWidth, PaintScale paintScale) {
+  public RetentionTimeMobilityDataPoint(MobilityScan mobilityScan, double mz, double intensity) {
     this.mz = mz;
     this.intensity = intensity;
-    this.mobilityWidth = mobilityWidth;
-    this.paintScale = paintScale;
     this.mobilityScan = mobilityScan;
   }
 
@@ -62,14 +56,6 @@ public class RetentionTimeMobilityDataPoint implements DataPoint {
 
   public MobilityScan getMobilityScan() {
     return mobilityScan;
-  }
-
-  public double getMobilityWidth() {
-    return mobilityWidth;
-  }
-
-  public PaintScale getPaintScale() {
-    return paintScale;
   }
 
   /*@Override

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_smoothing/IonSpectrumSeriesSmoothing.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_smoothing/IonSpectrumSeriesSmoothing.java
@@ -1,0 +1,88 @@
+/*
+ *  Copyright 2006-2020 The MZmine Development Team
+ *
+ *  This file is part of MZmine.
+ *
+ *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ *  General Public License as published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
+ *
+ *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ *  Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with MZmine; if not,
+ *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ *  USA
+ */
+
+package io.github.mzmine.modules.dataprocessing.featdet_smoothing;
+
+import io.github.mzmine.datamodel.MassSpectrum;
+import io.github.mzmine.datamodel.featuredata.IonSpectrumSeries;
+import io.github.mzmine.datamodel.featuredata.impl.SimpleIonMobilitySeries;
+import io.github.mzmine.datamodel.featuredata.impl.SimpleIonMobilogramTimeSeries;
+import io.github.mzmine.datamodel.featuredata.impl.SimpleIonTimeSeries;
+import io.github.mzmine.util.DataPointUtils;
+import io.github.mzmine.util.MemoryMapStorage;
+import java.util.List;
+
+public class IonSpectrumSeriesSmoothing<T extends IonSpectrumSeries> {
+
+  private final T origSeries;
+  private final List<MassSpectrum> allSpectra;
+  private final MemoryMapStorage newStorage;
+
+  IonSpectrumSeriesSmoothing(T origSeries, MemoryMapStorage newStorage,
+      List<MassSpectrum> allSpectra) {
+    if (origSeries instanceof SimpleIonMobilogramTimeSeries) {
+      throw new IllegalArgumentException(
+          "Direct smoothing of " + SimpleIonMobilogramTimeSeries.class.getName()
+              + " is not supported, since averaged intensities and mobilities are calculated based "
+              + "on the individual " + SimpleIonMobilitySeries.class.getName()
+              + ". Smooth those instead.");
+    }
+    this.origSeries = origSeries;
+    this.newStorage = newStorage;
+    this.allSpectra = allSpectra;
+  }
+
+  public T smooth(double[] weights) {
+    int numScans = allSpectra.size();
+
+    final double[] origIntensities = new double[numScans];
+    for (int i = 0; i < numScans; i++) {
+      origIntensities[i] = origSeries.getIntensityForSpectrum(allSpectra.get(i));
+    }
+
+    final double[] smoothed = SavitzkyGolayFilter.convolve(origIntensities, weights);
+
+    // add no new data points for scans, just use smoothed ones where we had dps in the first place
+    final double[] newIntensities = new double[origSeries.getNumberOfValues()];
+    int newIntensityIndex = 0;
+    List<MassSpectrum> origSpectra = origSeries.getSpectra();
+    for (int i = 0; i < numScans; i++) {
+      // check if we originally had a data point for that spectrum, otherwise continue.
+      int index = origSpectra.indexOf(allSpectra.get(i));
+      if (index == -1) {
+        continue;
+      }
+      // keep zeros we put on flanking data points during chromatogram building
+      newIntensities[newIntensityIndex] =
+          (Double.compare(origSeries.getIntensity(index), 0d) != 0) ? smoothed[i] : 0d;
+      newIntensityIndex++;
+    }
+
+    double[] origMz = DataPointUtils.getDoubleBufferAsArray(origSeries.getMZValues());
+    if (origSeries instanceof SimpleIonMobilitySeries) {
+      return (T) new SimpleIonMobilitySeries(newStorage, origMz, newIntensities,
+          origSeries.getSpectra());
+    } else if (origSeries instanceof SimpleIonTimeSeries) {
+      return (T) new SimpleIonTimeSeries(newStorage, origMz, newIntensities,
+          origSeries.getSpectra());
+    } else {
+      throw new IllegalArgumentException(
+          "Smoothing of " + origSeries.getClass().getName() + " is not yet supported.");
+    }
+  }
+}

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_smoothing/SmoothingTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_smoothing/SmoothingTask.java
@@ -24,12 +24,15 @@
 
 package io.github.mzmine.modules.dataprocessing.featdet_smoothing;
 
-import com.google.common.collect.Range;
-import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.MZmineProject;
-import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.MassSpectrum;
 import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.datamodel.featuredata.FeatureDataUtils;
+import io.github.mzmine.datamodel.featuredata.IonMobilogramTimeSeries;
 import io.github.mzmine.datamodel.featuredata.IonTimeSeries;
+import io.github.mzmine.datamodel.featuredata.impl.SimpleIonMobilitySeries;
+import io.github.mzmine.datamodel.featuredata.impl.SimpleIonMobilogramTimeSeries;
+import io.github.mzmine.datamodel.featuredata.impl.SimpleIonTimeSeries;
 import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureList.FeatureListAppliedMethod;
@@ -38,11 +41,11 @@ import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
-import io.github.mzmine.datamodel.impl.SimpleDataPoint;
+import io.github.mzmine.datamodel.features.types.FeatureDataType;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
-import io.github.mzmine.util.RangeUtils;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -58,16 +61,14 @@ public class SmoothingTask extends AbstractTask {
   // Feature lists: original and processed.
   private final MZmineProject project;
   private final ModularFeatureList origPeakList;
-  private ModularFeatureList newPeakList;
-
   // Parameters.
   private final ParameterSet parameters;
   private final String suffix;
   private final boolean removeOriginal;
   private final int filterWidth;
-
-  private int progress;
   private final int progressMax;
+  private ModularFeatureList newPeakList;
+  private int progress;
 
   /**
    * Create the task.
@@ -111,9 +112,7 @@ public class SmoothingTask extends AbstractTask {
       final double[] filterWeights = SavitzkyGolayFilter.getNormalizedWeights(filterWidth);
 
       // Create new feature list
-      newPeakList = origPeakList.createCopy(origPeakList.getName() + " " + suffix);
-      newPeakList = new ModularFeatureList(origPeakList + " " + suffix,
-          origPeakList.getRawDataFiles());
+      newPeakList = origPeakList.createEmptyCopyWithSameTypes(origPeakList + " " + suffix);
 
       // Process each row.
       for (final FeatureListRow row : origPeakList.getRows()) {
@@ -126,89 +125,49 @@ public class SmoothingTask extends AbstractTask {
 
           // Process each peak.
           for (final Feature peak : row.getFeatures()) {
+            if (isCanceled()) {
+              return;
+            }
+
             ModularFeature feature = (ModularFeature) peak;
             // TODO feature data
+            IonTimeSeries<? extends Scan> featureData = feature.getFeatureData();
 
-            if (!isCanceled()) {
+            IonTimeSeries<? extends Scan> smoothedSeries = null;
+            if (featureData instanceof SimpleIonTimeSeries) {
 
-              // Copy original peak intensities.
-              final List<Scan> scans = (List<Scan>) ((ModularFeatureList) feature.getFeatureList())
-                  .getSeletedScans(feature.getRawDataFile());
-              final int numScans = scans.size();
-              final double[] intensities = new double[numScans];
-              for (int i = 0; i < numScans; i++) {
-                intensities[i] = feature.getFeatureData().getIntensityForScan(scans.get(i));
+              IonSpectrumSeriesSmoothing smoother = new IonSpectrumSeriesSmoothing(featureData,
+                  newPeakList.getMemoryMapStorage(),
+                  origPeakList.getSeletedScans(feature.getRawDataFile()));
+              smoothedSeries = (IonTimeSeries<? extends Scan>) smoother.smooth(filterWeights);
+
+            } else if (featureData instanceof IonMobilogramTimeSeries) {
+
+              // for ims, we smooth every mobilogram indivudually instead of the summed intensities
+              List<SimpleIonMobilitySeries> smoothedMobilograms = new ArrayList<>();
+              for (SimpleIonMobilitySeries mobilogram : ((IonMobilogramTimeSeries) featureData)
+                  .getMobilograms()) {
+                List<? extends MassSpectrum> spectra = mobilogram.getSpectrum(0).getFrame()
+                    .getMobilityScans();
+                IonSpectrumSeriesSmoothing<SimpleIonMobilitySeries> smoother =
+                    new IonSpectrumSeriesSmoothing<>(mobilogram, newPeakList.getMemoryMapStorage(),
+                        (List<MassSpectrum>) spectra);
+                smoothedMobilograms.add(smoother.smooth(filterWeights));
+
               }
 
-              // Smooth peak.
-              final double[] smoothed = convolve(intensities, filterWeights);
-
-              // keep track for new feature data
-              // we won't add intensities for point's that were 0 before!
-              double[] newIntensities = new double[feature.getFeatureData().getNumberOfValues()];
-              int newIntensitiesIndex = 0;
-
-              // Measure peak (max, ranges, area etc.)
-              final RawDataFile dataFile = feature.getRawDataFile();
-              float maxIntensity = 0f;
-              Scan maxScan = null;
-              int maxIntensityIndex = -1;
-              Range<Double> intensityRange = null;
-              float area = 0f;
-
-              for (int i = 0; i < numScans; i++) {
-                final Scan scan = scans.get(i);
-//                final DataPoint dataPoint = peak.getDataPointAtIndex(i);
-                final double originalIntensity = feature.getFeatureData().getIntensityForScan(scan);
-                final double intensity = smoothed[i] > 0 ? smoothed[i] : 0d;
-
-                if (originalIntensity > 0d) {
-                  // Create a new data point.
-//                  final double mz = feature.getFeatureData().getMzForScan(scan);
-                  final double rt = scan.getRetentionTime();
-//                  final DataPoint newDataPoint = new SimpleDataPoint(mz, intensity);
-                  newIntensities[newIntensitiesIndex] = intensity;
-
-                  // Track maximum intensity data point.
-                  if (intensity > maxIntensity) {
-                    maxIntensity = (float) intensity;
-                    maxScan = scan;
-                    maxIntensityIndex = i;
-                  }
-
-                  // Update ranges.
-                  if (intensityRange == null) {
-                    intensityRange = Range.singleton(intensity);
-                  } else {
-                    intensityRange = intensityRange.span(Range.singleton(intensity));
-                  }
-
-                  // Accumulate peak area.
-                  if (i != 0) {
-                    final double lastIntensity = smoothed[i-1] < 0 ? 0.0 : smoothed[i];
-                    final double lastRT = scans.get(i - 1).getRetentionTime();
-                    area += (rt - lastRT) * 60d * (intensity + lastIntensity) / 2.0;
-                  }
-                }
-              }
-
-              assert maxIntensityIndex != -1;
-
-              if (!isCanceled() && maxScan != null) {
-                // Create a new peak.
-                // TODO
-                ModularFeature newFeature
-                    = new ModularFeature(newPeakList, dataFile, feature.getMZ(), peak.getRT(),
-                    maxIntensity,
-                    area, feature.getFeatureData().getSpectra(), newIntensities,  peak.getFeatureStatus(),
-                    maxScan,
-                    peak.getMostIntenseFragmentScan(),
-                    peak.getAllMS2FragmentScans().toArray(Scan[]::new),
-                    peak.getRawDataPointsRTRange(),
-                    peak.getRawDataPointsMZRange(), RangeUtils.toFloatRange(intensityRange));
-                newRow.addFeature(dataFile, newFeature);
-              }
+              smoothedSeries = new SimpleIonMobilogramTimeSeries(newPeakList.getMemoryMapStorage(),
+                  smoothedMobilograms);
+            } else {
+              logger.info("Could not smooth feature, unknown ion series type.");
+              continue;
             }
+
+            ModularFeature newFeature = new ModularFeature(newPeakList, feature);
+            newFeature.set(FeatureDataType.class, smoothedSeries);
+            FeatureDataUtils.recalculateIonSeriesDependingTypes(newFeature);
+
+            newRow.addFeature(newFeature.getRawDataFile(), newFeature);
           }
           newPeakList.addRow(newRow);
           progress++;
@@ -250,36 +209,5 @@ public class SmoothingTask extends AbstractTask {
       setErrorMessage(t.getMessage());
       setStatus(TaskStatus.ERROR);
     }
-  }
-
-  /**
-   * Convolve a set of weights with a set of intensities.
-   *
-   * @param intensities the intensities.
-   * @param weights     the filter weights.
-   * @return the convolution results.
-   */
-  private static double[] convolve(final double[] intensities, final double[] weights) {
-
-    // Initialise.
-    final int fullWidth = weights.length;
-    final int halfWidth = (fullWidth - 1) / 2;
-    final int numPoints = intensities.length;
-
-    // Convolve.
-    final double[] convolved = new double[numPoints];
-    for (int i = 0; i < numPoints; i++) {
-
-      double sum = 0.0;
-      final int k = i - halfWidth;
-      for (int j = Math.max(0, -k); j < Math.min(fullWidth, numPoints - k); j++) {
-        sum += intensities[k + j] * weights[j];
-      }
-
-      // Set the result.
-      convolved[i] = sum;
-    }
-
-    return convolved;
   }
 }

--- a/src/main/java/io/github/mzmine/modules/visualization/chromatogram/FeatureDataSet.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/chromatogram/FeatureDataSet.java
@@ -1,16 +1,16 @@
 /*
  * Copyright 2006-2020 The MZmine Development Team
- * 
+ *
  * This file is part of MZmine.
- * 
+ *
  * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
  * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
  * Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
  * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
  * USA
@@ -22,6 +22,7 @@ import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
+import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.util.FeatureUtils;
 import java.util.Arrays;
 import java.util.List;
@@ -48,7 +49,7 @@ public class FeatureDataSet extends AbstractXYDataset {
   /**
    * Create the data set.
    *
-   * @param p the feature.
+   * @param p  the feature.
    * @param id peak identity to use as a label.
    */
   public FeatureDataSet(final Feature p, final String id) {
@@ -77,16 +78,20 @@ public class FeatureDataSet extends AbstractXYDataset {
 
       // Copy RT and m/z.
       retentionTimes[i] = scanNumber.getRetentionTime();
-      final DataPoint dataPoint = feature.getDataPoint(scanNumber);
-      if (dataPoint == null) {
 
-        mzValues[i] = 0.0;
-        intensities[i] = 0.0;
-
-      } else {
-
-        mzValues[i] = dataPoint.getMZ();
-        intensities[i] = dataPoint.getIntensity();
+      if (feature instanceof ModularFeature) {
+        mzValues[i] = ((ModularFeature) feature).getFeatureData().getMzForSpectrum(scanNumber);
+        intensities[i] = ((ModularFeature) feature).getFeatureData()
+            .getIntensityForSpectrum(scanNumber);
+      } else { // todo remove this when everything is a ModularFeature
+        final DataPoint dataPoint = feature.getDataPoint(scanNumber);
+        if (dataPoint == null) {
+          mzValues[i] = 0.0;
+          intensities[i] = 0.0;
+        } else {
+          mzValues[i] = dataPoint.getMZ();
+          intensities[i] = dataPoint.getIntensity();
+        }
       }
     }
 

--- a/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/IMSRawDataOverviewPane.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/IMSRawDataOverviewPane.java
@@ -22,6 +22,7 @@ import io.github.mzmine.datamodel.Frame;
 import io.github.mzmine.datamodel.IMSRawDataFile;
 import io.github.mzmine.datamodel.MobilityScan;
 import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.impl.SimpleFrame;
 import io.github.mzmine.gui.chartbasics.chartgroups.ChartGroup;
 import io.github.mzmine.gui.chartbasics.gui.wrapper.ChartViewWrapper;
 import io.github.mzmine.gui.chartbasics.simplechart.SimpleXYChart;
@@ -33,6 +34,7 @@ import io.github.mzmine.gui.preferences.UnitFormat;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.visualization.chromatogram.TICDataSet;
 import io.github.mzmine.modules.visualization.chromatogram.TICPlot;
+import io.github.mzmine.modules.visualization.rawdataoverviewims.providers.CachedFrame;
 import io.github.mzmine.modules.visualization.rawdataoverviewims.providers.FrameHeatmapProvider;
 import io.github.mzmine.modules.visualization.rawdataoverviewims.providers.FrameSummedMobilogramProvider;
 import io.github.mzmine.modules.visualization.rawdataoverviewims.providers.FrameSummedSpectrumProvider;
@@ -182,7 +184,8 @@ public class IMSRawDataOverviewPane extends BorderPane {
     }
     // ticChart.removeDatasets(mzRangeTicDatasetIndices);
     mzRangeTicDatasetIndices.clear();
-    cachedFrame = selectedFrame.get();// , frameNoiseLevel, mobilityScanNoiseLevel);
+    cachedFrame = new CachedFrame((SimpleFrame) selectedFrame.get(), frameNoiseLevel,
+        mobilityScanNoiseLevel);//selectedFrame.get();//
     heatmapChart.setDataset(new FrameHeatmapProvider(cachedFrame));
     mobilogramChart.addDataset(new FrameSummedMobilogramProvider(cachedFrame));
     summedSpectrumChart.addDataset(new FrameSummedSpectrumProvider(cachedFrame));

--- a/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/providers/CachedFrame.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/providers/CachedFrame.java
@@ -1,0 +1,296 @@
+/*
+ *  Copyright 2006-2020 The MZmine Development Team
+ *
+ *  This file is part of MZmine.
+ *
+ *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ *  General Public License as published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
+ *
+ *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ *  Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with MZmine; if not,
+ *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ *  USA
+ */
+
+package io.github.mzmine.modules.visualization.rawdataoverviewims.providers;
+
+import com.google.common.collect.Range;
+import io.github.mzmine.datamodel.DataPoint;
+import io.github.mzmine.datamodel.Frame;
+import io.github.mzmine.datamodel.ImsMsMsInfo;
+import io.github.mzmine.datamodel.MassList;
+import io.github.mzmine.datamodel.MassSpectrumType;
+import io.github.mzmine.datamodel.MobilityScan;
+import io.github.mzmine.datamodel.MobilityType;
+import io.github.mzmine.datamodel.PolarityType;
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.impl.SimpleFrame;
+import io.github.mzmine.util.DataPointUtils;
+import java.nio.DoubleBuffer;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Loads a frame and it's subscans into ram.
+ *
+ * @author https://github.com/SteffenHeu
+ */
+public class CachedFrame implements Frame {
+
+  private final double[] mzs;
+  private final double[] intensities;
+  private final Frame originalFrame;
+  private List<MobilityScan> mobilityScans;
+  private List<MobilityScan> sortedMobilityScans;
+
+  public CachedFrame(SimpleFrame frame, double frameNoiseLevel, double mobilityScaNoiseLevel) {
+    originalFrame = frame;
+
+    double[][] data = DataPointUtils
+        .getDatapointsAboveNoiseLevel(frame.getMzValues(), frame.getIntensityValues(),
+            frameNoiseLevel);
+
+    mzs = data[0];
+    intensities = data[1];
+
+    this.mobilityScans = new ArrayList<>();
+    for (MobilityScan scan : frame.getMobilityScans()) {
+      mobilityScans.add(new CachedMobilityScan(scan, mobilityScaNoiseLevel));
+    }
+    sortedMobilityScans = mobilityScans.stream()
+        .sorted(Comparator.comparingDouble(MobilityScan::getMobility)).collect(Collectors.toList());
+  }
+
+
+  public double[] getIntensities() {
+    return intensities;
+  }
+
+  public double[] getMzs() {
+    return mzs;
+  }
+
+  @Override
+  public int getNumberOfMobilityScans() {
+    return mobilityScans.size();
+  }
+
+  @Nonnull
+  @Override
+  public MobilityType getMobilityType() {
+    return originalFrame.getMobilityType();
+  }
+
+  @Nonnull
+  @Override
+  public Range<Double> getMobilityRange() {
+    return originalFrame.getMobilityRange();
+  }
+
+  @Nullable
+  @Override
+  public MobilityScan getMobilityScan(int num) {
+    return mobilityScans.get(num);
+  }
+
+  @Nonnull
+  @Override
+  public List<MobilityScan> getMobilityScans() {
+    return mobilityScans;
+  }
+
+  @Nonnull
+  @Override
+  public List<MobilityScan> getSortedMobilityScans() {
+    return sortedMobilityScans;
+  }
+
+  @Override
+  public double getMobilityForMobilityScanNumber(int mobilityScanIndex) {
+    return originalFrame.getMobilityForMobilityScanNumber(mobilityScanIndex);
+  }
+
+  @Override
+  public double getMobilityForMobilityScan(MobilityScan scan) {
+    return originalFrame.getMobilityForMobilityScan(scan);
+  }
+
+  @Nullable
+  @Override
+  public DoubleBuffer getMobilities() {
+    return originalFrame.getMobilities();
+  }
+
+  @Nonnull
+  @Override
+  public Set<ImsMsMsInfo> getImsMsMsInfos() {
+    return originalFrame.getImsMsMsInfos();
+  }
+
+  @Nullable
+  @Override
+  public ImsMsMsInfo getImsMsMsInfoForMobilityScan(int mobilityScanNumber) {
+    return originalFrame.getImsMsMsInfoForMobilityScan(mobilityScanNumber);
+  }
+
+  @Override
+  public void addMobilityScan(MobilityScan originalMobilityScan) {
+    originalFrame.addMobilityScan(originalMobilityScan);
+  }
+
+  @Override
+  public int getNumberOfDataPoints() {
+    return mzs.length;
+  }
+
+  @Override
+  public MassSpectrumType getSpectrumType() {
+    return originalFrame.getSpectrumType();
+  }
+
+  @Nonnull
+  @Override
+  public DoubleBuffer getMzValues() {
+    throw new UnsupportedOperationException(
+        "Not intended. This frame is used for visualisation only");
+  }
+
+  @Nonnull
+  @Override
+  public DoubleBuffer getIntensityValues() {
+    throw new UnsupportedOperationException(
+        "Not intended. This frame is used for visualisation only");
+  }
+
+  @Override
+  public double getMzValue(int index) {
+    return mzs[index];
+  }
+
+  @Override
+  public double getIntensityValue(int index) {
+    return intensities[index];
+  }
+
+  @Nullable
+  @Override
+  public Double getBasePeakMz() {
+    return originalFrame.getBasePeakMz();
+  }
+
+  @Nullable
+  @Override
+  public Double getBasePeakIntensity() {
+    return originalFrame.getBasePeakIntensity();
+  }
+
+  @Nullable
+  @Override
+  public Integer getBasePeakIndex() {
+    throw new UnsupportedOperationException(
+        "Not intended. This frame is used for visualisation only");
+  }
+
+  @Nullable
+  @Override
+  public Range<Double> getDataPointMZRange() {
+    throw new UnsupportedOperationException(
+        "Not intended. This frame is used for visualisation only");
+  }
+
+  @Nullable
+  @Override
+  public Double getTIC() {
+    throw new UnsupportedOperationException(
+        "Not intended. This frame is used for visualisation only");
+  }
+
+  @Override
+  public Stream<DataPoint> stream() {
+    throw new UnsupportedOperationException(
+        "Not intended. This frame is used for visualisation only");
+  }
+
+  @Nonnull
+  @Override
+  public RawDataFile getDataFile() {
+    return originalFrame.getDataFile();
+  }
+
+  @Override
+  public int getScanNumber() {
+    return originalFrame.getScanNumber();
+  }
+
+  @Nonnull
+  @Override
+  public String getScanDefinition() {
+    return originalFrame.getScanDefinition();
+  }
+
+  @Override
+  public int getMSLevel() {
+    return originalFrame.getMSLevel();
+  }
+
+  @Override
+  public float getRetentionTime() {
+    return originalFrame.getRetentionTime();
+  }
+
+  @Nonnull
+  @Override
+  public Range<Double> getScanningMZRange() {
+    return originalFrame.getScanningMZRange();
+  }
+
+  @Nonnull
+  @Override
+  public PolarityType getPolarity() {
+    return originalFrame.getPolarity();
+  }
+
+  @Nonnull
+  @Override
+  public MassList[] getMassLists() {
+    throw new UnsupportedOperationException(
+        "Not intended. This frame is used for visualisation only");
+  }
+
+  @Nullable
+  @Override
+  public MassList getMassList(@Nonnull String name) {
+    throw new UnsupportedOperationException(
+        "Not intended. This frame is used for visualisation only");
+  }
+
+  @Override
+  public void addMassList(@Nonnull MassList massList) {
+    throw new UnsupportedOperationException(
+        "Not intended. This frame is used for visualisation only");
+  }
+
+  @Override
+  public void removeMassList(@Nonnull MassList massList) {
+    throw new UnsupportedOperationException(
+        "Not intended. This frame is used for visualisation only");
+  }
+
+  @Nonnull
+  @Override
+  public Iterator<DataPoint> iterator() {
+    throw new UnsupportedOperationException(
+        "Not intended. This frame is used for visualisation only");
+  }
+}

--- a/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/providers/CachedMobilityScan.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/providers/CachedMobilityScan.java
@@ -1,0 +1,202 @@
+/*
+ *  Copyright 2006-2020 The MZmine Development Team
+ *
+ *  This file is part of MZmine.
+ *
+ *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ *  General Public License as published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
+ *
+ *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ *  Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with MZmine; if not,
+ *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ *  USA
+ */
+
+package io.github.mzmine.modules.visualization.rawdataoverviewims.providers;
+
+import com.google.common.collect.Range;
+import io.github.mzmine.datamodel.DataPoint;
+import io.github.mzmine.datamodel.Frame;
+import io.github.mzmine.datamodel.ImsMsMsInfo;
+import io.github.mzmine.datamodel.MassList;
+import io.github.mzmine.datamodel.MassSpectrumType;
+import io.github.mzmine.datamodel.MobilityScan;
+import io.github.mzmine.datamodel.MobilityType;
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.util.DataPointUtils;
+import java.nio.DoubleBuffer;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Loads a frame and it's subscans into ram.
+ *
+ * @author https://github.com/SteffenHeu
+ */
+public class CachedMobilityScan implements MobilityScan {
+
+  private final MobilityScan originalMobilityScan;
+  private final double[] mzs;
+  private final double[] intensities;
+  private final double tic;
+
+  public CachedMobilityScan(MobilityScan scan, double noiseLevel) {
+    this.originalMobilityScan = scan;
+
+    double[][] data = DataPointUtils
+        .getDatapointsAboveNoiseLevel(scan.getMzValues(), scan.getIntensityValues(), noiseLevel);
+
+    mzs = data[0];
+    intensities = data[1];
+    tic = Arrays.stream(intensities).sum();
+  }
+
+  @Override
+  public int getNumberOfDataPoints() {
+    return mzs.length;
+  }
+
+  @Override
+  public MassSpectrumType getSpectrumType() {
+    return originalMobilityScan.getSpectrumType();
+  }
+
+  @Nonnull
+  @Override
+  public DoubleBuffer getMzValues() {
+    throw new UnsupportedOperationException(
+        "Not intended. This frame is used for visualisation only");
+  }
+
+  @Nonnull
+  @Override
+  public DoubleBuffer getIntensityValues() {
+    throw new UnsupportedOperationException(
+        "Not intended. This frame is used for visualisation only");
+  }
+
+  @Override
+  public double getMzValue(int index) {
+    return mzs[index];
+  }
+
+  @Override
+  public double getIntensityValue(int index) {
+    return intensities[index];
+  }
+
+  @Nullable
+  @Override
+  public Double getBasePeakMz() {
+    return originalMobilityScan.getBasePeakMz();
+  }
+
+  @Nullable
+  @Override
+  public Double getBasePeakIntensity() {
+    return originalMobilityScan.getBasePeakIntensity();
+  }
+
+  @Nullable
+  @Override
+  public Integer getBasePeakIndex() {
+    throw new UnsupportedOperationException(
+        "Not intended. This frame is used for visualisation only");
+  }
+
+  @Nullable
+  @Override
+  public Range<Double> getDataPointMZRange() {
+    return originalMobilityScan.getDataPointMZRange();
+  }
+
+  @Nullable
+  @Override
+  public Double getTIC() {
+    return tic;
+  }
+
+  @Override
+  public Stream<DataPoint> stream() {
+    throw new UnsupportedOperationException(
+        "Not intended. This frame is used for visualisation only");
+  }
+
+  @Nonnull
+  @Override
+  public RawDataFile getDataFile() {
+    return originalMobilityScan.getDataFile();
+  }
+
+  @Override
+  public double getMobility() {
+    return originalMobilityScan.getMobility();
+  }
+
+  @Override
+  public MobilityType getMobilityType() {
+    return originalMobilityScan.getMobilityType();
+  }
+
+  @Override
+  public Frame getFrame() {
+    return originalMobilityScan.getFrame();
+  }
+
+  @Override
+  public float getRetentionTime() {
+    return originalMobilityScan.getRetentionTime();
+  }
+
+  @Override
+  public int getMobilityScamNumber() {
+    return originalMobilityScan.getMobilityScamNumber();
+  }
+
+  @Nullable
+  @Override
+  public ImsMsMsInfo getMsMsInfo() {
+    throw new UnsupportedOperationException(
+        "Not intended. This frame is used for visualisation only");
+  }
+
+  @Override
+  public void addMassList(@Nonnull MassList massList) {
+    throw new UnsupportedOperationException(
+        "Not intended. This frame is used for visualisation only");
+  }
+
+  @Override
+  public void removeMassList(@Nonnull MassList massList) {
+    throw new UnsupportedOperationException(
+        "Not intended. This frame is used for visualisation only");
+  }
+
+  @Nonnull
+  @Override
+  public Set<MassList> getMassLists() {
+    throw new UnsupportedOperationException(
+        "Not intended. This frame is used for visualisation only");
+  }
+
+  @Override
+  public MassList getMassList(@Nonnull String name) {
+    throw new UnsupportedOperationException(
+        "Not intended. This frame is used for visualisation only");
+  }
+
+  @Nonnull
+  @Override
+  public Iterator<DataPoint> iterator() {
+    throw new UnsupportedOperationException(
+        "Not intended. This frame is used for visualisation only");
+  }
+}

--- a/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/providers/FrameHeatmapProvider.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/providers/FrameHeatmapProvider.java
@@ -18,20 +18,19 @@
 
 package io.github.mzmine.modules.visualization.rawdataoverviewims.providers;
 
-import java.awt.Color;
-import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.List;
-import javax.annotation.Nullable;
-import org.jfree.chart.renderer.PaintScale;
-import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.Frame;
 import io.github.mzmine.datamodel.MobilityScan;
 import io.github.mzmine.gui.chartbasics.simplechart.providers.PlotXYZDataProvider;
 import io.github.mzmine.gui.preferences.UnitFormat;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import java.awt.Color;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.List;
 import javafx.beans.property.SimpleObjectProperty;
+import javax.annotation.Nullable;
+import org.jfree.chart.renderer.PaintScale;
 
 public class FrameHeatmapProvider implements PlotXYZDataProvider {
 
@@ -101,16 +100,15 @@ public class FrameHeatmapProvider implements PlotXYZDataProvider {
     double numScans = frame.getNumberOfMobilityScans();
     int finishedScans = 0;
     for (MobilityScan mobilityScan : frame.getSortedMobilityScans()) {
-      for (DataPoint dp : mobilityScan) {
+      for (int i = 0; i < mobilityScan.getNumberOfDataPoints(); i++) {
         rangeValues.add(mobilityScan.getMobility());
-        domainValues.add(dp.getMZ());
-        zValues.add(dp.getIntensity());
+        domainValues.add(mobilityScan.getMzValue(i));
+        zValues.add(mobilityScan.getIntensityValue(i));
         mobilityScanAtValueIndex.add(mobilityScan);
       }
       finishedScans++;
       finishedPercentage = finishedScans / numScans;
     }
-
   }
 
   public MobilityScan getMobilityScanAtValueIndex(int index) {

--- a/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/providers/FrameSummedMobilogramProvider.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/providers/FrameSummedMobilogramProvider.java
@@ -18,15 +18,15 @@
 
 package io.github.mzmine.modules.visualization.rawdataoverviewims.providers;
 
-import java.awt.Color;
-import java.text.NumberFormat;
-import java.util.List;
 import io.github.mzmine.datamodel.Frame;
 import io.github.mzmine.datamodel.MobilityScan;
 import io.github.mzmine.gui.chartbasics.simplechart.providers.PlotXYDataProvider;
 import io.github.mzmine.gui.preferences.UnitFormat;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import java.awt.Color;
+import java.text.NumberFormat;
+import java.util.List;
 import javafx.beans.property.SimpleObjectProperty;
 
 public class FrameSummedMobilogramProvider implements PlotXYDataProvider {
@@ -80,7 +80,7 @@ public class FrameSummedMobilogramProvider implements PlotXYDataProvider {
   @Override
   public String getToolTipText(int itemIndex) {
     MobilityScan scan = frame.getSortedMobilityScans().get(itemIndex);
-    if (scan == null || scan.getBasePeakIndex() == null) {
+    if (scan == null || scan.getBasePeakMz() == null || scan.getBasePeakIntensity() == null) {
       return null;
     }
     return "Scan #" + scan.getMobilityScamNumber() + "\nMobility: "

--- a/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/providers/FrameSummedSpectrumProvider.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/providers/FrameSummedSpectrumProvider.java
@@ -18,15 +18,13 @@
 
 package io.github.mzmine.modules.visualization.rawdataoverviewims.providers;
 
-import java.awt.Color;
-import java.text.NumberFormat;
-import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.Frame;
 import io.github.mzmine.gui.chartbasics.simplechart.providers.PlotXYDataProvider;
 import io.github.mzmine.gui.preferences.UnitFormat;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.taskcontrol.TaskStatus;
-import io.github.mzmine.util.scans.ScanUtils;
+import java.awt.Color;
+import java.text.NumberFormat;
 import javafx.beans.property.SimpleObjectProperty;
 
 public class FrameSummedSpectrumProvider implements PlotXYDataProvider {
@@ -37,7 +35,7 @@ public class FrameSummedSpectrumProvider implements PlotXYDataProvider {
   protected final NumberFormat intensityFormat;
   protected final UnitFormat unitFormat;
   private final Frame frame;
-  private DataPoint[] dataPoints;
+//  private DataPoint[] dataPoints;
 
   private double finishedPercentage;
 
@@ -54,7 +52,7 @@ public class FrameSummedSpectrumProvider implements PlotXYDataProvider {
 
   @Override
   public String getLabel(int index) {
-    return mzFormat.format(dataPoints[index].getMZ());
+    return mzFormat.format((frame.getMzValue(index)));
   }
 
   @Override
@@ -76,28 +74,28 @@ public class FrameSummedSpectrumProvider implements PlotXYDataProvider {
   @Override
   public String getToolTipText(int itemIndex) {
     return "Frame #" + frame.getFrameId() + "RT " + frame.getRetentionTime() + "\nm/z "
-        + mzFormat.format(dataPoints[itemIndex].getMZ()) + "\nIntensity "
-        + intensityFormat.format(dataPoints[itemIndex].getIntensity());
+        + mzFormat.format(frame.getMzValue(itemIndex)) + "\nIntensity "
+        + intensityFormat.format(frame.getIntensityValue(itemIndex));
   }
 
   @Override
   public void computeValues(SimpleObjectProperty<TaskStatus> status) {
-    dataPoints = ScanUtils.extractDataPoints(frame);
+//    dataPoints = ScanUtils.extractDataPoints(frame);
   }
 
   @Override
   public double getDomainValue(int index) {
-    return dataPoints[index].getMZ();
+    return frame.getMzValue(index);
   }
 
   @Override
   public double getRangeValue(int index) {
-    return dataPoints[index].getIntensity();
+    return frame.getIntensityValue(index);
   }
 
   @Override
   public int getValueCount() {
-    return dataPoints.length;
+    return frame.getNumberOfDataPoints();
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/providers/SingleSpectrumProvider.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/providers/SingleSpectrumProvider.java
@@ -18,15 +18,13 @@
 
 package io.github.mzmine.modules.visualization.rawdataoverviewims.providers;
 
-import java.awt.Color;
-import java.text.NumberFormat;
-import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.MobilityScan;
 import io.github.mzmine.gui.chartbasics.simplechart.providers.PlotXYDataProvider;
 import io.github.mzmine.gui.preferences.UnitFormat;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.taskcontrol.TaskStatus;
-import io.github.mzmine.util.scans.ScanUtils;
+import java.awt.Color;
+import java.text.NumberFormat;
 import javafx.beans.property.SimpleObjectProperty;
 
 public class SingleSpectrumProvider implements PlotXYDataProvider {
@@ -38,7 +36,7 @@ public class SingleSpectrumProvider implements PlotXYDataProvider {
   protected final UnitFormat unitFormat;
   private final MobilityScan scan;
   private double finishedPercentage;
-  private DataPoint[] dataPoints;
+//  private DataPoint[] dataPoints;
 
   public SingleSpectrumProvider(MobilityScan scan) {
     this.scan = scan;
@@ -63,7 +61,7 @@ public class SingleSpectrumProvider implements PlotXYDataProvider {
 
   @Override
   public String getLabel(int index) {
-    return mzFormat.format(dataPoints[index].getMZ());
+    return mzFormat.format(scan.getMzValue(index));
   }
 
   @Override
@@ -77,30 +75,29 @@ public class SingleSpectrumProvider implements PlotXYDataProvider {
     return "Frame #" + scan.getFrame().getFrameId() + "\nMobility scan #"
         + scan.getMobilityScamNumber() + "\nMobility: " + mobilityFormat.format(scan.getMobility())
         + " " + scan.getMobilityType().getUnit() + "\nm/z: "
-        + mzFormat.format(dataPoints[itemIndex].getMZ()) + "\nIntensity: "
-        + intensityFormat.format(dataPoints[itemIndex].getIntensity());
+        + mzFormat.format(scan.getMzValue(itemIndex)) + "\nIntensity: "
+        + intensityFormat.format(scan.getIntensityValue(itemIndex));
 
   }
 
   @Override
   public void computeValues(SimpleObjectProperty<TaskStatus> status) {
-    dataPoints = ScanUtils.extractDataPoints(scan);
     finishedPercentage = 1.d;
   }
 
   @Override
   public double getDomainValue(int index) {
-    return dataPoints[index].getMZ();
+    return scan.getMzValue(index);
   }
 
   @Override
   public double getRangeValue(int index) {
-    return dataPoints[index].getIntensity();
+    return scan.getIntensityValue(index);
   }
 
   @Override
   public int getValueCount() {
-    return dataPoints.length;
+    return scan.getNumberOfDataPoints();
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/datasets/SinglePeakDataSet.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/datasets/SinglePeakDataSet.java
@@ -1,16 +1,16 @@
 /*
  * Copyright 2006-2020 The MZmine Development Team
- * 
+ *
  * This file is part of MZmine.
- * 
+ *
  * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
  * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
  * Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
  * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
  * USA
@@ -20,10 +20,9 @@ package io.github.mzmine.modules.visualization.spectra.simplespectra.datasets;
 
 import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
+import io.github.mzmine.datamodel.features.ModularFeature;
 import org.jfree.data.xy.AbstractXYDataset;
 import org.jfree.data.xy.IntervalXYDataset;
-
-import io.github.mzmine.datamodel.DataPoint;
 
 /**
  * Data set for a single highlighted peak
@@ -31,15 +30,23 @@ import io.github.mzmine.datamodel.DataPoint;
 public class SinglePeakDataSet extends AbstractXYDataset implements IntervalXYDataset {
 
   /**
-   * 
+   *
    */
   private static final long serialVersionUID = 1L;
-  private DataPoint dataPoint;
   private String label;
+  private double mz;
+  private double intensity;
+
 
   public SinglePeakDataSet(Scan scanNumber, Feature peak) {
     this.label = peak.toString();
-    this.dataPoint = peak.getDataPoint(scanNumber);
+    if (peak instanceof ModularFeature) {
+      mz = ((ModularFeature) peak).getFeatureData().getMzForSpectrum(scanNumber);
+      intensity = ((ModularFeature) peak).getFeatureData().getIntensityForSpectrum(scanNumber);
+    } else {
+      mz = peak.getDataPoint(scanNumber).getMZ();
+      intensity = peak.getDataPoint(scanNumber).getIntensity();
+    }
   }
 
   @Override
@@ -57,11 +64,11 @@ public class SinglePeakDataSet extends AbstractXYDataset implements IntervalXYDa
   }
 
   public Number getX(int series, int item) {
-    return dataPoint.getMZ();
+    return mz;
   }
 
   public Number getY(int series, int item) {
-    return dataPoint.getIntensity();
+    return intensity;
   }
 
   public Number getEndX(int series, int item) {

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/ScanSelection.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/ScanSelection.java
@@ -27,9 +27,9 @@ import io.github.mzmine.datamodel.PolarityType;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.util.TextUtils;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.List;
 import java.util.stream.Stream;
 import javax.annotation.concurrent.Immutable;
 
@@ -102,8 +102,8 @@ public class ScanSelection {
     return scanDefinition;
   }
 
-  public Set<? extends Scan> getMachtingScans(Collection<? extends Scan> scans) {
-    Set<Scan> eligibleScans = new HashSet<>();
+  public List<? extends Scan> getMachtingScans(Collection<? extends Scan> scans) {
+    List<Scan> eligibleScans = new ArrayList<>();
     for (Scan scan : scans) {
       if (matches(scan)) {
         eligibleScans.add(scan);

--- a/src/main/java/io/github/mzmine/taskcontrol/impl/TaskQueue.java
+++ b/src/main/java/io/github/mzmine/taskcontrol/impl/TaskQueue.java
@@ -18,9 +18,9 @@
 
 package io.github.mzmine.taskcontrol.impl;
 
+import io.github.mzmine.taskcontrol.TaskStatus;
 import java.util.Arrays;
 import java.util.logging.Logger;
-import io.github.mzmine.taskcontrol.TaskStatus;
 import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -31,12 +31,12 @@ import javafx.collections.ObservableList;
  */
 public class TaskQueue {
 
-  private Logger logger = Logger.getLogger(this.getClass().getName());
-
   /**
    * This observable list stores the actual tasks
    */
-  private final ObservableList<WrappedTask> queue = FXCollections.observableArrayList();
+  private final ObservableList<WrappedTask> queue = FXCollections
+      .synchronizedObservableList(FXCollections.observableArrayList());
+  private Logger logger = Logger.getLogger(this.getClass().getName());
 
   public int getNumOfWaitingTasks() {
     final WrappedTask snapshot[] = getQueueSnapshot();

--- a/src/main/java/io/github/mzmine/util/DataPointUtils.java
+++ b/src/main/java/io/github/mzmine/util/DataPointUtils.java
@@ -1,8 +1,11 @@
 package io.github.mzmine.util;
 
+import com.google.common.primitives.Doubles;
 import io.github.mzmine.datamodel.DataPoint;
 import java.nio.DoubleBuffer;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.logging.Logger;
 
 public class DataPointUtils {
@@ -79,6 +82,26 @@ public class DataPointUtils {
     for (int i = 0; i < dataPoints.length; i++) {
       data[i] = dataPoints[i].getIntensity();
     }
+    return data;
+  }
+
+  public static double[][] getDatapointsAboveNoiseLevel(DoubleBuffer rawMzs,
+      DoubleBuffer rawIntensities,
+      double noiseLevel) {
+    assert rawMzs.capacity() == rawIntensities.capacity();
+
+    List<Double> mzs = new ArrayList<>();
+    List<Double> intensities = new ArrayList<>();
+
+    for (int i = 0; i < rawMzs.capacity(); i++) {
+      if (rawIntensities.get(i) > noiseLevel) {
+        mzs.add(rawMzs.get(i));
+        intensities.add(rawIntensities.get(i));
+      }
+    }
+    double[][] data = new double[2][];
+    data[0] = Doubles.toArray(mzs);
+    data[1] = Doubles.toArray(intensities);
     return data;
   }
 }

--- a/src/main/java/io/github/mzmine/util/DataPointUtils.java
+++ b/src/main/java/io/github/mzmine/util/DataPointUtils.java
@@ -44,11 +44,40 @@ public class DataPointUtils {
     assert mzValues.capacity() == intensityValues.capacity();
 
     double data[][] = new double[2][];
-    data[0]= new double[mzValues.capacity()];
-    data[1]= new double[mzValues.capacity()];
-    for(int i = 0; i < mzValues.capacity(); i++) {
+    data[0] = new double[mzValues.capacity()];
+    data[1] = new double[mzValues.capacity()];
+    for (int i = 0; i < mzValues.capacity(); i++) {
       data[0][i] = mzValues.get(i);
       data[1][i] = intensityValues.get(i);
+    }
+    return data;
+  }
+
+  public static double[] getDoubleBufferAsArray(DoubleBuffer values) {
+    double[] data = new double[values.capacity()];
+
+    for (int i = 0; i < values.capacity(); i++) {
+      data[i] = values.get(i);
+    }
+    return data;
+  }
+
+  @Deprecated
+  public static double[] getMZsAsDoubleArray(DataPoint[] dataPoints) {
+    double[] data = new double[dataPoints.length];
+
+    for (int i = 0; i < dataPoints.length; i++) {
+      data[i] = dataPoints[i].getMZ();
+    }
+    return data;
+  }
+
+  @Deprecated
+  public static double[] getIntenstiesAsDoubleArray(DataPoint[] dataPoints) {
+    double[] data = new double[dataPoints.length];
+
+    for (int i = 0; i < dataPoints.length; i++) {
+      data[i] = dataPoints[i].getIntensity();
     }
     return data;
   }

--- a/src/main/java/io/github/mzmine/util/scans/ScanUtils.java
+++ b/src/main/java/io/github/mzmine/util/scans/ScanUtils.java
@@ -18,28 +18,6 @@
 
 package io.github.mzmine.util.scans;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.text.Format;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
@@ -60,8 +38,30 @@ import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.util.exceptions.MissingMassListException;
 import io.github.mzmine.util.scans.sorting.ScanSortMode;
 import io.github.mzmine.util.scans.sorting.ScanSorter;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.text.Format;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Scan related utilities
@@ -125,18 +125,27 @@ public class ScanUtils {
   /**
    * Find a base peak of a given scan in a given m/z range
    *
-   * @param scan Scan to search
+   * @param scan    Scan to search
    * @param mzRange mz range to search in
    * @return double[2] containing base peak m/z and intensity
    */
-  public static @Nullable DataPoint findBasePeak(@Nonnull Scan scan,
-      @Nonnull Range<Double> mzRange) {
+  @Nullable
+  public static DataPoint findBasePeak(@Nonnull Scan scan, @Nonnull Range<Double> mzRange) {
 
-    Integer basePeakIndex = scan.getBasePeakIndex();
-    if (basePeakIndex == null)
-      return null;
-    SimpleDataPoint dp = new SimpleDataPoint(scan.getBasePeakMz(), scan.getBasePeakIntensity());
-    return dp;
+    double baseMz = 0d;
+    double baseIntensity = 0d;
+    for (int i = 0; i < scan.getNumberOfDataPoints(); i++) {
+      double mz = scan.getMzValue(i);
+      if (!mzRange.contains(mz)) {
+        continue;
+      }
+      double intensity = scan.getIntensityValue(i);
+      if (intensity > baseIntensity) {
+        baseIntensity = intensity;
+        baseMz = mz;
+      }
+    }
+    return new SimpleDataPoint(baseMz, baseIntensity);
   }
 
   /**


### PR DESCRIPTION
In addition to #153:
- fixes the ims visualiser (I know you dont like the idea of a CachedFrame, so im open to ideas, but this is the easiest solution)
- Fixes ScanUtils.findBasePeak, by that, most of the old plot datasets are fixed.
  - plot datasets preferably use the new data type, for generation. However, i did not change their internal data storage.