### PR TITLE
Ims series optimisation

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/featuredata/IonMobilitySeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/IonMobilitySeries.java
@@ -7,4 +7,8 @@ import io.github.mzmine.datamodel.MobilityScan;
  */
 public interface IonMobilitySeries extends IonSpectrumSeries<MobilityScan>, MobilitySeries {
 
+  @Override
+  default double getMobility(int index) {
+    return getSpectrum(index).getMobility();
+  }
 }

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/IonMobilitySeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/IonMobilitySeries.java
@@ -1,0 +1,10 @@
+package io.github.mzmine.datamodel.featuredata;
+
+import io.github.mzmine.datamodel.MobilityScan;
+
+/**
+ * Tag interface for mobilograms.
+ */
+public interface IonMobilitySeries extends IonSpectrumSeries<MobilityScan>, MobilitySeries {
+
+}

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/IonMobilogramTimeSeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/IonMobilogramTimeSeries.java
@@ -19,7 +19,6 @@
 package io.github.mzmine.datamodel.featuredata;
 
 import io.github.mzmine.datamodel.Frame;
-import io.github.mzmine.datamodel.featuredata.impl.SimpleIonMobilitySeries;
 import io.github.mzmine.datamodel.featuredata.impl.SummedIntensityMobilitySeries;
 import io.github.mzmine.util.MemoryMapStorage;
 import java.util.List;
@@ -39,9 +38,9 @@ public interface IonMobilogramTimeSeries extends IonTimeSeries<Frame> {
     return getSpectrum(index).getRetentionTime();
   }
 
-  List<SimpleIonMobilitySeries> getMobilograms();
+  List<IonMobilitySeries> getMobilograms();
 
-  default SimpleIonMobilitySeries getMobilogram(int index) {
+  default IonMobilitySeries getMobilogram(int index) {
     return getMobilograms().get(index);
   }
 
@@ -62,7 +61,7 @@ public interface IonMobilogramTimeSeries extends IonTimeSeries<Frame> {
    */
   IonMobilogramTimeSeries copyAndReplace(@Nullable MemoryMapStorage storage,
       @Nonnull double[] newMzValues, @Nonnull double[] newIntensityValues,
-      @Nonnull List<SimpleIonMobilitySeries> newMobilograms,
+      @Nonnull List<IonMobilitySeries> newMobilograms,
       @Nullable double[] smoothedSummedMobilogramIntensities);
 
   /**

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/IonSpectrumSeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/IonSpectrumSeries.java
@@ -66,4 +66,16 @@ public interface IonSpectrumSeries<T extends MassSpectrum> extends IonSeries {
    * @return The subset series.
    */
   IonSpectrumSeries<T> subSeries(@Nullable MemoryMapStorage storage, @Nonnull List<T> subset);
+
+  /**
+   * Creates a copy of this series using the same list of scans but possibly new mz/intensity
+   * values.
+   *
+   * @param storage            May be null if the new series shall be stored in ram.
+   * @param newMzValues
+   * @param newIntensityValues
+   * @return
+   */
+  IonSpectrumSeries<T> copyAndReplace(@Nullable MemoryMapStorage storage, @Nonnull double[] newMzValues,
+      @Nonnull double[] newIntensityValues);
 }

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/IonTimeSeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/IonTimeSeries.java
@@ -59,21 +59,10 @@ public interface IonTimeSeries<T extends Scan> extends IonSpectrumSeries<T>, Tim
     return 0;
   }
 
-  /**
-   * Creates a copy of this series using the same list of scans but possibly new mz/intensity
-   * values.
-   *
-   * @param storage            May be null if the new series shall be stored in ram.
-   * @param newMzValues
-   * @param newIntensityValues
-   * @return
-   */
-  IonTimeSeries<T> copyAndReplace(@Nullable MemoryMapStorage storage, @Nonnull double[] newMzValues,
-      @Nonnull double[] newIntensityValues);
-
-
   @Override
   IonTimeSeries<T> subSeries(@Nullable MemoryMapStorage storage, @Nonnull List<T> subset);
 
-
+  @Override
+  IonSpectrumSeries<T> copyAndReplace(@Nullable MemoryMapStorage storage,
+      @Nonnull double[] newMzValues, @Nonnull double[] newIntensityValues);
 }

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/impl/ModifiableSpectra.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/impl/ModifiableSpectra.java
@@ -1,8 +1,35 @@
+/*
+ *  Copyright 2006-2020 The MZmine Development Team
+ *
+ *  This file is part of MZmine.
+ *
+ *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ *  General Public License as published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
+ *
+ *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ *  Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with MZmine; if not,
+ *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ *  USA
+ */
+
 package io.github.mzmine.datamodel.featuredata.impl;
 
 import io.github.mzmine.datamodel.MassSpectrum;
 import java.util.List;
 
