### PR TITLE
ims feature visualizer now shows msms spectra

### DIFF
--- a/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/SingleSpectrumProvider.java
+++ b/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/SingleSpectrumProvider.java
@@ -78,8 +78,8 @@ public class SingleSpectrumProvider implements PlotXYDataProvider {
   @Override
   public String getToolTipText(int itemIndex) {
     return "m/z: " + mzFormat
-        .format(spectrum.getMzValue(itemIndex) + "\nIntensity: " + intensityFormat
-            .format(spectrum.getIntensityValue(itemIndex)));
+        .format(spectrum.getMzValue(itemIndex)) + "\nIntensity: " + intensityFormat
+        .format(spectrum.getIntensityValue(itemIndex));
   }
 
   @Override


### PR DESCRIPTION
Since msms spectra are assigned now, they are now displayed in the visualizer:

![grafik](https://user-images.githubusercontent.com/37407705/107206980-087ebd00-6a00-11eb-9722-0a4f4555e8e8.png)
