### PR TITLE
flistsummary sets paramters to batch mode

### DIFF
--- a/src/main/java/io/github/mzmine/gui/mainwindow/FeatureListSummaryController.java
+++ b/src/main/java/io/github/mzmine/gui/mainwindow/FeatureListSummaryController.java
@@ -28,7 +28,14 @@ import io.github.mzmine.modules.batchmode.BatchModeParameters;
 import io.github.mzmine.modules.batchmode.BatchQueue;
 import io.github.mzmine.modules.impl.MZmineProcessingStepImpl;
 import io.github.mzmine.parameters.Parameter;
+import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.parametertypes.ParameterSetParameter;
+import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
+import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsSelection;
+import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsSelectionType;
+import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesParameter;
+import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesSelection;
+import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesSelectionType;
 import java.util.logging.Logger;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
@@ -128,8 +135,10 @@ public class FeatureListSummaryController {
 
     for (FeatureListAppliedMethod item : lvAppliedMethods.getItems()) {
       if(item.getModule() instanceof MZmineProcessingModule) {
+        ParameterSet parameterSet = item.getParameters().cloneParameterSet();
+        setSelectionToLastBatchStep(parameterSet);
         MZmineProcessingStep<MZmineProcessingModule> step = new MZmineProcessingStepImpl(
-            item.getModule(), item.getParameters());
+            item.getModule(), parameterSet);
         queue.add(step);
       } else {
         logger.warning(() -> "Cannot add module " + item.getModule() + " as a batch step because "
@@ -142,5 +151,19 @@ public class FeatureListSummaryController {
     batchModeParameters.getParameter(BatchModeParameters.batchQueue).setValue(queue);
 
     batchModeParameters.showSetupDialog(true);
+  }
+
+  private void setSelectionToLastBatchStep(ParameterSet parameters) {
+    for (Parameter<?> parameter : parameters.getParameters()) {
+      if(parameter instanceof FeatureListsParameter) {
+        final FeatureListsSelection featureListsSelection = new FeatureListsSelection();
+        featureListsSelection.setSelectionType(FeatureListsSelectionType.BATCH_LAST_FEATURELISTS);
+        ((FeatureListsParameter)parameter).setValue(featureListsSelection);
+      } else if(parameter instanceof RawDataFilesParameter) {
+        final RawDataFilesSelection rawDataFilesSelection = new RawDataFilesSelection(
+            RawDataFilesSelectionType.BATCH_LAST_FILES);
+        ((RawDataFilesParameter)parameter).setValue(rawDataFilesSelection);
+      }
+    }
   }
 }


### PR DESCRIPTION
Sets feature list & raw file parameters to "those created by last batch step" when summary is opened in batch mode.