+/**
+ * Package-private tag interface to access the original, modifiable spectra list of an {@link
+ * SimpleIonMobilitySeries} when it is used to create an {@link StorableIonMobilitySeries}. The
+ * generation of numerous immutable list wrappers is therefore circumvented in this package private
+ * interface.
+ *
+ * @param <T>
+ * @author https://github.com/SteffenHeu
+ */
 interface ModifiableSpectra<T extends MassSpectrum> {
 
   List<T> getSpectraModifiable();

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/impl/ModifiableSpectra.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/impl/ModifiableSpectra.java
@@ -1,0 +1,9 @@
+package io.github.mzmine.datamodel.featuredata.impl;
+
+import io.github.mzmine.datamodel.MassSpectrum;
+import java.util.List;
+
+interface ModifiableSpectra<T extends MassSpectrum> {
+
+  List<T> getSpectraModifiable();
+}

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonMobilitySeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonMobilitySeries.java
@@ -20,6 +20,7 @@ package io.github.mzmine.datamodel.featuredata.impl;
 
 import io.github.mzmine.datamodel.Frame;
 import io.github.mzmine.datamodel.MobilityScan;
+import io.github.mzmine.datamodel.featuredata.IonMobilitySeries;
 import io.github.mzmine.datamodel.featuredata.IonSpectrumSeries;
 import io.github.mzmine.util.DataPointUtils;
 import io.github.mzmine.util.MemoryMapStorage;
@@ -38,7 +39,7 @@ import javax.annotation.Nullable;
  *
  * @author https://github.com/SteffenHeu
  */
-public class SimpleIonMobilitySeries implements IonSpectrumSeries<MobilityScan> {
+public class SimpleIonMobilitySeries implements IonMobilitySeries {
 
   private static final Logger logger = Logger.getLogger(SimpleIonMobilitySeries.class.getName());
 

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonMobilitySeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonMobilitySeries.java
@@ -26,7 +26,6 @@ import io.github.mzmine.util.DataPointUtils;
 import io.github.mzmine.util.MemoryMapStorage;
 import java.io.IOException;
 import java.nio.DoubleBuffer;
-import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -132,9 +131,19 @@ public class SimpleIonMobilitySeries implements IonMobilitySeries {
     return getSpectra().get(index).getMobility();
   }
 
+  /**
+   * Unlike other implementations, this returns the actual list of scans in this series due to
+   * {@link SimpleIonMobilogramTimeSeries#storeMobilograms(MemoryMapStorage, List)} creating a
+   * {@link StorableIonMobilitySeries}, since we don't want to create wrapper objects over and over
+   * again.
+   *
+   * @return The spectra list.
+   */
   @Override
   public List<MobilityScan> getSpectra() {
-    return Collections.unmodifiableList(scans);
+    // intentionally returning the source list, so it is not wrapped in an unmodifiable list
+    // over and over again during storing.
+    return scans;
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonMobilogramTimeSeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonMobilogramTimeSeries.java
@@ -122,7 +122,7 @@ public class SimpleIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
       throw new IllegalArgumentException("Cannot combine mobilograms of different raw data files.");
     }
 
-    this.mobilograms = mobilograms;
+    this.mobilograms = storeMobilograms(storage, mobilograms);
     this.frames = frames;
 
     summedMobilogram = new SummedIntensityMobilitySeries(storage,
@@ -163,7 +163,7 @@ public class SimpleIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
       throw new IllegalArgumentException("Cannot combine mobilograms of different raw data files.");
     }
 
-    this.mobilograms = mobilograms;
+    this.mobilograms = storeMobilograms(storage, mobilograms);
     this.frames = frames;
 
     final double mz = Arrays.stream(mzs).filter(val -> Double.compare(val, 0d) != 0).average()
@@ -194,9 +194,7 @@ public class SimpleIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
   private SimpleIonMobilogramTimeSeries(@Nullable MemoryMapStorage storage,
       @Nonnull IonMobilogramTimeSeries series, List<Frame> frames) {
     this.frames = frames;
-    this.mobilograms = new ArrayList<>();
-    series.getMobilograms().forEach(m -> mobilograms.add(
-        (SimpleIonMobilitySeries) m.copy(storage)));
+    this.mobilograms = storeMobilograms(storage, series.getMobilograms());
 
     double[][] data = DataPointUtils
         .getDataPointsAsDoubleArray(series.getMZValues(), series.getIntensityValues());
@@ -365,15 +363,18 @@ public class SimpleIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
       StorableIonMobilitySeries mobilogram/*, double[] dst*/) {
 //    assert mobilogram.getNumberOfValues() <= dst.length;
 //    mobilogramMzValues.get(mobilogram.getStorageOffset(), dst, 0, mobilogram.getNumberOfValues());
-    return mobilogramMzValues.slice(mobilogram.getStorageOffset(), mobilogram.getNumberOfValues());
+    double[] values = new double[mobilogram.getNumberOfValues()];
+    mobilogramMzValues.get(mobilogram.getStorageOffset(), values, 0, values.length);
+    return DoubleBuffer.wrap(values);
   }
 
   protected DoubleBuffer getMobilogramIntensityValues(
       StorableIonMobilitySeries mobilogram/*, double[] dst*/) {
 //    assert mobilogram.getNumberOfValues() <= dst.length;
 //    mobilogramIntensityValues.get(mobilogram.getStorageOffset(), dst, 0, mobilogram.getNumberOfValues());
-    return mobilogramIntensityValues
-        .slice(mobilogram.getStorageOffset(), mobilogram.getNumberOfValues());
+    double[] values = new double[mobilogram.getNumberOfValues()];
+    mobilogramIntensityValues.get(mobilogram.getStorageOffset(), values, 0, values.length);
+    return DoubleBuffer.wrap(values);
   }
 
   protected double getMobilogramMzValue(StorableIonMobilitySeries mobilogram, int index) {

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonMobilogramTimeSeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonMobilogramTimeSeries.java
@@ -20,6 +20,7 @@ package io.github.mzmine.datamodel.featuredata.impl;
 
 import io.github.mzmine.datamodel.Frame;
 import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.featuredata.IonMobilitySeries;
 import io.github.mzmine.datamodel.featuredata.IonMobilogramTimeSeries;
 import io.github.mzmine.util.DataPointUtils;
 import io.github.mzmine.util.MemoryMapStorage;
@@ -48,7 +49,7 @@ public class SimpleIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
   private static final CenterFunction mzCentering = new CenterFunction(CenterMeasure.AVG,
       Weighting.logger10, 0d, 4);
 
-  protected final List<SimpleIonMobilitySeries> mobilograms;
+  protected final List<IonMobilitySeries> mobilograms;
   protected final List<Frame> frames;
   protected final DoubleBuffer intensityValues;
   protected final DoubleBuffer mzValues;
@@ -68,7 +69,7 @@ public class SimpleIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
    * double[])
    */
   public SimpleIonMobilogramTimeSeries(@Nullable MemoryMapStorage storage,
-      @Nonnull List<SimpleIonMobilitySeries> mobilograms) {
+      @Nonnull List<IonMobilitySeries> mobilograms) {
     if (!checkRawFileIntegrity(mobilograms)) {
       throw new IllegalArgumentException("Cannot combine mobilograms of different raw data files.");
     }
@@ -76,7 +77,7 @@ public class SimpleIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
     frames = new ArrayList<>(mobilograms.size());
     this.mobilograms = mobilograms;
 
-    for (SimpleIonMobilitySeries ims : mobilograms) {
+    for (IonMobilitySeries ims : mobilograms) {
       final Frame frame = ims.getSpectra().get(0).getFrame();
       frames.add(frame);
     }
@@ -125,7 +126,7 @@ public class SimpleIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
    * double[])
    */
   private SimpleIonMobilogramTimeSeries(@Nullable MemoryMapStorage storage, @Nonnull double[] mzs,
-      @Nonnull double[] intensities, List<SimpleIonMobilitySeries> mobilograms,
+      @Nonnull double[] intensities, List<IonMobilitySeries> mobilograms,
       List<Frame> frames) {
     if (mzs.length != intensities.length || mobilograms.size() != intensities.length
         || mzs.length != mobilograms.size()) {
@@ -179,7 +180,7 @@ public class SimpleIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
    * double[])
    */
   private SimpleIonMobilogramTimeSeries(@Nullable MemoryMapStorage storage, @Nonnull double[] mzs,
-      @Nonnull double[] intensities, @Nonnull List<SimpleIonMobilitySeries> mobilograms,
+      @Nonnull double[] intensities, @Nonnull List<IonMobilitySeries> mobilograms,
       @Nonnull List<Frame> frames, @Nullable double[] summedMobilogramMobilitities,
       @Nullable double[] smoothedSummedMobilogramIntensities) {
 
@@ -281,8 +282,8 @@ public class SimpleIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
       intensities[i] = getIntensityForSpectrum(subset.get(i));
     }
 
-    List<SimpleIonMobilitySeries> subMobilograms = new ArrayList<>(subset.size());
-    for (SimpleIonMobilitySeries mobilogram : mobilograms) {
+    List<IonMobilitySeries> subMobilograms = new ArrayList<>(subset.size());
+    for (IonMobilitySeries mobilogram : mobilograms) {
       if (subset.contains(mobilogram.getSpectrum(0).getFrame())) {
         subMobilograms.add(mobilogram);
       }
@@ -310,7 +311,7 @@ public class SimpleIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
   }
 
   @Override
-  public List<SimpleIonMobilitySeries> getMobilograms() {
+  public List<IonMobilitySeries> getMobilograms() {
     return Collections.unmodifiableList(mobilograms);
   }
 
@@ -347,7 +348,7 @@ public class SimpleIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
   @Override
   public IonMobilogramTimeSeries copyAndReplace(@Nullable MemoryMapStorage storage,
       @Nonnull double[] newMzValues, @Nonnull double[] newIntensityValues,
-      @Nonnull List<SimpleIonMobilitySeries> newMobilograms,
+      @Nonnull List<IonMobilitySeries> newMobilograms,
       @Nullable double[] smoothedSummedMobilogramIntensities) {
 
     double[] summedMobilogramMobilities = null;
@@ -361,12 +362,12 @@ public class SimpleIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
         smoothedSummedMobilogramIntensities);
   }
 
-  private double[] weightMzs(List<SimpleIonMobilitySeries> mobilograms,
+  private double[] weightMzs(List<IonMobilitySeries> mobilograms,
       double[] summedIntensities) {
     double[] weightedMzs = new double[mobilograms.size()];
 
     for (int i = 0; i < mobilograms.size(); i++) {
-      SimpleIonMobilitySeries ims = mobilograms.get(i);
+      IonMobilitySeries ims = mobilograms.get(i);
       DoubleBuffer intensities = ims.getIntensityValues();
       DoubleBuffer mzValues = ims.getMZValues();
       double weightedMz = 0;
@@ -382,10 +383,10 @@ public class SimpleIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
     return weightedMzs;
   }
 
-  private double[] sumIntensities(List<SimpleIonMobilitySeries> mobilograms) {
+  private double[] sumIntensities(List<IonMobilitySeries> mobilograms) {
     double[] summedIntensities = new double[mobilograms.size()];
     for (int i = 0; i < mobilograms.size(); i++) {
-      SimpleIonMobilitySeries ims = mobilograms.get(i);
+      IonMobilitySeries ims = mobilograms.get(i);
       DoubleBuffer intensities = ims.getIntensityValues();
       for (int j = 0; j < intensities.capacity(); j++) {
         summedIntensities[i] += intensities.get(j);
@@ -394,9 +395,9 @@ public class SimpleIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
     return summedIntensities;
   }
 
-  private boolean checkRawFileIntegrity(List<SimpleIonMobilitySeries> mobilograms) {
+  private boolean checkRawFileIntegrity(List<IonMobilitySeries> mobilograms) {
     final RawDataFile file = mobilograms.get(0).getSpectrum(0).getDataFile();
-    for (SimpleIonMobilitySeries mobilogram : mobilograms) {
+    for (IonMobilitySeries mobilogram : mobilograms) {
       if (mobilogram.getSpectrum(0).getDataFile() != file) {
         return false;
       }

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonMobilogramTimeSeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonMobilogramTimeSeries.java
@@ -19,6 +19,7 @@
 package io.github.mzmine.datamodel.featuredata.impl;
 
 import io.github.mzmine.datamodel.Frame;
+import io.github.mzmine.datamodel.MobilityScan;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.featuredata.IonMobilitySeries;
 import io.github.mzmine.datamodel.featuredata.IonMobilogramTimeSeries;
@@ -240,8 +241,16 @@ public class SimpleIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
 
     List<IonMobilitySeries> storedMobilograms = new ArrayList<>();
     for (int i = 0; i < offsets.length; i++) {
+      IonMobilitySeries mobilogram = mobilograms.get(i);
+      List<MobilityScan> spectra;
+      if(mobilogram instanceof ModifiableSpectra) {
+        spectra = ((ModifiableSpectra)mobilogram).getSpectraModifiable();
+      } else {
+        spectra = mobilogram.getSpectra();
+      }
+
       storedMobilograms.add(new StorableIonMobilitySeries(this, offsets[i],
-          mobilograms.get(i).getNumberOfValues(), mobilograms.get(i).getSpectra()));
+         mobilogram.getNumberOfValues(), spectra));
     }
     return storedMobilograms;
   }

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/impl/StorableIonMobilitySeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/impl/StorableIonMobilitySeries.java
@@ -1,0 +1,122 @@
+/*
+ *  Copyright 2006-2020 The MZmine Development Team
+ *
+ *  This file is part of MZmine.
+ *
+ *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ *  General Public License as published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
+ *
+ *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ *  Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with MZmine; if not,
+ *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ *  USA
+ */
+
+package io.github.mzmine.datamodel.featuredata.impl;
+
+import io.github.mzmine.datamodel.Frame;
+import io.github.mzmine.datamodel.MobilityScan;
+import io.github.mzmine.datamodel.featuredata.IonMobilitySeries;
+import io.github.mzmine.datamodel.featuredata.IonSpectrumSeries;
+import io.github.mzmine.util.DataPointUtils;
+import io.github.mzmine.util.MemoryMapStorage;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+import javax.annotation.Nonnull;
+
+/**
+ * Stores data points of several {@link MobilityScan}s. Usually wrapped in a {@link
+ * SimpleIonMobilogramTimeSeries} representing the same feature with mobility resolution.
+ *
+ * @author https://github.com/SteffenHeu
+ */
+public class StorableIonMobilitySeries implements IonSpectrumSeries<MobilityScan> {
+
+  private static final Logger logger = Logger.getLogger(StorableIonMobilitySeries.class.getName());
+
+  protected final List<MobilityScan> scans;
+
+  protected int offset;
+  protected int numPoints;
+
+  protected StorableIonMobilitySeries(final int offset, final int numPoints,
+      @Nonnull List<MobilityScan> scans) {
+    if (numPoints != scans.size()) {
+      throw new IllegalArgumentException("numPoints and number of scans scans does not match.");
+    }
+
+    final Frame frame = scans.get(0).getFrame();
+    for (MobilityScan scan : scans) {
+      if (frame != scan.getFrame()) {
+        throw new IllegalArgumentException("All mobility scans must belong to the same frame.");
+      }
+    }
+
+    this.scans = scans;
+
+  }
+
+  @Override
+  public double getIntensityForSpectrum(MobilityScan spectrum) {
+    int index = scans.indexOf(spectrum);
+    if (index != -1) {
+      return getIntensity(index);
+    }
+    return 0d;
+  }
+
+  @Override
+  public double getMzForSpectrum(MobilityScan spectrum) {
+    int index = scans.indexOf(spectrum);
+    if (index != -1) {
+      return getMZ(index);
+    }
+    return 0d;
+  }
+
+  @Override
+  public IonMobilitySeries subSeries(@Nullable MemoryMapStorage storage,
+      @Nonnull List<MobilityScan> subset) {
+    double[] mzs = new double[subset.size()];
+    double[] intensities = new double[subset.size()];
+
+    for (int i = 0; i < subset.size(); i++) {
+      mzs[i] = getMzForSpectrum(subset.get(i));
+      intensities[i] = getIntensityForSpectrum(subset.get(i));
+    }
+
+    return new StorableIonMobilitySeries(storage, mzs, intensities, subset);
+  }
+
+  @Override
+  public DoubleBuffer getIntensityValues() {
+    return intensityValues;
+  }
+
+  @Override
+  public DoubleBuffer getMZValues() {
+    return mzValues;
+  }
+
+  public double getMobility(int index) {
+    return getSpectra().get(index).getMobility();
+  }
+
+  @Override
+  public List<MobilityScan> getSpectra() {
+    return Collections.unmodifiableList(scans);
+  }
+
+  @Override
+  public IonSpectrumSeries<MobilityScan> copy(@Nullable MemoryMapStorage storage) {
+    double[][] data = DataPointUtils
+        .getDataPointsAsDoubleArray(getMZValues(), getIntensityValues());
+
+    return new StorableIonMobilitySeries(storage, data[0], data[1], scans);
+  }
+}

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/impl/StorableIonMobilitySeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/impl/StorableIonMobilitySeries.java
@@ -37,7 +37,7 @@ import javax.annotation.Nullable;
  *
  * @author https://github.com/SteffenHeu
  */
-public class StorableIonMobilitySeries implements IonMobilitySeries {
+public class StorableIonMobilitySeries implements IonMobilitySeries, ModifiableSpectra<MobilityScan> {
 
   private static final Logger logger = Logger.getLogger(StorableIonMobilitySeries.class.getName());
 
@@ -143,5 +143,16 @@ public class StorableIonMobilitySeries implements IonMobilitySeries {
   @Override
   public int getNumberOfValues() {
     return numValues;
+  }
+
+  @Override
+  public List<MobilityScan> getSpectraModifiable() {
+    return scans;
+  }
+
+  @Override
+  public IonSpectrumSeries<MobilityScan> copyAndReplace(@Nullable MemoryMapStorage storage,
+      @Nonnull double[] newMzValues, @Nonnull double[] newIntensityValues) {
+    return new SimpleIonMobilitySeries(storage, newMzValues, newIntensityValues, scans);
   }
 }

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/impl/StorableIonMobilitySeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/impl/StorableIonMobilitySeries.java
@@ -100,8 +100,18 @@ public class StorableIonMobilitySeries implements IonMobilitySeries {
   }
 
   @Override
+  public double getIntensity(int index) {
+    return ionTrace.getMobilogramIntensityValue(this, index);
+  }
+
+  @Override
+  public double getMZ(int index) {
+    return ionTrace.getMobilogramMzValue(this, index);
+  }
+
+  @Override
   public DoubleBuffer getIntensityValues() {
-    return ionTrace.getMobilogramMzValues(this);
+    return ionTrace.getMobilogramIntensityValues(this);
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/impl/StorageFactory.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/impl/StorageFactory.java
@@ -1,0 +1,111 @@
+package io.github.mzmine.datamodel.featuredata.impl;
+
+import io.github.mzmine.datamodel.featuredata.IonSeries;
+import io.github.mzmine.util.DataPointUtils;
+import io.github.mzmine.util.MemoryMapStorage;
+import java.io.IOException;
+import java.nio.DoubleBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class StorageFactory {
+
+  public static <T extends IonSeries> DoubleBuffer[] storeIonSeriesToSingleBuffer(
+      @Nullable final MemoryMapStorage storage, List<T> seriesList) {
+
+    final List<double[][]> mzIntensities = new ArrayList<>();
+
+    for (final T series : seriesList) {
+      double[][] mzIntensity = DataPointUtils
+          .getDataPointsAsDoubleArray(series.getMZValues(), series.getIntensityValues());
+      mzIntensities.add(mzIntensity);
+    }
+
+    final int[] offsets = generateOffsets(mzIntensities);
+    final int numDp =
+        offsets[offsets.length - 1] + mzIntensities.get(mzIntensities.size() - 1)[0].length;
+
+    final DoubleBuffer[] storedValues = new DoubleBuffer[2];
+    double[] storageBuffer = new double[numDp];
+    for (int i = 0; i < 2; i++) {
+      putAllValuesIntoOneArray(mzIntensities, i, storageBuffer);
+      storedValues[i] = storeValuesToDoubleBuffer(storage, storageBuffer);
+      if(storage == null) {
+        storageBuffer = new double[numDp];
+      }
+    }
+    return storedValues;
+  }
+
+  public static int[] generateOffsets(List<double[][]> mzsIntensities) {
+    final int[] offsets = new int[mzsIntensities.size()];
+    offsets[0] = 0;
+    for (int i = 1; i < offsets.length; i++) {
+      offsets[i] = offsets[i - 1] + mzsIntensities.get(i - 1)[0].length;
+    }
+    return offsets;
+  }
+
+  /**
+   * @param peaks      List of values. it will be iterated over peaks[arrayIndex][i]
+   * @param arrayIndex the index of the first dimension of the input array.
+   * @param dst        the destination array of an appropriate size.
+   * @return An array of base peak indices if arrayIndex == 1.
+   */
+  public static int[] putAllValuesIntoOneArray(final List<double[][]> peaks,
+      final int arrayIndex, double[] dst) {
+    int[] basePeakIndices = null;
+    if (arrayIndex == 1) {
+      basePeakIndices = new int[peaks.size()];
+      Arrays.fill(basePeakIndices, -1);
+    }
+
+    int dpCounter = 0;
+    for (int scanNum = 0, numScans = peaks.size(); scanNum < numScans; scanNum++) {
+      double[][] mzIntensity = peaks.get(scanNum);
+      double maxIntensity = -1d;
+
+      double[] doubles = mzIntensity[arrayIndex];
+      for (int peakNum = 0; peakNum < doubles.length; peakNum++) {
+        double thisMzOrIntensity = doubles[peakNum];
+        dst[dpCounter] = thisMzOrIntensity;
+        dpCounter++;
+        if (arrayIndex == 1 && thisMzOrIntensity > maxIntensity) {
+          maxIntensity = thisMzOrIntensity;
+          basePeakIndices[scanNum] = peakNum;
+        }
+      }
+    }
+
+    return basePeakIndices;
+  }
+
+  /**
+   * Stores the given array into a double buffer.
+   *
+   * @param storage The storage to be used. If null, the values will be wrapped using {@link
+   *                DoubleBuffer#wrap(double[])}.
+   * @param values  The values to be stored.
+   * @return The double buffer the values were stored in.
+   */
+  @Nonnull
+  public static DoubleBuffer storeValuesToDoubleBuffer(@Nullable final MemoryMapStorage storage,
+      @Nonnull final double[] values) {
+
+    DoubleBuffer buffer;
+    if (storage != null) {
+      try {
+        buffer = storage.storeData(values);
+      } catch (IOException e) {
+        e.printStackTrace();
+        buffer = DoubleBuffer.wrap(values);
+      }
+    } else {
+      buffer = DoubleBuffer.wrap(values);
+    }
+    return buffer;
+  }
+}

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/impl/StorageUtils.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/impl/StorageUtils.java
@@ -11,10 +11,27 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public class StorageFactory {
+/**
+ * Used to store lists of arrays into a single DoubleBuffer to safe memory.
+ *
+ * @author https://github.com/SteffenHeu
+ */
+public class StorageUtils {
 
+  /**
+   * @param storage    The storage the m/z and intensity values shall be saved to. If null, the
+   *                   values will be wrapped in a double buffer and stored in ram.
+   * @param seriesList A list of the series that shall be combined into a single buffer. It is
+   *                   assumed that the number of m/z and intensity values for a single series are
+   *                   equal.
+   * @param offsets    (out) An array the series' offsets in the returned storage buffer will be
+   *                   written into. Must have the same length as seriesList.
+   * @param <T>        A class extending {@link IonSeries}.
+   * @return Two double buffers. [0] containing m/z values, [1] containing intensity values.
+   */
   public static <T extends IonSeries> DoubleBuffer[] storeIonSeriesToSingleBuffer(
-      @Nullable final MemoryMapStorage storage, List<T> seriesList) {
+      @Nullable final MemoryMapStorage storage, final List<T> seriesList, int[] offsets) {
+    assert offsets.length == seriesList.size();
 
     final List<double[][]> mzIntensities = new ArrayList<>();
 
@@ -24,48 +41,62 @@ public class StorageFactory {
       mzIntensities.add(mzIntensity);
     }
 
-    final int[] offsets = generateOffsets(mzIntensities);
+    // generate and copy the offsets to the array passed as an argument.
+    final int[] generatedOffsets = generateOffsets(mzIntensities);
+    System.arraycopy(generatedOffsets, 0, offsets, 0, generatedOffsets.length);
+
     final int numDp =
         offsets[offsets.length - 1] + mzIntensities.get(mzIntensities.size() - 1)[0].length;
-
     final DoubleBuffer[] storedValues = new DoubleBuffer[2];
     double[] storageBuffer = new double[numDp];
+
     for (int i = 0; i < 2; i++) {
       putAllValuesIntoOneArray(mzIntensities, i, storageBuffer);
       storedValues[i] = storeValuesToDoubleBuffer(storage, storageBuffer);
-      if(storage == null) {
+      if (storage == null) {
         storageBuffer = new double[numDp];
       }
     }
+
     return storedValues;
   }
 
-  public static int[] generateOffsets(List<double[][]> mzsIntensities) {
-    final int[] offsets = new int[mzsIntensities.size()];
+  /**
+   * Generates offsets for a list of 2D-double-arrays. it is assumed, that the first dimension [x][]
+   * specifies the dimension of the value, and the second dimension [][x] contains the values. For
+   * example, [0][0] contains the first, [0][1] the second m/z value and [1][0] contains the first
+   * and [1][1] contains the second intensity value.
+   *
+   * @param dataArrayList A list of all the values offsets shall be generated for.
+   * @return An array of integer offsets. The indices in the array correspond to the indices in the
+   * given list.
+   */
+  public static int[] generateOffsets(List<double[][]> dataArrayList) {
+    final int[] offsets = new int[dataArrayList.size()];
     offsets[0] = 0;
     for (int i = 1; i < offsets.length; i++) {
-      offsets[i] = offsets[i - 1] + mzsIntensities.get(i - 1)[0].length;
+      offsets[i] = offsets[i - 1] + dataArrayList.get(i - 1)[0].length;
     }
     return offsets;
   }
 
   /**
-   * @param peaks      List of values. it will be iterated over peaks[arrayIndex][i]
+   * @param values     List of values. it will be iterated over values[arrayIndex][i]
    * @param arrayIndex the index of the first dimension of the input array.
    * @param dst        the destination array of an appropriate size.
    * @return An array of base peak indices if arrayIndex == 1.
    */
-  public static int[] putAllValuesIntoOneArray(final List<double[][]> peaks,
+  public static int[] putAllValuesIntoOneArray(final List<double[][]> values,
       final int arrayIndex, double[] dst) {
     int[] basePeakIndices = null;
     if (arrayIndex == 1) {
-      basePeakIndices = new int[peaks.size()];
+      basePeakIndices = new int[values.size()];
       Arrays.fill(basePeakIndices, -1);
     }
 
     int dpCounter = 0;
-    for (int scanNum = 0, numScans = peaks.size(); scanNum < numScans; scanNum++) {
-      double[][] mzIntensity = peaks.get(scanNum);
+    for (int scanNum = 0, numScans = values.size(); scanNum < numScans; scanNum++) {
+      double[][] mzIntensity = values.get(scanNum);
       double maxIntensity = -1d;
 
       double[] doubles = mzIntensity[arrayIndex];

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SummedIntensityMobilitySeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SummedIntensityMobilitySeries.java
@@ -24,6 +24,7 @@ import com.google.common.collect.TreeRangeMap;
 import io.github.mzmine.datamodel.Frame;
 import io.github.mzmine.datamodel.MobilityType;
 import io.github.mzmine.datamodel.featuredata.IntensitySeries;
+import io.github.mzmine.datamodel.featuredata.IonMobilitySeries;
 import io.github.mzmine.datamodel.featuredata.MobilitySeries;
 import io.github.mzmine.util.IonMobilityUtils;
 import io.github.mzmine.util.MemoryMapStorage;
@@ -54,7 +55,7 @@ public class SummedIntensityMobilitySeries implements IntensitySeries, MobilityS
    * @param mz
    */
   public SummedIntensityMobilitySeries(@Nullable MemoryMapStorage storage,
-      List<SimpleIonMobilitySeries> mobilograms,
+      List<IonMobilitySeries> mobilograms,
       double mz) {
 
     this.mz = mz;
@@ -67,7 +68,7 @@ public class SummedIntensityMobilitySeries implements IntensitySeries, MobilityS
     RangeMap<Double, Double> mobilityIntensityValues = TreeRangeMap.create();
 
     for (int i = 0; i < mobilograms.size(); i++) {
-      SimpleIonMobilitySeries mobilogram = mobilograms.get(i);
+      IonMobilitySeries mobilogram = mobilograms.get(i);
       for (int j = 0; j < mobilogram.getNumberOfValues(); j++) {
         double intensity = mobilogram.getIntensity(j);
         double mobility = mobilogram.getMobility(j);

--- a/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/series/IonMobilogramTimeSeriesToRtMobilityHeatmapProvider.java
+++ b/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/series/IonMobilogramTimeSeriesToRtMobilityHeatmapProvider.java
@@ -19,8 +19,8 @@
 package io.github.mzmine.gui.chartbasics.simplechart.providers.impl.series;
 
 import io.github.mzmine.datamodel.MobilityScan;
+import io.github.mzmine.datamodel.featuredata.IonMobilitySeries;
 import io.github.mzmine.datamodel.featuredata.IonMobilogramTimeSeries;
-import io.github.mzmine.datamodel.featuredata.impl.SimpleIonMobilitySeries;
 import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.gui.chartbasics.simplechart.providers.MassSpectrumProvider;
 import io.github.mzmine.gui.chartbasics.simplechart.providers.PlotXYZDataProvider;
@@ -121,7 +121,7 @@ public class IonMobilogramTimeSeriesToRtMobilityHeatmapProvider implements PlotX
 
   @Override
   public double getDomainValue(int index) {
-    for (SimpleIonMobilitySeries mobilitySeries : data.getMobilograms()) {
+    for (IonMobilitySeries mobilitySeries : data.getMobilograms()) {
       if (index >= mobilitySeries.getNumberOfValues()) {
         index -= mobilitySeries.getNumberOfValues();
       } else {
@@ -133,7 +133,7 @@ public class IonMobilogramTimeSeriesToRtMobilityHeatmapProvider implements PlotX
 
   @Override
   public double getRangeValue(int index) {
-    for (SimpleIonMobilitySeries mobilitySeries : data.getMobilograms()) {
+    for (IonMobilitySeries mobilitySeries : data.getMobilograms()) {
       if (index >= mobilitySeries.getNumberOfValues()) {
         index -= mobilitySeries.getNumberOfValues();
       } else {
@@ -155,7 +155,7 @@ public class IonMobilogramTimeSeriesToRtMobilityHeatmapProvider implements PlotX
 
   @Override
   public double getZValue(int index) {
-    for (SimpleIonMobilitySeries mobilitySeries : data.getMobilograms()) {
+    for (IonMobilitySeries mobilitySeries : data.getMobilograms()) {
       if (index >= mobilitySeries.getNumberOfValues()) {
         index -= mobilitySeries.getNumberOfValues();
       } else {
@@ -180,7 +180,7 @@ public class IonMobilogramTimeSeriesToRtMobilityHeatmapProvider implements PlotX
   @Nullable
   @Override
   public MobilityScan getSpectrum(int index) {
-    for (SimpleIonMobilitySeries mobilitySeries : data.getMobilograms()) {
+    for (IonMobilitySeries mobilitySeries : data.getMobilograms()) {
       if (index >= mobilitySeries.getNumberOfValues()) {
         index -= mobilitySeries.getNumberOfValues();
       } else {

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/ResolvingUtil.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/ResolvingUtil.java
@@ -98,8 +98,9 @@ public class ResolvingUtil {
           if (subset.size() < 3) {
             continue;
           }
+          // IonMobilitySeries are stored in ram until they are added to an IonMobilogramTimeSeries
           SimpleIonMobilitySeries resolvedMobilogram = (SimpleIonMobilitySeries) mobilogram
-              .subSeries(storage, subset);
+              .subSeries(null, subset);
           resolvedMobilograms.add(resolvedMobilogram);
         }
         IonMobilogramTimeSeries resolved = new SimpleIonMobilogramTimeSeries(
@@ -141,10 +142,10 @@ public class ResolvingUtil {
 
         // tims 1/k0 decreases with scan number, drift time increases
         MobilityType mt = mobData.getSpectra().get(0).getMobilityType();
-        int operation = mt == MobilityType.TIMS ? -1 : +1;
+        int direction = mt == MobilityType.TIMS ? -1 : +1;
         int dataIndex = 0;
         for (int j = (mt == MobilityType.TIMS ? summedMobilogram.getNumberOfValues() - 1 : 0);
-            j < summedMobilogram.getNumberOfValues() && j >= 0; j += operation) {
+            j < summedMobilogram.getNumberOfValues() && j >= 0; j += direction) {
           xdata[dataIndex] = summedMobilogram.getMobility(j);
           ydata[dataIndex] = summedMobilogram.getIntensity(j);
           dataIndex++;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/ResolvingUtil.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/ResolvingUtil.java
@@ -22,6 +22,7 @@ import io.github.mzmine.datamodel.Frame;
 import io.github.mzmine.datamodel.MobilityScan;
 import io.github.mzmine.datamodel.MobilityType;
 import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.datamodel.featuredata.IonMobilitySeries;
 import io.github.mzmine.datamodel.featuredata.IonMobilogramTimeSeries;
 import io.github.mzmine.datamodel.featuredata.IonTimeSeries;
 import io.github.mzmine.datamodel.featuredata.impl.SimpleIonMobilitySeries;
@@ -86,8 +87,8 @@ public class ResolvingUtil {
 
       } else if (dimension == ResolvingDimension.MOBILITY
           && data instanceof IonMobilogramTimeSeries) {
-        List<SimpleIonMobilitySeries> resolvedMobilograms = new ArrayList<>();
-        for (SimpleIonMobilitySeries mobilogram : ((IonMobilogramTimeSeries) data)
+        List<IonMobilitySeries> resolvedMobilograms = new ArrayList<>();
+        for (IonMobilitySeries mobilogram : ((IonMobilogramTimeSeries) data)
             .getMobilograms()) {
           // make a sub list of the original scans
           List<MobilityScan> subset = mobilogram.getSpectra().stream()

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_smoothing/IonSpectrumSeriesSmoothing.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_smoothing/IonSpectrumSeriesSmoothing.java
@@ -93,8 +93,7 @@ public class IonSpectrumSeriesSmoothing<T extends IonSpectrumSeries> {
     if (origSeries instanceof SimpleIonMobilitySeries
         || origSeries instanceof StorableIonMobilitySeries) {
       // IonMobilitySeries are stored in ram until they are added to an IonMobilogramTimeSeries
-      return (T) new SimpleIonMobilitySeries(null, origMz, newIntensities,
-          origSeries.getSpectra());
+      return (T) ((IonMobilitySeries) origSeries).copyAndReplace(null, origMz, newIntensities);
     } else if (origSeries instanceof SimpleIonTimeSeries) {
       return (T) ((SimpleIonTimeSeries) origSeries)
           .copyAndReplace(newStorage, origMz, newIntensities);

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_smoothing/IonSpectrumSeriesSmoothing.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_smoothing/IonSpectrumSeriesSmoothing.java
@@ -20,6 +20,7 @@ package io.github.mzmine.modules.dataprocessing.featdet_smoothing;
 
 import io.github.mzmine.datamodel.MassSpectrum;
 import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.featuredata.IonMobilitySeries;
 import io.github.mzmine.datamodel.featuredata.IonSpectrumSeries;
 import io.github.mzmine.datamodel.featuredata.impl.SimpleIonMobilitySeries;
 import io.github.mzmine.datamodel.featuredata.impl.SimpleIonMobilogramTimeSeries;
@@ -69,14 +70,14 @@ public class IonSpectrumSeriesSmoothing<T extends IonSpectrumSeries> {
    */
   public T smooth(@Nonnull double[] rtWeights, @Nonnull double[] mobilityWeights) {
     // smooth mobilograms in case there are any, use the mobilityWeights there.
-    List<SimpleIonMobilitySeries> smoothedMobilograms = null;
+    List<IonMobilitySeries> smoothedMobilograms = null;
     if (origSeries instanceof SimpleIonMobilogramTimeSeries) {
       smoothedMobilograms = new ArrayList<>();
-      for (SimpleIonMobilitySeries mobilogram : ((SimpleIonMobilogramTimeSeries) origSeries)
+      for (IonMobilitySeries mobilogram : ((SimpleIonMobilogramTimeSeries) origSeries)
           .getMobilograms()) {
         List<? extends MassSpectrum> mobilityScans = mobilogram.getSpectrum(0).getFrame()
             .getMobilityScans();
-        IonSpectrumSeriesSmoothing<SimpleIonMobilitySeries> smoothing = new IonSpectrumSeriesSmoothing<>(
+        IonSpectrumSeriesSmoothing<IonMobilitySeries> smoothing = new IonSpectrumSeriesSmoothing<>(
             mobilogram, newStorage, (List<MassSpectrum>) mobilityScans, mobilitySmoothingType);
         smoothedMobilograms.add(smoothing.smooth(rtWeights, mobilityWeights));
       }

--- a/src/main/java/io/github/mzmine/util/FeatureConvertors.java
+++ b/src/main/java/io/github/mzmine/util/FeatureConvertors.java
@@ -26,6 +26,7 @@ import io.github.mzmine.datamodel.Frame;
 import io.github.mzmine.datamodel.IMSRawDataFile;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.datamodel.featuredata.IonMobilitySeries;
 import io.github.mzmine.datamodel.featuredata.IonMobilogramTimeSeries;
 import io.github.mzmine.datamodel.featuredata.IonTimeSeries;
 import io.github.mzmine.datamodel.featuredata.impl.SimpleIonMobilitySeries;
@@ -203,7 +204,7 @@ public class FeatureConvertors {
 
     MemoryMapStorage storage = ((ModularFeatureList) ionTrace.getFeatureList())
         .getMemoryMapStorage();
-    List<SimpleIonMobilitySeries> mobilograms = new ArrayList<>();
+    List<IonMobilitySeries> mobilograms = new ArrayList<>();
     var sortedDp = FeatureConvertorIonMobility.groupDataPointsByFrameId(ionTrace.getDataPoints());
     for (Entry<Frame, SortedSet<RetentionTimeMobilityDataPoint>> entry : sortedDp.entrySet()) {
       double[][] data = DataPointUtils.getDataPointsAsDoubleArray(entry.getValue());


### PR DESCRIPTION
Optimises ram usage of  ion mobility series with regard to double buffers. 

Similar to MobilityScans and the soon to come mass lists, all mobilogram data for an ion mobility trace is stored in a single double buffer.

