### PR TITLE
consecutive rt scans in ion mobility trace builder

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonMobilitySeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonMobilitySeries.java
@@ -52,8 +52,6 @@ public class SimpleIonMobilitySeries implements IonSpectrumSeries<MobilityScan> 
    * @param mzValues
    * @param intensityValues
    * @param scans
-   * @param forceStoreInRam Forces storage of mz and intensity values in ram. Note that all series
-   *                        created as subset or copy from this series will also be stored in ram.
    */
   public SimpleIonMobilitySeries(@Nullable MemoryMapStorage storage, @Nonnull double[] mzValues,
       @Nonnull double[] intensityValues, @Nonnull List<MobilityScan> scans) {

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_ionmobilitytracebuilder/IonMobilityTraceBuilderParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_ionmobilitytracebuilder/IonMobilityTraceBuilderParameters.java
@@ -18,15 +18,10 @@
 
 package io.github.mzmine.modules.dataprocessing.featdet_ionmobilitytracebuilder;
 
-import com.google.common.collect.Range;
-import io.github.mzmine.gui.chartbasics.chartutils.paintscales.PaintScale;
-import io.github.mzmine.gui.chartbasics.chartutils.paintscales.PaintScaleBoundStyle;
-import io.github.mzmine.gui.chartbasics.chartutils.paintscales.PaintScaleColorStyle;
 import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
 import io.github.mzmine.parameters.parametertypes.IntegerParameter;
 import io.github.mzmine.parameters.parametertypes.MassListParameter;
-import io.github.mzmine.parameters.parametertypes.PaintScaleParameter;
 import io.github.mzmine.parameters.parametertypes.StringParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.ScanSelection;
@@ -50,35 +45,20 @@ public class IonMobilityTraceBuilderParameters extends SimpleParameterSet {
       false);
 
   public static final IntegerParameter minDataPointsRt = new IntegerParameter(
-      "Minimum retention time data points",
-      "Minimum number of time resolved data points in an ion mobility trace. In other words, chromatographic peak width in number of data points",
+      "Minimum consecutive retention time data points",
+      "Minimum number of consecutive time resolved data points in an ion mobility trace."
+          + " In other words, chromatographic peak width in number of data points",
       7);
 
   public static final IntegerParameter minTotalSignals =
       new IntegerParameter("Minimum total Signals",
           "Minimum number of signals (data points) in an ion mobility trace", 200);
 
-  public static final PaintScaleParameter paintScale =
-      new PaintScaleParameter("Color scale", "Select paint scale",
-          new PaintScale[] {
-              new PaintScale(PaintScaleColorStyle.RAINBOW, PaintScaleBoundStyle.NONE,
-                  Range.closed(0.0, 100.0)),
-              new PaintScale(PaintScaleColorStyle.GRREN_RED, PaintScaleBoundStyle.NONE,
-                  Range.closed(0.0, 100.0)),
-              new PaintScale(PaintScaleColorStyle.RED, PaintScaleBoundStyle.NONE,
-                  Range.closed(0.0, 100.0)),
-              new PaintScale(PaintScaleColorStyle.GREEN, PaintScaleBoundStyle.NONE,
-                  Range.closed(0.0, 100.0)),
-              new PaintScale(PaintScaleColorStyle.CYAN, PaintScaleBoundStyle.NONE,
-                  Range.closed(0.0, 100.0)),
-              new PaintScale(PaintScaleColorStyle.YELLOW, PaintScaleBoundStyle.NONE,
-                  Range.closed(0.0, 100.0))});
-
   public static final StringParameter suffix = new StringParameter("Suffix",
       "This string is added to filename as suffix", "ionmobilitytrace");
 
   public IonMobilityTraceBuilderParameters() {
-    super(new Parameter[] {rawDataFiles, massList, scanSelection, mzTolerance, minDataPointsRt,
-        minTotalSignals, paintScale, suffix});
+    super(new Parameter[]{rawDataFiles, massList, scanSelection, mzTolerance, minDataPointsRt,
+        minTotalSignals, suffix});
   }
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_ionmobilitytracebuilder/IonMobilityTraceBuilderTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_ionmobilitytracebuilder/IonMobilityTraceBuilderTask.java
@@ -394,7 +394,7 @@ public class IonMobilityTraceBuilderTask extends AbstractTask {
       frame = frameIterator.next();
       if (frame == frames.get(i)) {
         consecutive++;
-        if (consecutive > minDataPointsRt) {
+        if (consecutive >= minDataPointsRt) {
           found = true;
           break;
         }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_ionmobilitytracebuilder/IonMobilityTraceBuilderTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_ionmobilitytracebuilder/IonMobilityTraceBuilderTask.java
@@ -75,7 +75,6 @@ public class IonMobilityTraceBuilderTask extends AbstractTask {
   private HashMap<Range<Double>, IIonMobilityTrace> rangeToIonTraceMap = new HashMap<>();
   private double progress = 0.0;
   private String taskDescription = "";
-  private List<Frame> sortedFrames;
 
   @SuppressWarnings("unchecked")
   public IonMobilityTraceBuilderTask(MZmineProject project, RawDataFile rawDataFile,
@@ -92,9 +91,6 @@ public class IonMobilityTraceBuilderTask extends AbstractTask {
     this.scanSelection =
         parameters.getParameter(IonMobilityTraceBuilderParameters.scanSelection).getValue();
     this.frames = (List<Frame>) scanSelection.getMachtingScans((frames));
-    this.sortedFrames = this.frames.stream().sorted(Comparator.comparingInt(Frame::getFrameId))
-        .collect(
-            Collectors.toList());
     this.suffix = parameters.getParameter(IonMobilityTraceBuilderParameters.suffix).getValue();
     setStatus(TaskStatus.WAITING);
   }
@@ -261,11 +257,11 @@ public class IonMobilityTraceBuilderTask extends AbstractTask {
       progress += progressStep;
       Range<Double> currentRangeKey = rangeIterator.next();
       IIonMobilityTrace ionTrace = rangeToIonTraceMap.get(currentRangeKey);
-      if (ionTrace.getDataPoints().size() >= minTotalSignals
-          && checkNumberOfRetentionTimeDataPoints(ionTrace.getDataPoints())) {
-//        logger.info("Build ion trace for m/z range " + ionTrace.getMzRange());
-        finishIonTrace(ionTrace);
-        ionMobilityTraces.add(ionTrace);
+      if (ionTrace.getDataPoints().size() >= minTotalSignals) {
+        ionTrace = finishIonTrace(ionTrace);
+        if (ionTrace != null) {
+          ionMobilityTraces.add(ionTrace);
+        }
       }
     }
     return ionMobilityTraces;
@@ -277,17 +273,6 @@ public class IonMobilityTraceBuilderTask extends AbstractTask {
     Range<Double> rawDataPointsMobilityRange = null;
     Range<Float> rawDataPointsRtRange = null;
     LinkedHashSet<MobilityScan> scanNumbers = new LinkedHashSet<>();
-    /*SortedSet<RetentionTimeMobilityDataPoint> sortedRetentionTimeMobilityDataPoints =
-        new TreeSet<>((o1, o2) -> {
-          int frameComp = Integer
-              .compare(o1.getFrame().getScanNumber(), o2.getFrame().getScanNumber());
-          if (frameComp != 0) {
-            return frameComp;
-          } else {
-            return Integer.compare(o1.getMobilityScan().getMobilityScamNumber(),
-                o2.getMobilityScan().getMobilityScamNumber());
-          }
-        });*/
 
     Float rt = 0.0f;
     double mobility = 0.0f;
@@ -297,8 +282,12 @@ public class IonMobilityTraceBuilderTask extends AbstractTask {
         .groupDataPointsByFrameId(ionTrace.getDataPoints());
     double maximumIntensity = Double.MIN_VALUE;
 
+    if (!checkConsecutiveFrames(groupedDps, frames)) {
+      return null;
+    }
+
     // fill borders of peaks with 0s
-    Set<RetentionTimeMobilityDataPoint> frameFillers = addZerosForFrames(sortedFrames,
+    Set<RetentionTimeMobilityDataPoint> frameFillers = addZerosForFrames(frames,
         (SortedSet<Frame>) groupedDps.keySet(), ionTrace.getMz(),
         ionTrace.getDataPoints(), 0, null, 4, 1);
     Set<RetentionTimeMobilityDataPoint> mobilityScanFillers = new HashSet<>();
@@ -390,6 +379,31 @@ public class IonMobilityTraceBuilderTask extends AbstractTask {
     // }
 
     return ionTrace;
+  }
+
+  private boolean checkConsecutiveFrames(SortedMap<Frame, ?> groupedDps, List<Frame> frames) {
+    // check for consecutive frames
+    int consecutive = 0;
+
+    Iterator<Frame> frameIterator = groupedDps.keySet().iterator();
+    Frame frame = frameIterator.next();
+    int index = frames.indexOf(frame);
+    boolean found = false;
+    for (int i = index + 1; i < frames.size() && frameIterator.hasNext(); i++) {
+      // now go forward
+      frame = frameIterator.next();
+      if (frame == frames.get(i)) {
+        consecutive++;
+        if (consecutive > minDataPointsRt) {
+          found = true;
+          break;
+        }
+      } else {
+        i = frames.indexOf(frame);
+        consecutive = 0;
+      }
+    }
+    return found;
   }
 
   private Set<RetentionTimeMobilityDataPoint> addZerosForMobilityScans(Frame frame,
@@ -543,15 +557,6 @@ public class IonMobilityTraceBuilderTask extends AbstractTask {
       }
     }
     return mobilityScans.get(mobilityScans.size() - 1);
-  }
-
-  private boolean checkNumberOfRetentionTimeDataPoints(
-      Set<RetentionTimeMobilityDataPoint> dataPoints) {
-    Set<Float> retentionTimes = new HashSet<>();
-    for (RetentionTimeMobilityDataPoint dataPoint : dataPoints) {
-      retentionTimes.add(dataPoint.getRetentionTime());
-    }
-    return (retentionTimes.size() >= minDataPointsRt);
   }
 
   private void buildModularFeatureList(SortedSet<IIonMobilityTrace> ionMobilityTraces) {

--- a/src/main/java/io/github/mzmine/modules/tools/qualityparameters/QualityParameters.java
+++ b/src/main/java/io/github/mzmine/modules/tools/qualityparameters/QualityParameters.java
@@ -52,7 +52,7 @@ public class QualityParameters {
       RawDataFile dataFile = peak.getRawDataFile();
       IonTimeSeries<? extends Scan> dps = peak.getFeatureData();
       if (height.getValue() == null || rt.getValue() == null || dataFile == null
-          || scanNumbers.isEmpty() || dps.getNumberOfValues() == 0) {
+          || scanNumbers.isEmpty() || dps.getNumberOfValues() < 3) {
         return;
       }
 


### PR DESCRIPTION
Ion mobility trace build now takes the number of censecutive frames into account, not just the total number of frames.