### PR TITLE
Remove temp files on exit

### DIFF
--- a/src/main/java/io/github/mzmine/gui/MZmineGUI.java
+++ b/src/main/java/io/github/mzmine/gui/MZmineGUI.java
@@ -32,6 +32,7 @@ import io.github.mzmine.gui.mainwindow.MainWindowController;
 import io.github.mzmine.gui.preferences.MZminePreferences;
 import io.github.mzmine.main.GoogleAnalyticsTracker;
 import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.main.TmpFileCleanup;
 import io.github.mzmine.modules.MZmineRunnableModule;
 import io.github.mzmine.modules.io.projectload.ProjectLoadModule;
 import io.github.mzmine.parameters.ParameterSet;
@@ -387,6 +388,7 @@ public class MZmineGUI extends Application implements Desktop {
     // save configuration on exit if we only run a batch
     ShutDownHook shutDownHook = new ShutDownHook();
     Runtime.getRuntime().addShutdownHook(shutDownHook);
+    Runtime.getRuntime().addShutdownHook(new Thread(new TmpFileCleanup()));
 
   }
 

--- a/src/main/java/io/github/mzmine/util/MemoryMapStorage.java
+++ b/src/main/java/io/github/mzmine/util/MemoryMapStorage.java
@@ -37,37 +37,33 @@ import javax.annotation.Nonnull;
  * storeData() function stores an array into the underlying temporary file and returns a buffer. The
  * buffer is directly bound to the memory-mapped portion of the file so the data can be directly
  * accessed without loading it into another intermediate primitive type array.
