### PR TITLE
Warning messages for ims data

### DIFF
--- a/src/main/java/io/github/mzmine/gui/Desktop.java
+++ b/src/main/java/io/github/mzmine/gui/Desktop.java
@@ -18,23 +18,23 @@
 
 package io.github.mzmine.gui;
 
+import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.gui.mainwindow.MZmineTab;
-import java.util.List;
-import java.net.URL;
-import javax.annotation.Nonnull;
-import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.modules.MZmineModule;
 import io.github.mzmine.taskcontrol.impl.WrappedTask;
 import io.github.mzmine.util.ExitCode;
+import java.net.URL;
+import java.util.List;
+import java.util.function.Consumer;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.TableView;
 import javafx.scene.paint.Color;
 import javafx.stage.Stage;
+import javax.annotation.Nonnull;
 
 /**
  * This interface represents the application GUI
- *
  */
 public interface Desktop extends MZmineModule {
 
@@ -85,15 +85,27 @@ public interface Desktop extends MZmineModule {
 
   /**
    * Displays an error message
-   *
    */
   public void displayException(Exception e);
 
   /**
    * Displays a confirmation Yes/No alert. Can be called from any thread.
-   *
    */
   public ButtonType displayConfirmation(String msg, ButtonType... buttonTypes);
+
+  /**
+   * Displays an opt-out yes/no dialog. Can be called from any thread.
+   *
+   * @param title
+   * @param headerText
+   * @param message
+   * @param optOutMessage
+   * @param optOutAction
+   * @return {@link ButtonType#YES} or {@link ButtonType#NO}. In headless mode, YES is always
+   * returned and the message is logged at warning level.
+   */
+  public ButtonType createAlertWithOptOut(String title, String headerText,
+      String message, String optOutMessage, Consumer<Boolean> optOutAction);
 
   /**
    * Returns array of currently selected raw data files in GUI
@@ -141,6 +153,5 @@ public interface Desktop extends MZmineModule {
    */
   @Nonnull
   public List<MZmineTab> getTabsInMainWindow();
-
 
 }

--- a/src/main/java/io/github/mzmine/gui/HeadLessDesktop.java
+++ b/src/main/java/io/github/mzmine/gui/HeadLessDesktop.java
@@ -28,6 +28,7 @@ import io.github.mzmine.util.ExitCode;
 import java.net.URL;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.collections.FXCollections;
@@ -137,9 +138,17 @@ public class HeadLessDesktop implements Desktop {
   public List<MZmineTab> getTabsInMainWindow() {
     return Collections.emptyList();
   }
+
   @Override
   public ButtonType displayConfirmation(String msg, ButtonType... buttonTypes) {
     throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ButtonType createAlertWithOptOut(String title, String headerText, String message,
+      String optOutMessage, Consumer<Boolean> optOutAction) {
+    logger.warning(title + "; " + headerText + "; " + message);
+    return ButtonType.YES;
   }
 
 }

--- a/src/main/java/io/github/mzmine/gui/MZmineGUI.java
+++ b/src/main/java/io/github/mzmine/gui/MZmineGUI.java
@@ -464,6 +464,8 @@ public class MZmineGUI extends Application implements Desktop {
     Platform.runLater(() -> {
       Dialog<ButtonType> dialog = new Dialog<>();
       Stage stage = (Stage) dialog.getDialogPane().getScene().getWindow();
+      stage.getScene().getStylesheets()
+          .addAll(MZmineCore.getDesktop().getMainWindow().getScene().getStylesheets());
       stage.getIcons().add(mzMineIcon);
       dialog.setTitle(title);
       dialog.setContentText(msg);
@@ -487,6 +489,8 @@ public class MZmineGUI extends Application implements Desktop {
 
     FutureTask<ButtonType> alertTask = new FutureTask<>(() -> {
       Alert alert = new Alert(AlertType.CONFIRMATION, msg, buttonTypes);
+      alert.getDialogPane().getScene().getStylesheets()
+          .addAll(MZmineCore.getDesktop().getMainWindow().getScene().getStylesheets());
       alert.showAndWait();
       return alert.getResult();
     });
@@ -572,6 +576,8 @@ public class MZmineGUI extends Application implements Desktop {
     // Credits: https://stackoverflow.com/questions/36949595/how-do-i-create-a-javafx-alert-with-a-check-box-for-do-not-ask-again
     FutureTask<ButtonType> task = new FutureTask<>(() -> {
       Alert alert = new Alert(AlertType.WARNING);
+      alert.getDialogPane().getScene().getStylesheets()
+          .addAll(MZmineCore.getDesktop().getMainWindow().getScene().getStylesheets());
       // Need to force the alert to layout in order to grab the graphic,
       // as we are replacing the dialog pane with a custom pane
       alert.getDialogPane().applyCss();

--- a/src/main/java/io/github/mzmine/gui/MZmineGUI.java
+++ b/src/main/java/io/github/mzmine/gui/MZmineGUI.java
@@ -20,18 +20,7 @@ package io.github.mzmine.gui;
 
 
 import static io.github.mzmine.modules.io.projectload.ProjectLoaderParameters.projectFile;
-import java.io.File;
-import java.io.IOException;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.FutureTask;
-import java.util.logging.Logger;
-import javax.annotation.Nonnull;
-import org.apache.commons.io.FilenameUtils;
-import org.controlsfx.control.StatusBar;
+
 import com.google.common.collect.ImmutableList;
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.datamodel.RawDataFile;
@@ -56,17 +45,31 @@ import io.github.mzmine.util.RawDataFileUtils;
 import io.github.mzmine.util.javafx.FxColorUtil;
 import io.github.mzmine.util.javafx.FxIconUtil;
 import io.github.mzmine.util.javafx.groupablelistview.GroupableListView;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.function.Consumer;
+import java.util.logging.Logger;
 import javafx.application.Application;
 import javafx.application.HostServices;
 import javafx.application.Platform;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXMLLoader;
+import javafx.scene.Group;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
 import javafx.scene.control.ButtonType;
+import javafx.scene.control.CheckBox;
 import javafx.scene.control.Dialog;
+import javafx.scene.control.DialogPane;
 import javafx.scene.control.TableView;
 import javafx.scene.image.Image;
 import javafx.scene.input.DragEvent;
@@ -76,128 +79,23 @@ import javafx.scene.layout.BorderPane;
 import javafx.scene.paint.Color;
 import javafx.stage.Stage;
 import javafx.stage.Window;
+import javax.annotation.Nonnull;
+import org.apache.commons.io.FilenameUtils;
+import org.controlsfx.control.StatusBar;
 
 /**
  * MZmine JavaFX Application class
  */
 public class MZmineGUI extends Application implements Desktop {
 
-  private final Logger logger = Logger.getLogger(this.getClass().getName());
-
+  public static final int MAX_TABS = 7;
   private static final Image mzMineIcon = FxIconUtil.loadImageFromResources("MZmineIcon.png");
   private static final String mzMineFXML = "mainwindow/MainWindow.fxml";
 
   private static MainWindowController mainWindowController;
-
-  public static final int MAX_TABS = 7;
-
   private static Stage mainStage;
   private static Scene rootScene;
-
-  @Override
-  public void start(Stage stage) {
-
-    MZmineGUI.mainStage = stage;
-    MZmineCore.setDesktop(this);
-
-    logger.finest("Initializing MZmine main window");
-
-    try {
-      // Load the main window
-      URL mainFXML = this.getClass().getResource(mzMineFXML);
-      FXMLLoader loader = new FXMLLoader(mainFXML);
-
-      rootScene = loader.load();
-      mainWindowController = loader.getController();
-      stage.setScene(rootScene);
-      rootScene.getStylesheets()
-          .add(getClass().getResource("/themes/MZmine_light.css").toExternalForm());
-
-      Boolean darkMode = MZmineCore.getConfiguration().getPreferences()
-          .getParameter(MZminePreferences.darkMode).getValue();
-      if (darkMode != null && darkMode == true) {
-        rootScene.getStylesheets()
-            .add(getClass().getResource("/themes/MZmine_dark.css").toExternalForm());
-      } else {
-        rootScene.getStylesheets()
-            .add(getClass().getResource("/themes/MZmine_light.css").toExternalForm());
-      }
-
-    } catch (Exception e) {
-      e.printStackTrace();
-      logger.severe("Error loading MZmine GUI from FXML: " + e);
-      Platform.exit();
-    }
-
-    stage.setTitle("MZmine " + MZmineCore.getMZmineVersion());
-    stage.setMinWidth(600);
-    stage.setMinHeight(400);
-
-    // Set application icon
-    stage.getIcons().setAll(mzMineIcon);
-
-    stage.setOnCloseRequest(e -> {
-      requestQuit();
-      e.consume();
-    });
-
-    // Drag over surface
-    rootScene.setOnDragOver(MZmineGUI::activateSetOnDragOver);
-    // Dropping over surface
-    rootScene.setOnDragDropped(MZmineGUI::activateSetOnDragDropped);
-
-    // Configure desktop properties such as the application taskbar icon
-    // on a new thread. It is important to start this thread after the
-    // JavaFX subsystem has started. Otherwise we could be treated like a
-    // Swing application.
-    Thread desktopSetupThread = new Thread(new DesktopSetup());
-    desktopSetupThread.setPriority(Thread.MIN_PRIORITY);
-    desktopSetupThread.start();
-
-    setStatusBarText("Welcome to MZmine " + MZmineCore.getMZmineVersion());
-
-    stage.show();
-
-    // update the size and position of the main window
-    /*
-     * ParameterSet paramSet = configuration.getPreferences(); WindowSettingsParameter settings =
-     * paramSet .getParameter(MZminePreferences.windowSetttings);
-     * settings.applySettingsToWindow(desktop.getMainWindow());
-     */
-    // add last project menu items
-    /*
-     * if (desktop instanceof MainWindow) { ((MainWindow) desktop).createLastUsedProjectsMenu(
-     * configuration.getLastProjects()); // listen for changes
-     * configuration.getLastProjectsParameter() .addFileListChangedListener(list -> { // new list of
-     * last used projects Desktop desk = getDesktop(); if (desk instanceof MainWindow) {
-     * ((MainWindow) desk) .createLastUsedProjectsMenu(list); } }); }
-     */
-
-    // Activate project - bind it to the desktop's project tree
-    MZmineProjectImpl currentProject =
-        (MZmineProjectImpl) MZmineCore.getProjectManager().getCurrentProject();
-    MZmineGUI.activateProject(currentProject);
-
-
-    // Check for updated version
-    NewVersionCheck NVC = new NewVersionCheck(CheckType.DESKTOP);
-    Thread nvcThread = new Thread(NVC);
-    nvcThread.setPriority(Thread.MIN_PRIORITY);
-    nvcThread.start();
-
-    // Tracker
-    GoogleAnalyticsTracker GAT =
-        new GoogleAnalyticsTracker("MZmine Loaded (GUI mode)", "/JAVA/Main/GUI");
-    Thread gatThread = new Thread(GAT);
-    gatThread.setPriority(Thread.MIN_PRIORITY);
-    gatThread.start();
-
-    // register shutdown hook only if we have GUI - we don't want to
-    // save configuration on exit if we only run a batch
-    ShutDownHook shutDownHook = new ShutDownHook();
-    Runtime.getRuntime().addShutdownHook(shutDownHook);
-
-  }
+  private final Logger logger = Logger.getLogger(this.getClass().getName());
 
   public static void requestQuit() {
     Platform.runLater(() -> {
@@ -389,6 +287,110 @@ public class MZmineGUI extends Application implements Desktop {
   }
 
   @Override
+  public void start(Stage stage) {
+
+    MZmineGUI.mainStage = stage;
+    MZmineCore.setDesktop(this);
+
+    logger.finest("Initializing MZmine main window");
+
+    try {
+      // Load the main window
+      URL mainFXML = this.getClass().getResource(mzMineFXML);
+      FXMLLoader loader = new FXMLLoader(mainFXML);
+
+      rootScene = loader.load();
+      mainWindowController = loader.getController();
+      stage.setScene(rootScene);
+      rootScene.getStylesheets()
+          .add(getClass().getResource("/themes/MZmine_light.css").toExternalForm());
+
+      Boolean darkMode = MZmineCore.getConfiguration().getPreferences()
+          .getParameter(MZminePreferences.darkMode).getValue();
+      if (darkMode != null && darkMode == true) {
+        rootScene.getStylesheets()
+            .add(getClass().getResource("/themes/MZmine_dark.css").toExternalForm());
+      } else {
+        rootScene.getStylesheets()
+            .add(getClass().getResource("/themes/MZmine_light.css").toExternalForm());
+      }
+
+    } catch (Exception e) {
+      e.printStackTrace();
+      logger.severe("Error loading MZmine GUI from FXML: " + e);
+      Platform.exit();
+    }
+
+    stage.setTitle("MZmine " + MZmineCore.getMZmineVersion());
+    stage.setMinWidth(600);
+    stage.setMinHeight(400);
+
+    // Set application icon
+    stage.getIcons().setAll(mzMineIcon);
+
+    stage.setOnCloseRequest(e -> {
+      requestQuit();
+      e.consume();
+    });
+
+    // Drag over surface
+    rootScene.setOnDragOver(MZmineGUI::activateSetOnDragOver);
+    // Dropping over surface
+    rootScene.setOnDragDropped(MZmineGUI::activateSetOnDragDropped);
+
+    // Configure desktop properties such as the application taskbar icon
+    // on a new thread. It is important to start this thread after the
+    // JavaFX subsystem has started. Otherwise we could be treated like a
+    // Swing application.
+    Thread desktopSetupThread = new Thread(new DesktopSetup());
+    desktopSetupThread.setPriority(Thread.MIN_PRIORITY);
+    desktopSetupThread.start();
+
+    setStatusBarText("Welcome to MZmine " + MZmineCore.getMZmineVersion());
+
+    stage.show();
+
+    // update the size and position of the main window
+    /*
+     * ParameterSet paramSet = configuration.getPreferences(); WindowSettingsParameter settings =
+     * paramSet .getParameter(MZminePreferences.windowSetttings);
+     * settings.applySettingsToWindow(desktop.getMainWindow());
+     */
+    // add last project menu items
+    /*
+     * if (desktop instanceof MainWindow) { ((MainWindow) desktop).createLastUsedProjectsMenu(
+     * configuration.getLastProjects()); // listen for changes
+     * configuration.getLastProjectsParameter() .addFileListChangedListener(list -> { // new list of
+     * last used projects Desktop desk = getDesktop(); if (desk instanceof MainWindow) {
+     * ((MainWindow) desk) .createLastUsedProjectsMenu(list); } }); }
+     */
+
+    // Activate project - bind it to the desktop's project tree
+    MZmineProjectImpl currentProject =
+        (MZmineProjectImpl) MZmineCore.getProjectManager().getCurrentProject();
+    MZmineGUI.activateProject(currentProject);
+
+    // Check for updated version
+    NewVersionCheck NVC = new NewVersionCheck(CheckType.DESKTOP);
+    Thread nvcThread = new Thread(NVC);
+    nvcThread.setPriority(Thread.MIN_PRIORITY);
+    nvcThread.start();
+
+    // Tracker
+    GoogleAnalyticsTracker GAT =
+        new GoogleAnalyticsTracker("MZmine Loaded (GUI mode)", "/JAVA/Main/GUI");
+    Thread gatThread = new Thread(GAT);
+    gatThread.setPriority(Thread.MIN_PRIORITY);
+    gatThread.start();
+
+    // register shutdown hook only if we have GUI - we don't want to
+    // save configuration on exit if we only run a batch
+    ShutDownHook shutDownHook = new ShutDownHook();
+    Runtime.getRuntime().addShutdownHook(shutDownHook);
+
+  }
+
+  @Override
   public String getName() {
     return "MZmine desktop";
   }
@@ -491,10 +493,11 @@ public class MZmineGUI extends Application implements Desktop {
 
     // Show the dialog
     try {
-      if (Platform.isFxApplicationThread())
+      if (Platform.isFxApplicationThread()) {
         alertTask.run();
-      else
+      } else {
         Platform.runLater(alertTask);
+      }
       return alertTask.get();
     } catch (Exception e) {
       e.printStackTrace();
@@ -564,4 +567,53 @@ public class MZmineGUI extends Application implements Desktop {
     return tabs;
   }
 
+  public ButtonType createAlertWithOptOut(String title, String headerText,
+      String message, String optOutMessage, Consumer<Boolean> optOutAction) {
+    // Credits: https://stackoverflow.com/questions/36949595/how-do-i-create-a-javafx-alert-with-a-check-box-for-do-not-ask-again
+    FutureTask<ButtonType> task = new FutureTask<>(() -> {
+      Alert alert = new Alert(AlertType.WARNING);
+      // Need to force the alert to layout in order to grab the graphic,
+      // as we are replacing the dialog pane with a custom pane
+      alert.getDialogPane().applyCss();
+      Node graphic = alert.getDialogPane().getGraphic();
+      // Create a new dialog pane that has a checkbox instead of the hide/show details button
+      // Use the supplied callback for the action of the checkbox
+      alert.setDialogPane(new DialogPane() {
+        @Override
+        protected Node createDetailsButton() {
+          CheckBox optOut = new CheckBox();
+          optOut.setText(optOutMessage);
+          optOut.setOnAction(e -> optOutAction.accept(optOut.isSelected()));
+          return optOut;
+        }
+      });
+      alert.getDialogPane().getButtonTypes().addAll(ButtonType.YES, ButtonType.NO);
+      alert.getDialogPane().setContentText(message);
+      // Fool the dialog into thinking there is some expandable content
+      // a Group won't take up any space if it has no children
+      alert.getDialogPane().setExpandableContent(new Group());
+      alert.getDialogPane().setExpanded(true);
+      // Reset the dialog graphic using the default style
+      alert.getDialogPane().setGraphic(graphic);
+      alert.setTitle(title);
+      alert.setHeaderText(headerText);
+      alert.showAndWait();
+      return alert.getResult();
+    });
+
+    if (Platform.isFxApplicationThread()) {
+      task.run();
+    } else {
+      Platform.runLater(task);
+    }
+
+    try {
+      return task.get();
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+    return ButtonType.NO;
+  }
 }

--- a/src/main/java/io/github/mzmine/gui/preferences/MZminePreferences.java
+++ b/src/main/java/io/github/mzmine/gui/preferences/MZminePreferences.java
@@ -25,6 +25,8 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
 import io.github.mzmine.parameters.parametertypes.BooleanParameter;
 import io.github.mzmine.parameters.parametertypes.ComboParameter;
+import io.github.mzmine.parameters.parametertypes.HiddenParameter;
+import io.github.mzmine.parameters.parametertypes.OptOutParameter;
 import io.github.mzmine.parameters.parametertypes.ParameterSetParameter;
 import io.github.mzmine.parameters.parametertypes.WindowSettingsParameter;
 import io.github.mzmine.parameters.parametertypes.colorpalette.ColorPaletteParameter;
@@ -34,6 +36,7 @@ import io.github.mzmine.parameters.parametertypes.paintscale.PaintScalePalettePa
 import io.github.mzmine.parameters.parametertypes.submodules.OptionalModuleParameter;
 import io.github.mzmine.util.ExitCode;
 import java.text.DecimalFormat;
+import java.util.Map;
 import javafx.collections.FXCollections;
 import org.w3c.dom.Element;
 
@@ -103,12 +106,17 @@ public class MZminePreferences extends SimpleParameterSet {
   public static final BooleanParameter darkMode = new BooleanParameter("Dark mode",
       "Enables dark mode");
 
+  public static final HiddenParameter<OptOutParameter, Map<String, Boolean>> imsModuleWarnings =
+      new HiddenParameter<>(new OptOutParameter("Ion mobility compatibility warnings",
+          "Shows a warning message when a module without explicit ion mobility support is "
+              + "used to process ion mobility data."));
+
   public MZminePreferences() {
     super(
         new Parameter[]{mzFormat, rtFormat, mobilityFormat, ccsFormat, intensityFormat, ppmFormat,
             unitFormat,
             numOfThreads, proxySettings, rExecPath, sendStatistics, windowSetttings, sendErrorEMail,
-            defaultColorPalette, defaultPaintScale, chartParam, darkMode});
+            defaultColorPalette, defaultPaintScale, chartParam, darkMode, imsModuleWarnings});
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/modules/batchmode/BatchSetupComponent.java
+++ b/src/main/java/io/github/mzmine/modules/batchmode/BatchSetupComponent.java
@@ -44,7 +44,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javafx.collections.FXCollections;
 import javafx.scene.control.Button;
 import javafx.scene.control.ChoiceDialog;
 import javafx.scene.control.ComboBox;
@@ -243,7 +242,7 @@ public class BatchSetupComponent extends BorderPane implements LastFilesComponen
 
         // Add step to queue.
         batchQueue.add(step);
-        currentStepsList.setItems(FXCollections.observableArrayList(batchQueue));
+        currentStepsList.setItems(batchQueue);
         currentStepsList.getSelectionModel().select(batchQueue.size() - 1);
 
       }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ADAPChromatogramBuilderParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ADAPChromatogramBuilderParameters.java
@@ -85,4 +85,11 @@ public class ADAPChromatogramBuilderParameters extends SimpleParameterSet {
     dialog.showAndWait();
     return dialog.getExitCode();
   }
+
+  @Override
+  public String getUntestedIonMobilityCompatibilityMessage() {
+    return "ADAP chromatogram builder will build two-dimensional chromatograms based on summed "
+        + "frame data (if there is any). Thus, ion mobility data is not taken into account. "
+        + "Do you wish to continue any way?";
+  }
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ADAPChromatogramBuilderParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ADAPChromatogramBuilderParameters.java
@@ -90,7 +90,7 @@ public class ADAPChromatogramBuilderParameters extends SimpleParameterSet {
   @Override
   public String getRestrictedIonMobilitySupportMessage() {
     return "ADAP chromatogram builder will build two-dimensional chromatograms based on summed "
-        + "frame data (if there is any). Thus, ion mobility data is not taken into account. "
+        + "frame data (if there is any). Thus, the mobility dimension is not taken into account. "
         + "Do you wish to continue any way?";
   }
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ADAPChromatogramBuilderParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ADAPChromatogramBuilderParameters.java
@@ -23,6 +23,7 @@ package io.github.mzmine.modules.dataprocessing.featdet_adapchromatogrambuilder;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.dialogs.ParameterSetupDialog;
+import io.github.mzmine.parameters.impl.IonMobilitySupport;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
 import io.github.mzmine.parameters.parametertypes.DoubleParameter;
 import io.github.mzmine.parameters.parametertypes.IntegerParameter;
@@ -87,9 +88,14 @@ public class ADAPChromatogramBuilderParameters extends SimpleParameterSet {
   }
 
   @Override
-  public String getUntestedIonMobilityCompatibilityMessage() {
+  public String getRestrictedIonMobilitySupportMessage() {
     return "ADAP chromatogram builder will build two-dimensional chromatograms based on summed "
         + "frame data (if there is any). Thus, ion mobility data is not taken into account. "
         + "Do you wish to continue any way?";
+  }
+
+  @Override
+  public IonMobilitySupport getIonMobilitySupport() {
+    return IonMobilitySupport.RESTRICTED;
   }
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/minimumsearch/MinimumSearchFeatureResolverParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/minimumsearch/MinimumSearchFeatureResolverParameters.java
@@ -26,6 +26,7 @@ import io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution
 import io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.XYResolver;
 import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.parameters.impl.IonMobilitySupport;
 import io.github.mzmine.parameters.parametertypes.DoubleParameter;
 import io.github.mzmine.parameters.parametertypes.PercentParameter;
 import io.github.mzmine.parameters.parametertypes.ranges.DoubleRangeParameter;
@@ -83,5 +84,10 @@ public class MinimumSearchFeatureResolverParameters extends GeneralResolverParam
   @Override
   public XYResolver<Double, Double, double[], double[]> getXYResolver(ParameterSet parameters) {
     return new MinimumSearchFeatureResolver(parameters);
+  }
+
+  @Override
+  public IonMobilitySupport getIonMobilitySupport() {
+    return IonMobilitySupport.SUPPORTED;
   }
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_ionmobilitytracebuilder/IonMobilityTraceBuilderParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_ionmobilitytracebuilder/IonMobilityTraceBuilderParameters.java
@@ -19,6 +19,7 @@
 package io.github.mzmine.modules.dataprocessing.featdet_ionmobilitytracebuilder;
 
 import io.github.mzmine.parameters.Parameter;
+import io.github.mzmine.parameters.impl.IonMobilitySupport;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
 import io.github.mzmine.parameters.parametertypes.IntegerParameter;
 import io.github.mzmine.parameters.parametertypes.MassListParameter;
@@ -60,5 +61,10 @@ public class IonMobilityTraceBuilderParameters extends SimpleParameterSet {
   public IonMobilityTraceBuilderParameters() {
     super(new Parameter[]{rawDataFiles, massList, scanSelection, mzTolerance, minDataPointsRt,
         minTotalSignals, suffix});
+  }
+
+  @Override
+  public IonMobilitySupport getIonMobilitySupport() {
+    return IonMobilitySupport.ONLY;
   }
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_massdetection/MassDetectionParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_massdetection/MassDetectionParameters.java
@@ -29,6 +29,7 @@ import io.github.mzmine.modules.dataprocessing.featdet_massdetection.localmaxima
 import io.github.mzmine.modules.dataprocessing.featdet_massdetection.recursive.RecursiveMassDetector;
 import io.github.mzmine.modules.dataprocessing.featdet_massdetection.wavelet.WaveletMassDetector;
 import io.github.mzmine.parameters.Parameter;
+import io.github.mzmine.parameters.impl.IonMobilitySupport;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
 import io.github.mzmine.parameters.parametertypes.ModuleComboParameter;
 import io.github.mzmine.parameters.parametertypes.OptionalParameter;
@@ -144,7 +145,8 @@ public class MassDetectionParameters extends SimpleParameterSet {
           + "data file. Only the centroid mass detector officially supports mobility scan peak "
           + "detection due to the size of ion mobility raw data files."
           + " Do you want to continue anyway?";
-      if(MZmineCore.getDesktop().displayConfirmation(msg, ButtonType.YES, ButtonType.NO) == ButtonType.NO) {
+      if (MZmineCore.getDesktop().displayConfirmation(msg, ButtonType.YES, ButtonType.NO)
+          == ButtonType.NO) {
         return ExitCode.CANCEL;
       }
     }
@@ -153,4 +155,8 @@ public class MassDetectionParameters extends SimpleParameterSet {
 
   }
 
+  @Override
+  public IonMobilitySupport getIonMobilitySupport() {
+    return IonMobilitySupport.SUPPORTED;
+  }
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_smoothing/SmoothingParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_smoothing/SmoothingParameters.java
@@ -25,6 +25,7 @@
 package io.github.mzmine.modules.dataprocessing.featdet_smoothing;
 
 import io.github.mzmine.parameters.Parameter;
+import io.github.mzmine.parameters.impl.IonMobilitySupport;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
 import io.github.mzmine.parameters.parametertypes.BooleanParameter;
 import io.github.mzmine.parameters.parametertypes.ComboParameter;
@@ -89,5 +90,10 @@ public class SmoothingParameters extends SimpleParameterSet {
     public String toString() {
       return str;
     }
+  }
+
+  @Override
+  public IonMobilitySupport getIonMobilitySupport() {
+    return IonMobilitySupport.SUPPORTED;
   }
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_ccscalc/CCSCalcParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_ccscalc/CCSCalcParameters.java
@@ -19,6 +19,7 @@
 package io.github.mzmine.modules.dataprocessing.id_ccscalc;
 
 import io.github.mzmine.parameters.UserParameter;
+import io.github.mzmine.parameters.impl.IonMobilitySupport;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
 import io.github.mzmine.parameters.parametertypes.BooleanParameter;
 import io.github.mzmine.parameters.parametertypes.OptionalParameter;
@@ -43,5 +44,10 @@ public class CCSCalcParameters extends SimpleParameterSet {
 
   public CCSCalcParameters() {
     super(new UserParameter[]{featureLists, assumeChargeStage, createNewFeatureList});
+  }
+
+  @Override
+  public IonMobilitySupport getIonMobilitySupport() {
+    return IonMobilitySupport.ONLY;
   }
 }

--- a/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableContextMenu.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableContextMenu.java
@@ -299,7 +299,7 @@ public class FeatureTableContextMenu extends ContextMenu {
             selectedFeature.getRepresentativeScan(), selectedFeature.getIsotopePattern()));
 
     final MenuItem showSpectralDBResults = new ConditionalMenuItem("Spectral DB search results",
-        () -> selectedFeature != null && rowHasSpectralDBMatchResults(selectedRows.get(0)));
+        () -> !selectedRows.isEmpty() && rowHasSpectralDBMatchResults(selectedRows.get(0)));
     showSpectralDBResults
         .setOnAction(e -> SpectraIdentificationResultsModule.showNewTab(selectedRows.get(0)));
 

--- a/src/main/java/io/github/mzmine/modules/visualization/imsfeaturevisualizer/IMSFeatureVisualizerParameters.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/imsfeaturevisualizer/IMSFeatureVisualizerParameters.java
@@ -18,8 +18,13 @@
 
 package io.github.mzmine.modules.visualization.imsfeaturevisualizer;
 
+import io.github.mzmine.parameters.impl.IonMobilitySupport;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
 
 public class IMSFeatureVisualizerParameters extends SimpleParameterSet {
 
+  @Override
+  public IonMobilitySupport getIonMobilitySupport() {
+    return IonMobilitySupport.ONLY;
+  }
 }

--- a/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/IMSRawDataOverviewParameters.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/IMSRawDataOverviewParameters.java
@@ -20,6 +20,7 @@ package io.github.mzmine.modules.visualization.rawdataoverviewims;
 
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.parameters.Parameter;
+import io.github.mzmine.parameters.impl.IonMobilitySupport;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
 import io.github.mzmine.parameters.parametertypes.DoubleParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesParameter;
@@ -52,5 +53,10 @@ public class IMSRawDataOverviewParameters extends SimpleParameterSet {
   public IMSRawDataOverviewParameters() {
     super(new Parameter[]{rawDataFiles, summedFrameNoiseLevel, mobilityScanNoiseLevel,
         mzTolerance, scanSelection, rtWidth});
+  }
+
+  @Override
+  public IonMobilitySupport getIonMobilitySupport() {
+    return IonMobilitySupport.ONLY;
   }
 }

--- a/src/main/java/io/github/mzmine/parameters/ParameterSet.java
+++ b/src/main/java/io/github/mzmine/parameters/ParameterSet.java
@@ -18,9 +18,10 @@
 
 package io.github.mzmine.parameters;
 
+import io.github.mzmine.parameters.impl.IonMobilitySupport;
+import io.github.mzmine.util.ExitCode;
 import java.util.Collection;
 import org.w3c.dom.Element;
-import io.github.mzmine.util.ExitCode;
 
 /**
  * This class represents a general parameter set of a module. Typical module will use a
@@ -41,6 +42,19 @@ public interface ParameterSet extends ParameterContainer {
   public boolean checkParameterValues(Collection<String> errorMessages);
 
   public ParameterSet cloneParameterSet();
+
+  /**
+   * This method specifies the fitness of a module to process data acquired on a ion mobility
+   * spectrometry (IMS)-mass spectrometer. The default implementation returns {@link
+   * IonMobilitySupport#UNTESTED}. However, overriding this method is encouraged to clarify it's
+   * fitness for ion mobility data, even if it will still return {@link
+   * IonMobilitySupport#UNTESTED}.
+   *
+   * @return
+   */
+  default IonMobilitySupport getIonMobilitySupport() {
+    return IonMobilitySupport.UNTESTED;
+  }
 
   /**
    * Represent method's parameters and their values in human-readable format

--- a/src/main/java/io/github/mzmine/parameters/impl/IonMobilitySupport.java
+++ b/src/main/java/io/github/mzmine/parameters/impl/IonMobilitySupport.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright 2006-2020 The MZmine Development Team
+ *
+ *  This file is part of MZmine.
+ *
+ *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ *  General Public License as published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
+ *
+ *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ *  Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with MZmine; if not,
+ *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ *  USA
+ */
+
+package io.github.mzmine.parameters.impl;
+
+public enum IonMobilitySupport {
+  /**
+   * Module requires mobility data to work.
+   */
+  ONLY,
+
+  /**
+   * Module can be used to process non-ims and ims data.
+   */
+  SUPPORTED,
+
+  /**
+   * Module does not support ion mobility data and will produce wrong results.
+   */
+  UNSUPPORTED,
+
+  /**
+   * Module has not been tested with ion mobility data, but should work.
+   */
+  UNTESTED
+}

--- a/src/main/java/io/github/mzmine/parameters/impl/IonMobilitySupport.java
+++ b/src/main/java/io/github/mzmine/parameters/impl/IonMobilitySupport.java
@@ -30,12 +30,19 @@ public enum IonMobilitySupport {
   SUPPORTED,
 
   /**
+   * Module has not been tested with ion mobility data, but should work.
+   */
+  UNTESTED,
+
+  /**
+   * Module has been tested with ion mobility data and shows certain restrictions when processing
+   * that data. A specific warning message should be displayed by overriding {@link
+   * SimpleParameterSet#getRestrictedIonMobilitySupportMessage()}.
+   */
+  RESTRICTED,
+
+  /**
    * Module does not support ion mobility data and will produce wrong results.
    */
   UNSUPPORTED,
-
-  /**
-   * Module has not been tested with ion mobility data, but should work.
-   */
-  UNTESTED
 }

--- a/src/main/java/io/github/mzmine/parameters/impl/SimpleParameterSet.java
+++ b/src/main/java/io/github/mzmine/parameters/impl/SimpleParameterSet.java
@@ -18,20 +18,30 @@
 
 package io.github.mzmine.parameters.impl;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
+import io.github.mzmine.datamodel.IMSRawDataFile;
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.features.FeatureList;
+import io.github.mzmine.gui.preferences.MZminePreferences;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.ParameterContainer;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.dialogs.ParameterSetupDialog;
+import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
+import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesParameter;
 import io.github.mzmine.util.ExitCode;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javafx.application.Platform;
+import javafx.scene.control.ButtonType;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 
 /**
  * Simple storage for the parameters. A typical MZmine module will inherit this class and define the
@@ -39,11 +49,9 @@ import javafx.application.Platform;
  */
 public class SimpleParameterSet implements ParameterSet {
 
-  private static Logger logger = Logger.getLogger(MZmineCore.class.getName());
-
   private static final String parameterElement = "parameter";
   private static final String nameAttribute = "name";
-
+  private static Logger logger = Logger.getLogger(MZmineCore.class.getName());
   protected Parameter<?> parameters[];
   private boolean skipSensitiveParameters = false;
 
@@ -64,8 +72,9 @@ public class SimpleParameterSet implements ParameterSet {
   public void setSkipSensitiveParameters(boolean skipSensitiveParameters) {
     this.skipSensitiveParameters = skipSensitiveParameters;
     for (Parameter<?> parameter : parameters) {
-      if (parameter instanceof ParameterContainer)
+      if (parameter instanceof ParameterContainer) {
         ((ParameterContainer) parameter).setSkipSensitiveParameters(skipSensitiveParameters);
+      }
     }
   }
 
@@ -92,8 +101,9 @@ public class SimpleParameterSet implements ParameterSet {
   public void saveValuesToXML(Element xmlElement) {
     Document parentDocument = xmlElement.getOwnerDocument();
     for (Parameter<?> param : parameters) {
-      if (skipSensitiveParameters && param.isSensitive())
+      if (skipSensitiveParameters && param.isSensitive()) {
         continue;
+      }
       Element paramElement = parentDocument.createElement(parameterElement);
       paramElement.setAttribute(nameAttribute, param.getName());
       xmlElement.appendChild(paramElement);
@@ -114,8 +124,9 @@ public class SimpleParameterSet implements ParameterSet {
       Parameter<?> param = parameters[i];
       Object value = param.getValue();
 
-      if (value == null)
+      if (value == null) {
         continue;
+      }
 
       s.append(param.getName());
       s.append(": ");
@@ -124,8 +135,9 @@ public class SimpleParameterSet implements ParameterSet {
       } else {
         s.append(value.toString());
       }
-      if (i < parameters.length - 1)
+      if (i < parameters.length - 1) {
         s.append(", ");
+      }
     }
     return s.toString();
   }
@@ -163,8 +175,9 @@ public class SimpleParameterSet implements ParameterSet {
   @SuppressWarnings("unchecked")
   public <T extends Parameter<?>> T getParameter(T parameter) {
     for (Parameter<?> p : parameters) {
-      if (p.getName().equals(parameter.getName()))
+      if (p.getName().equals(parameter.getName())) {
         return (T) p;
+      }
     }
     throw new IllegalArgumentException("Parameter " + parameter.getName() + " does not exist");
   }
@@ -174,8 +187,9 @@ public class SimpleParameterSet implements ParameterSet {
 
     assert Platform.isFxApplicationThread();
 
-    if ((parameters == null) || (parameters.length == 0))
+    if ((parameters == null) || (parameters.length == 0)) {
       return ExitCode.OK;
+    }
     ParameterSetupDialog dialog = new ParameterSetupDialog(valueCheckRequired, this);
     dialog.showAndWait();
     return dialog.getExitCode();
@@ -186,10 +200,83 @@ public class SimpleParameterSet implements ParameterSet {
     boolean allParametersOK = true;
     for (Parameter<?> p : parameters) {
       boolean pOK = p.checkValue(errorMessages);
-      if (!pOK)
+      if (!pOK) {
         allParametersOK = false;
+      }
+      if (p instanceof RawDataFilesParameter) {
+        pOK = checkRawDataFileIonMobilitySupport(
+            ((RawDataFilesParameter) p).getValue().getMatchingRawDataFiles(), errorMessages);
+      } else if (p instanceof FeatureListsParameter) {
+        FeatureList[] lists = ((FeatureListsParameter) p).getValue().getMatchingFeatureLists();
+        Set<RawDataFile> files = new HashSet<>();
+        Arrays.stream(lists).map(FeatureList::getRawDataFiles)
+            .forEach(listFiles -> listFiles.forEach(file -> files.add(file)));
+        pOK = checkRawDataFileIonMobilitySupport(files.toArray(new RawDataFile[0]), errorMessages);
+      }
+      if (!pOK) {
+        allParametersOK = false;
+      }
     }
     return allParametersOK;
+  }
+
+  public boolean checkRawDataFileIonMobilitySupport(RawDataFile[] rawDataFiles,
+      Collection<String> errorMessages) {
+    boolean onlyImsFiles = true;
+    boolean containsImsFile = false;
+    for (RawDataFile file : rawDataFiles) {
+      if (!(file instanceof IMSRawDataFile)) {
+        onlyImsFiles = false;
+        errorMessages.add("Non-ion mobility spectrometry files: " + file.getName());
+      } else {
+        containsImsFile = true;
+      }
+    }
+
+    Map<String, Boolean> showMsgMap = MZmineCore.getConfiguration().getPreferences().getParameter(
+        MZminePreferences.imsModuleWarnings).getValue();
+    String className = this.getClass().getName();
+    Boolean showMsg = showMsgMap.getOrDefault(className, true);
+
+    if (containsImsFile && getIonMobilitySupport() == IonMobilitySupport.UNTESTED) {
+      logger.warning(
+          "This module has not been tested with ion mobility data files. This could lead to unexpected results.");
+      if (showMsg) {
+        return MZmineCore.getDesktop()
+            .createAlertWithOptOut("Compatibility warning", "Untested compatibility",
+                getUntestedIonMobilityCompatibilityMessage(), "Do not show again",
+                optOut -> showMsgMap.put(this.getClass().getName(), !optOut)) == ButtonType.YES;
+      }
+      return true;
+    } else if (!onlyImsFiles && getIonMobilitySupport() == IonMobilitySupport.ONLY) {
+      logger.warning(
+          "This module is designed for ion mobility data only. Cannot process non-ion mobility files.");
+      errorMessages.add(
+          "This module is designed for ion mobility data only. Cannot process non-ion mobility files.");
+      return false;
+    } else if (containsImsFile && getIonMobilitySupport() == IonMobilitySupport.UNSUPPORTED) {
+      logger.warning("This module does not support ion mobility data.");
+      errorMessages.add("This module does not support ion mobility data.");
+      return MZmineCore.getDesktop()
+          .displayConfirmation(
+              "This module does not support ion mobility data. This will lead to unexpected "
+                  + "results. Do you want to continue anyway?", ButtonType.YES, ButtonType.NO)
+          == ButtonType.YES;
+    } // dont have to check for IonMobilitySupport.SUPPORTED
+
+    return true;
+  }
+
+  /**
+   * This message is displayed when a ion mobility file is processed with this module without it
+   * explicitly supporting ion mobility data. This method can be overridden to display a more
+   * specific user information on the expected outcome.
+   *
+   * @return The message.
+   */
+  public String getUntestedIonMobilityCompatibilityMessage() {
+    return "This module has not been tested with ion mobility data files. This could lead "
+        + "to unexpected results. Do you want to continue anyway?";
   }
 
 }

--- a/src/main/java/io/github/mzmine/parameters/impl/SimpleParameterSet.java
+++ b/src/main/java/io/github/mzmine/parameters/impl/SimpleParameterSet.java
@@ -244,10 +244,21 @@ public class SimpleParameterSet implements ParameterSet {
       if (showMsg) {
         return MZmineCore.getDesktop()
             .createAlertWithOptOut("Compatibility warning", "Untested compatibility",
-                getUntestedIonMobilityCompatibilityMessage(), "Do not show again",
+                "This module has not been tested with ion mobility data files. This could lead "
+                    + "to unexpected results. Do you want to continue anyway?", "Do not show again",
                 optOut -> showMsgMap.put(this.getClass().getName(), !optOut)) == ButtonType.YES;
       }
       return true;
+    } else if (containsImsFile && getIonMobilitySupport() == IonMobilitySupport.RESTRICTED) {
+      logger.warning(
+          "This module has certain restrictions when processing ion mobility data files. This"
+              + " could lead to unexpected results");
+      if (showMsg) {
+        return MZmineCore.getDesktop()
+            .createAlertWithOptOut("Compatibility warning", "Restricted compatibility",
+                getRestrictedIonMobilitySupportMessage(), "Do not show again",
+                optOut -> showMsgMap.put(this.getClass().getName(), !optOut)) == ButtonType.YES;
+      }
     } else if (!onlyImsFiles && getIonMobilitySupport() == IonMobilitySupport.ONLY) {
       logger.warning(
           "This module is designed for ion mobility data only. Cannot process non-ion mobility files.");
@@ -274,9 +285,8 @@ public class SimpleParameterSet implements ParameterSet {
    *
    * @return The message.
    */
-  public String getUntestedIonMobilityCompatibilityMessage() {
-    return "This module has not been tested with ion mobility data files. This could lead "
-        + "to unexpected results. Do you want to continue anyway?";
+  public String getRestrictedIonMobilitySupportMessage() {
+    return "This module has certain restrictions when processing ion mobility data files. This "
+        + "could lead to unexpected results. Do you want to continue anyway?";
   }
-
 }

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/OptOutComponent.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/OptOutComponent.java
@@ -1,0 +1,25 @@
+/*
+ *  Copyright 2006-2020 The MZmine Development Team
+ *
+ *  This file is part of MZmine.
+ *
+ *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ *  General Public License as published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
+ *
+ *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ *  Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with MZmine; if not,
+ *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ *  USA
+ */
+
+package io.github.mzmine.parameters.parametertypes;
+
+import javafx.scene.layout.FlowPane;
+
+public class OptOutComponent extends FlowPane {
+// no visual representation
+}

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/OptOutParameter.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/OptOutParameter.java
@@ -60,7 +60,7 @@ public class OptOutParameter implements UserParameter<Map<String, Boolean>, OptO
 
   @Override
   public boolean checkValue(Collection<String> errorMessages) {
-    return false;
+    return true;
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/OptOutParameter.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/OptOutParameter.java
@@ -1,0 +1,115 @@
+/*
+ *  Copyright 2006-2020 The MZmine Development Team
+ *
+ *  This file is part of MZmine.
+ *
+ *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ *  General Public License as published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
+ *
+ *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ *  Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with MZmine; if not,
+ *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ *  USA
+ */
+
+package io.github.mzmine.parameters.parametertypes;
+
+import io.github.mzmine.parameters.UserParameter;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+/**
+ * Saves a mapping of string -> boolean to store answers to opt out messages.
+ */
+public class OptOutParameter implements UserParameter<Map<String, Boolean>, OptOutComponent> {
+
+  public static final String MODULE_TAG = "module";
+  public static final String MODULE_NAME = "name";
+  private final String name;
+  private final String description;
+  private Map<String, Boolean> value;
+
+  public OptOutParameter(String name, String description) {
+    this.name = name;
+    this.description = description;
+    this.value = new HashMap<>();
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public Map<String, Boolean> getValue() {
+    return value;
+  }
+
+  @Override
+  public void setValue(Map<String, Boolean> newValue) {
+    this.value = newValue;
+  }
+
+  @Override
+  public boolean checkValue(Collection<String> errorMessages) {
+    return false;
+  }
+
+  @Override
+  public void loadValueFromXML(Element xmlElement) {
+    NodeList nodeList = xmlElement.getElementsByTagName(MODULE_TAG);
+    for (int i = 0; i < nodeList.getLength(); i++) {
+      Element element = (Element) nodeList.item(i);
+      String module = element.getAttribute(MODULE_NAME);
+      Boolean val = Boolean.valueOf(element.getTextContent());
+      value.put(module, val);
+    }
+  }
+
+  @Override
+  public void saveValueToXML(Element xmlElement) {
+    Document doc = xmlElement.getOwnerDocument();
+
+    value.forEach((key, value) -> {
+      Element element = doc.createElement(MODULE_TAG);
+      element.setAttribute(MODULE_NAME, key);
+      element.setTextContent(value.toString());
+      xmlElement.appendChild(element);
+    });
+  }
+
+  @Override
+  public String getDescription() {
+    return description;
+  }
+
+  @Override
+  public OptOutComponent createEditingComponent() {
+    return new OptOutComponent();
+  }
+
+  @Override
+  public void setValueFromComponent(OptOutComponent optOutComponent) {
+    // no component (yet)
+  }
+
+  @Override
+  public void setValueToComponent(OptOutComponent optOutComponent, Map<String, Boolean> newValue) {
+    // no component (yet)
+  }
+
+  @Override
+  public UserParameter<Map<String, Boolean>, OptOutComponent> cloneParameter() {
+    OptOutParameter clone = new OptOutParameter(name, description);
+    value.forEach((k, v) -> clone.getValue().put(k, v.booleanValue())); // we want a duplicate here
+    return clone;
+  }
+}

--- a/src/main/resources/themes/MZmine_dark.css
+++ b/src/main/resources/themes/MZmine_dark.css
@@ -15,7 +15,7 @@
  deriving most of the colors off the default one makes it easy to get uniform looking themes **/
 {
   -pane-bg-match: derive(-fx-base, 30%);
-  -control-bg: derive(-fx-base, 20%);
+  -control-bg: derive(-fx-base, 15%);
   -control-bg-hovered: derive(-control-bg, 25%);
 
   -default-border-color: -fx-base;


### PR DESCRIPTION
This adds an opt out warning message if a module that is untested/restriced with ims data is used to process it. By default, every module is untested.

Default untested warning message:
![grafik](https://user-images.githubusercontent.com/37407705/107200279-ca7d9b00-69f7-11eb-8dbb-b8a53d635c20.png)

If a module has been tested with ims data and bears cetrain restrictions, it can override a method and display a specific warning message:
![grafik](https://user-images.githubusercontent.com/37407705/107201884-d5d1c600-69f9-11eb-9599-ac5849b2c0b5.png)


At the same time, modules can only support ims data:
![grafik](https://user-images.githubusercontent.com/37407705/107201650-8ee3d080-69f9-11eb-80fa-4b35863166f2.png)

The opt out values are saved in a hidden parameter in the preferences and can thus only be deleted, by going to the config directly. If someone feels like doing a component for that, we could change it.