- *
+ * <p>
  * The size of each temporary file is STORAGE_FILE_CAPACITY bytes. When the file is full, a new file
  * is automatically created using the createNewMappedFile() function. The size of each temporary
  * file in the filesystem may show as 1GB, but actually only a portion of that space is occupied on
  * the disk, depending on the amount of stored data (this can be examined using the 'du -hs' Linux
  * command.
- *
+ * <p>
  * There is no support for removing data from the file - we assume such operation is rare and
  * therefore the data can be left on the disk until the whole temporary file is discarded.
- *
+ * <p>
  * There is a limit on the number of open file descriptors (e.g. 1024 by default on Linux). With 1
  * GB per temporary file, this would give us about 1 TB of storage space, so perhaps it is okay.
  * There is no way to remove the memory-mapped file, it is removed automatically when the
  * MappedByteBuffer is garbage-collected.
- *
+ * <p>
  * The total amount of storage space is also limited by the amount of addressable virtual memory
  * (e.g., 128TB on Linux). For this reason, this approach requires a 64-bit system - the limit would
  * be only 2GB on a 32-bit system.
- *
- *
  */
 public class MemoryMapStorage {
-
-  private final Logger logger = Logger.getLogger(this.getClass().getName());
 
   /**
    * One temporary file can store STORAGE_FILE_CAPACITY bytes. We need to fit within 2GB limit for a
    * single MappedByteBuffer. 1 GB per file seems like a good start.
    */
   private static final long STORAGE_FILE_CAPACITY = 1_000_000_000L;
-
+  private final Logger logger = Logger.getLogger(this.getClass().getName());
   private final Set<File> temporaryFiles = new HashSet<>();
 
   /**
@@ -116,7 +112,8 @@ public class MemoryMapStorage {
    * @return a read-only DoubleBuffer that is directly mapped to the stored data on the disk
    * @throws IOException
    */
-  public synchronized @Nonnull DoubleBuffer storeData(@Nonnull final double data[])
+  @Nonnull
+  public synchronized DoubleBuffer storeData(@Nonnull final double data[])
       throws IOException {
     return storeData(data, 0, data.length);
   }
@@ -125,13 +122,14 @@ public class MemoryMapStorage {
    * Store the given double[] array in a memory-mapped temporary file and return a read-only
    * DoubleBuffer that can access the data.
    *
-   * @param data the double[] array with the data
+   * @param data   the double[] array with the data
    * @param offset offset of the stored portion of the data[] array
    * @param length size of the stored portion of the data[] array
    * @return a read-only DoubleBuffer that is directly mapped to the stored data on the disk
    * @throws IOException
    */
-  public synchronized @Nonnull DoubleBuffer storeData(@Nonnull final double data[], int offset,
+  @Nonnull
+  public synchronized DoubleBuffer storeData(@Nonnull final double data[], int offset,
       int length) throws IOException {
 
     // If we have no storage file or if the current file is full, create a new one
@@ -171,7 +169,8 @@ public class MemoryMapStorage {
    * @return a read-only FloatBuffer that is directly mapped to the stored data on the disk
    * @throws IOException
    */
-  public synchronized @Nonnull FloatBuffer storeData(@Nonnull final float data[])
+  @Nonnull
+  public synchronized FloatBuffer storeData(@Nonnull final float data[])
       throws IOException {
     return storeData(data, 0, data.length);
   }
@@ -180,13 +179,14 @@ public class MemoryMapStorage {
    * Store the given float[] array in a memory-mapped temporary file and return a read-only
    * FloatBuffer that can access the data.
    *
-   * @param data the float[] array with the data
+   * @param data   the float[] array with the data
    * @param offset offset of the stored portion of the data[] array
    * @param length size of the stored portion of the data[] array
    * @return a read-only FloatBuffer that is directly mapped to the stored data on the disk
    * @throws IOException
    */
-  public synchronized @Nonnull FloatBuffer storeData(@Nonnull final float data[], int offset,
+  @Nonnull
+  public synchronized FloatBuffer storeData(@Nonnull final float data[], int offset,
       int length) throws IOException {
 
     // If we have no storage file or if the current file is full, create a new one
@@ -226,7 +226,8 @@ public class MemoryMapStorage {
    * @return a read-only IntBuffer that is directly mapped to the stored data on the disk
    * @throws IOException
    */
-  public synchronized @Nonnull IntBuffer storeData(@Nonnull final int data[]) throws IOException {
+  @Nonnull
+  public synchronized IntBuffer storeData(@Nonnull final int data[]) throws IOException {
     return storeData(data, 0, data.length);
   }
 
@@ -234,13 +235,14 @@ public class MemoryMapStorage {
    * Store the given int[] array in a memory-mapped temporary file and return a read-only IntBuffer
    * that can access the data.
    *
-   * @param data the int[] array with the data
+   * @param data   the int[] array with the data
    * @param offset offset of the stored portion of the data[] array
    * @param length size of the stored portion of the data[] array
    * @return a read-only IntBuffer that is directly mapped to the stored data on the disk
    * @throws IOException
    */
-  public synchronized @Nonnull IntBuffer storeData(@Nonnull final int data[], int offset,
+  @Nonnull
+  public synchronized IntBuffer storeData(@Nonnull final int data[], int offset,
       int length) throws IOException {
 
     // If we have no storage file or if the current file is full, create a new one
@@ -276,10 +278,12 @@ public class MemoryMapStorage {
    * Discard this memory-mapped storage and remove all the associated temporary files.
    */
   public synchronized void discard() throws IOException {
-    for (File tmpFile : temporaryFiles)
-      tmpFile.delete();
+    for (File tmpFile : temporaryFiles) {
+      if (!tmpFile.delete()) {
+        logger.warning("Could not delete temporary file " + tmpFile.getAbsolutePath());
+      }
+    }
     temporaryFiles.clear();
     currentMappedFile = null;
   }
-
 }


### PR DESCRIPTION
In reference to #204.

I did some digging and understood why the we have the cleanup on startup. However, the disk space should be freed on exit of MZmine. Therefore, i did some more research and found a way to remove a temp file of a byte buffer. 

Nevertheless, I have the feeling you guys might not like it because of the usage of sun.misc.Unsafe. :D Furthermore, I think this will currently only delete one file per MemoryMapStorage. We would need to keep track of all MappedByteBuffers created by MemoryMapStorage.

Also, the deletion method uses reflection to access a private field of the MemoryMapStorage, which is a hack, i totally agree, but the field is also meant to not be accessed in any other case during runtime. So i thought the hackiest solution might be the best one.

Keeping track of all MappedByteBuffers  could be incorporated with #206.

In case the deletion of a MappedByteBuffer is only a windows problem, i could add a platform check.

What do you guys think?