### PR TITLE
An advanced data import module for all formats

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/data_access/EfficientDataAccess.java
+++ b/src/main/java/io/github/mzmine/datamodel/data_access/EfficientDataAccess.java
@@ -57,7 +57,18 @@ public class EfficientDataAccess {
    *
    * @param dataFile  target data file to loop over all scans or mass lists
    * @param type      processed or raw data
-   * @param selection processed or raw data
+   */
+  public static ScanDataAccess of(RawDataFile dataFile, ScanDataType type) {
+    return of(dataFile, type, null);
+  }
+  /**
+   * The intended use of this memory access is to loop over all selected scans in a {@link RawDataFile} and
+   * access data points via {@link ScanDataAccess#getMzValue(int)} and {@link
+   * ScanDataAccess#getIntensityValue(int)}
+   *
+   * @param dataFile  target data file to loop over all scans or mass lists
+   * @param type      processed or raw data
+   * @param selection scan selection (null for all scans)
    */
   public static ScanDataAccess of(RawDataFile dataFile, ScanDataType type,
       ScanSelection selection) {

--- a/src/main/java/io/github/mzmine/datamodel/data_access/ScanDataAccess.java
+++ b/src/main/java/io/github/mzmine/datamodel/data_access/ScanDataAccess.java
@@ -42,6 +42,7 @@ public class ScanDataAccess implements MassSpectrum {
 
   protected final RawDataFile dataFile;
   protected final ScanDataType type;
+  private final ScanSelection selection;
   protected final int scans;
 
   // current data
@@ -62,15 +63,15 @@ public class ScanDataAccess implements MassSpectrum {
       ScanDataType type, ScanSelection selection) {
     this.dataFile = dataFile;
     this.type = type;
+    this.selection = selection;
     // count matching scans
-    if(selection==null) {
-          scans = dataFile.getScans().size();
-    }
-    else {
+    if (selection == null) {
+      scans = dataFile.getScans().size();
+    } else {
       int size = 0;
-      for(Scan s : dataFile.getScans()) {
-        if(selection.matches(s)) {
-          size ++;
+      for (Scan s : dataFile.getScans()) {
+        if (selection.matches(s)) {
+          size++;
         }
       }
       scans = size;
@@ -139,8 +140,15 @@ public class ScanDataAccess implements MassSpectrum {
   @Nullable
   public Scan nextScan() throws MissingMassListException {
     if (hasNextScan()) {
-      currentScan++;
-      Scan scan = dataFile.getScan(currentScan);
+      Scan scan = null;
+      do {
+        currentScan++;
+        scan = dataFile.getScan(currentScan);
+
+        assert scan != null;
+        // find next scan
+      } while (selection != null && !selection.matches(scan));
+
       switch (type) {
         case RAW -> {
           scan.getMzValues(mzs);

--- a/src/main/java/io/github/mzmine/datamodel/data_access/ScanDataAccess.java
+++ b/src/main/java/io/github/mzmine/datamodel/data_access/ScanDataAccess.java
@@ -165,6 +165,7 @@ public class ScanDataAccess implements MassSpectrum {
           currentNumberOfDataPoints = masses.getNumberOfDataPoints();
         }
       }
+      assert currentNumberOfDataPoints <= mzs.length;
       return scan;
     }
     return null;

--- a/src/main/java/io/github/mzmine/datamodel/data_access/ScanDataAccess.java
+++ b/src/main/java/io/github/mzmine/datamodel/data_access/ScanDataAccess.java
@@ -42,7 +42,7 @@ public class ScanDataAccess implements MassSpectrum {
 
   protected final RawDataFile dataFile;
   protected final ScanDataType type;
-  protected final Scan[] scans;
+  protected final int scans;
 
   // current data
   protected final double[] mzs;
@@ -62,7 +62,19 @@ public class ScanDataAccess implements MassSpectrum {
       ScanDataType type, ScanSelection selection) {
     this.dataFile = dataFile;
     this.type = type;
-    scans = selection.getMatchingScans(dataFile);
+    // count matching scans
+    if(selection==null) {
+          scans = dataFile.getScans().size();
+    }
+    else {
+      int size = 0;
+      for(Scan s : dataFile.getScans()) {
+        if(selection.matches(s)) {
+          size ++;
+        }
+      }
+      scans = size;
+    }
     // might even use the maximum number of data points in the selected scans
     // but seems unnecessary
     int length = getMaxNumberOfDataPoints();
@@ -81,7 +93,7 @@ public class ScanDataAccess implements MassSpectrum {
 
   public Scan getCurrentScan() {
     assert currentScan >= 0 && hasNextScan();
-    return scans[currentScan];
+    return dataFile.getScan(currentScan);
   }
 
   /**
@@ -128,23 +140,24 @@ public class ScanDataAccess implements MassSpectrum {
   public Scan nextScan() throws MissingMassListException {
     if (hasNextScan()) {
       currentScan++;
+      Scan scan = dataFile.getScan(currentScan);
       switch (type) {
         case RAW -> {
-          scans[currentScan].getMzValues(mzs);
-          scans[currentScan].getIntensityValues(intensities);
-          currentNumberOfDataPoints = scans[currentScan].getNumberOfDataPoints();
+          scan.getMzValues(mzs);
+          scan.getIntensityValues(intensities);
+          currentNumberOfDataPoints = scan.getNumberOfDataPoints();
         }
         case CENTROID -> {
-          MassList masses = scans[currentScan].getMassList();
+          MassList masses = scan.getMassList();
           if (masses == null) {
-            throw new MissingMassListException(scans[currentScan]);
+            throw new MissingMassListException(scan);
           }
           masses.getMzValues(mzs);
           masses.getIntensityValues(intensities);
           currentNumberOfDataPoints = masses.getNumberOfDataPoints();
         }
       }
-      return scans[currentScan];
+      return scan;
     }
     return null;
   }
@@ -164,7 +177,7 @@ public class ScanDataAccess implements MassSpectrum {
    * @return
    */
   public int getNumberOfScans() {
-    return scans.length;
+    return scans;
   }
 
   /**
@@ -184,7 +197,7 @@ public class ScanDataAccess implements MassSpectrum {
   @Override
   public MassSpectrumType getSpectrumType() {
     return switch (type) {
-      case RAW -> scans[currentScan].getSpectrumType();
+      case RAW -> dataFile.getScan(currentScan).getSpectrumType();
       case CENTROID -> MassSpectrumType.CENTROIDED;
     };
   }

--- a/src/main/java/io/github/mzmine/datamodel/impl/AbstractMassSpectrum.java
+++ b/src/main/java/io/github/mzmine/datamodel/impl/AbstractMassSpectrum.java
@@ -103,7 +103,6 @@ public abstract class AbstractMassSpectrum implements MassSpectrum {
   }
 
   /**
-   * @see Scan#getHighestDataPoint()
    */
   @Override
   public @Nullable Integer getBasePeakIndex() {
@@ -170,7 +169,7 @@ public abstract class AbstractMassSpectrum implements MassSpectrum {
     return Streams.stream(this);
   }
 
-  private class DataPointIterator implements Iterator<DataPoint>, DataPoint {
+  public static class DataPointIterator implements Iterator<DataPoint>, DataPoint {
 
     // We start at -1 so the first call to next() moves us to index 0
     private int cursor = -1;

--- a/src/main/java/io/github/mzmine/datamodel/impl/AbstractMassSpectrum.java
+++ b/src/main/java/io/github/mzmine/datamodel/impl/AbstractMassSpectrum.java
@@ -97,7 +97,7 @@ public abstract class AbstractMassSpectrum implements MassSpectrum {
    * @see io.github.mzmine.datamodel.Scan#
    */
   @Override
-  @Nonnull
+  @Nullable
   public Range<Double> getDataPointMZRange() {
     return mzRange;
   }

--- a/src/main/java/io/github/mzmine/datamodel/impl/MsdkScanWrapper.java
+++ b/src/main/java/io/github/mzmine/datamodel/impl/MsdkScanWrapper.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2006-2020 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package io.github.mzmine.datamodel.impl;
+
+import com.google.common.collect.Range;
+import io.github.msdk.datamodel.IsolationInfo;
+import io.github.msdk.datamodel.MsScan;
+import io.github.mzmine.datamodel.DataPoint;
+import io.github.mzmine.datamodel.MassList;
+import io.github.mzmine.datamodel.MassSpectrumType;
+import io.github.mzmine.datamodel.PolarityType;
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.modules.io.import_mzml_msdk.ConversionUtils;
+import java.util.Iterator;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * @author Robin Schmid (https://github.com/robinschmid)
+ */
+public class MsdkScanWrapper implements Scan {
+
+  // wrap this scan
+  private final MsScan scan;
+
+  public MsdkScanWrapper(MsScan scan) {
+    this.scan = scan;
+  }
+
+  @Override
+  public int getNumberOfDataPoints() {
+    return scan.getNumberOfDataPoints();
+  }
+
+  @Override
+  public MassSpectrumType getSpectrumType() {
+    return ConversionUtils.msdkToMZmineSpectrumType(scan.getSpectrumType());
+  }
+
+  @Override
+  public double[] getMzValues(@Nonnull double[] dst) {
+    return scan.getMzValues(dst);
+  }
+
+  @Override
+  public double[] getIntensityValues(@Nonnull double[] dst) {
+    throw new UnsupportedOperationException(
+        "Unsupported operation. MSDK scan uses float array and the conversion in this method is not efficient.");
+  }
+
+  @Override
+  public double getMzValue(int index) {
+    return scan.getMzValues()[index];
+  }
+
+  @Override
+  public double getIntensityValue(int index) {
+    return scan.getIntensityValues()[index];
+  }
+
+  @Nullable
+  @Override
+  public Double getBasePeakMz() {
+    throw new UnsupportedOperationException(
+        "Unsupported operation. MSDK scan is not supposed to be used here.");
+  }
+
+  @Nullable
+  @Override
+  public Double getBasePeakIntensity() {
+    throw new UnsupportedOperationException(
+        "Unsupported operation. MSDK scan is not supposed to be used here.");
+  }
+
+  @Nullable
+  @Override
+  public Integer getBasePeakIndex() {
+    throw new UnsupportedOperationException(
+        "Unsupported operation. MSDK scan is not supposed to be used here.");
+  }
+
+  @Nullable
+  @Override
+  public Range<Double> getDataPointMZRange() {
+    return scan.getMzRange();
+  }
+
+  @Nullable
+  @Override
+  public Double getTIC() {
+    return Double.valueOf(scan.getTIC());
+  }
+
+  @Override
+  public Stream<DataPoint> stream() {
+    throw new UnsupportedOperationException(
+        "Unsupported operation. MSDK scan is not supposed to be used here.");
+  }
+
+  @Nonnull
+  @Override
+  public Iterator<DataPoint> iterator() {
+    throw new UnsupportedOperationException(
+        "Unsupported operation. MSDK scan is not supposed to be used here.");
+  }
+
+  @Nonnull
+  @Override
+  public RawDataFile getDataFile() {
+    throw new UnsupportedOperationException(
+        "Unsupported operation. MSDK scan is not supposed to be used here.");
+  }
+
+  @Override
+  public int getScanNumber() {
+    return scan.getScanNumber();
+  }
+
+  @Nonnull
+  @Override
+  public String getScanDefinition() {
+    return scan.getScanDefinition();
+  }
+
+  @Override
+  public int getMSLevel() {
+    return scan.getMsLevel();
+  }
+
+  @Override
+  public float getRetentionTime() {
+    return scan.getRetentionTime();
+  }
+
+  @Nonnull
+  @Override
+  public Range<Double> getScanningMZRange() {
+    return scan.getScanningRange();
+  }
+
+  @Override
+  public double getPrecursorMZ() {
+    return scan.getIsolations().stream().findFirst().map(IsolationInfo::getPrecursorMz).orElse(-1d);
+  }
+
+  @Override
+  public int getPrecursorCharge() {
+    return scan.getIsolations().stream().findFirst().map(IsolationInfo::getPrecursorCharge)
+        .orElse(-1);
+  }
+
+  @Nonnull
+  @Override
+  public PolarityType getPolarity() {
+    return ConversionUtils.msdkToMZminePolarityType(scan.getPolarity());
+  }
+
+
+  @Nullable
+  @Override
+  public MassList getMassList() {
+    return null;
+  }
+
+  @Override
+  public void addMassList(@Nonnull MassList massList) {
+
+  }
+}

--- a/src/main/java/io/github/mzmine/datamodel/impl/masslist/ScanPointerMassList.java
+++ b/src/main/java/io/github/mzmine/datamodel/impl/masslist/ScanPointerMassList.java
@@ -1,0 +1,139 @@
+/*
+ *  Copyright 2006-2020 The MZmine Development Team
+ *
+ *  This file is part of MZmine.
+ *
+ *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ *  General Public License as published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
+ *
+ *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ *  Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with MZmine; if not,
+ *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ *  USA
+ */
+
+package io.github.mzmine.datamodel.impl.masslist;
+
+import com.google.common.collect.Range;
+import io.github.mzmine.datamodel.DataPoint;
+import io.github.mzmine.datamodel.MassList;
+import io.github.mzmine.datamodel.MassSpectrumType;
+import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.datamodel.impl.SimpleDataPoint;
+import io.github.mzmine.modules.io.import_all_data_files.AllSpectralDataImportModule;
+import io.github.mzmine.modules.io.import_mzml_msdk.MSDKmzMLImportTask;
+import java.util.Iterator;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * This class points back to the scan to access data. (Useful if the scan is already centroided /
+ * thresholded) See its use in {@link AllSpectralDataImportModule} or in {@link MSDKmzMLImportTask}
+ */
+public class ScanPointerMassList implements MassList {
+
+  // points to this scan data
+  private final Scan scan;
+
+  public ScanPointerMassList(Scan scan) {
+    super();
+    this.scan = scan;
+  }
+
+  /**
+   * Use mzValues and intensityValues constructor
+   */
+  @Override
+  public DataPoint[] getDataPoints() {
+    final double[][] mzIntensity = new double[2][];
+    final int numDp = getNumberOfDataPoints();
+
+    mzIntensity[0] = new double[numDp];
+    mzIntensity[1] = new double[numDp];
+    getMzValues(mzIntensity[0]);
+    getIntensityValues(mzIntensity[1]);
+
+    DataPoint[] dps = new DataPoint[numDp];
+    for (int i = 0; i < numDp; i++) {
+      dps[i] = new SimpleDataPoint(mzIntensity[0][i], mzIntensity[1][i]);
+    }
+
+    return dps;
+  }
+
+  @Override
+  public int getNumberOfDataPoints() {
+    return scan.getNumberOfDataPoints();
+  }
+
+  @Override
+  public MassSpectrumType getSpectrumType() {
+    return scan.getSpectrumType();
+  }
+
+  @Override
+  public double[] getMzValues(@Nonnull double[] dst) {
+    return scan.getMzValues(dst);
+  }
+
+  @Override
+  public double[] getIntensityValues(@Nonnull double[] dst) {
+    return scan.getIntensityValues(dst);
+  }
+
+  @Override
+  public double getMzValue(int index) {
+    return scan.getMzValue(index);
+  }
+
+  @Override
+  public double getIntensityValue(int index) {
+    return scan.getIntensityValue(index);
+  }
+
+  @Nullable
+  @Override
+  public Double getBasePeakMz() {
+    return scan.getBasePeakMz();
+  }
+
+  @Nullable
+  @Override
+  public Double getBasePeakIntensity() {
+    return scan.getBasePeakIntensity();
+  }
+
+  @Nullable
+  @Override
+  public Integer getBasePeakIndex() {
+    return scan.getBasePeakIndex();
+  }
+
+  @Nullable
+  @Override
+  public Range<Double> getDataPointMZRange() {
+    return scan.getDataPointMZRange();
+  }
+
+  @Nullable
+  @Override
+  public Double getTIC() {
+    return scan.getTIC();
+  }
+
+  @Override
+  public Stream<DataPoint> stream() {
+    return scan.stream();
+  }
+
+  @Nonnull
+  @Override
+  public Iterator<DataPoint> iterator() {
+    return scan.iterator();
+  }
+}

--- a/src/main/java/io/github/mzmine/datamodel/impl/masslist/SimpleMassList.java
+++ b/src/main/java/io/github/mzmine/datamodel/impl/masslist/SimpleMassList.java
@@ -39,7 +39,6 @@ public class SimpleMassList extends AbstractStorableSpectrum implements MassList
   /**
    * Use mzValues and intensityValues constructor
    *
-   * @param scan
    * @param storageMemoryMap
    * @param dps
    */

--- a/src/main/java/io/github/mzmine/gui/mainwindow/MainMenu.fxml
+++ b/src/main/java/io/github/mzmine/gui/mainwindow/MainMenu.fxml
@@ -286,7 +286,7 @@
         userData="io.github.mzmine.modules.dataprocessing.filter_neutralloss.NeutralLossFilterModule"/>
       <MenuItem onAction="#runModule" text="mobility-m/z region filter"
         userData="io.github.mzmine.modules.dataprocessing.filter_mobilitymzregionextraction.MobilityMzRegionExtractionModule"/>
-      <MenuItem onAction="#runModule" text="mobility-m/z region filter"
+      <MenuItem onAction="#runModule" text="Assign MS2 to features"
         userData="io.github.mzmine.modules.dataprocessing.filter_groupms2.GroupMS2Module"/>
     </Menu>
 

--- a/src/main/java/io/github/mzmine/gui/mainwindow/MainMenu.fxml
+++ b/src/main/java/io/github/mzmine/gui/mainwindow/MainMenu.fxml
@@ -82,7 +82,8 @@
         </accelerator>
         
       <SeparatorMenuItem/>
-        
+
+      <MenuItem text="MS data (advanced)" onAction="#runModule" userData="io.github.mzmine.modules.io.import_all_data_files.AllSpectralDataImportModule" />
       <MenuItem text="mzML" onAction="#runModule" userData="io.github.mzmine.modules.io.import_mzml_msdk.MSDKmzMLImportModule" />
       <MenuItem text="mzML via jmzml" onAction="#runModule" userData="io.github.mzmine.modules.io.import_mzml_jmzml.MzMLImportModule" />
       <MenuItem text="imzML" onAction="#runModule" userData="io.github.mzmine.modules.io.import_imzml.ImzMLImportModule" />   

--- a/src/main/java/io/github/mzmine/modules/batchmode/BatchModeModule.java
+++ b/src/main/java/io/github/mzmine/modules/batchmode/BatchModeModule.java
@@ -95,7 +95,7 @@ public class BatchModeModule implements MZmineProcessingModule {
       else
         return ExitCode.ERROR;
     } catch (Throwable e) {
-      logger.log(Level.SEVERE, "Error while running batch", e);
+      logger.log(Level.SEVERE, "Error while running batch. "+e.getMessage(), e);
       e.printStackTrace();
       return ExitCode.ERROR;
     }

--- a/src/main/java/io/github/mzmine/modules/batchmode/UnknownModuleNameException.java
+++ b/src/main/java/io/github/mzmine/modules/batchmode/UnknownModuleNameException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2006-2020 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package io.github.mzmine.modules.batchmode;
+
+/**
+ * @author Robin Schmid (https://github.com/robinschmid)
+ */
+public class UnknownModuleNameException extends RuntimeException {
+
+  public UnknownModuleNameException(String methodName) {
+    super("Unknown module name or class path: "+methodName);
+  }
+
+  public UnknownModuleNameException(String methodName, Throwable cause) {
+    super("Unknown module name or class path: "+methodName, cause);
+  }
+
+  public UnknownModuleNameException(Throwable cause) {
+    super("Unknown module name or class path", cause);
+  }
+}

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ADAPChromatogram.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ADAPChromatogram.java
@@ -27,7 +27,6 @@ import io.github.mzmine.datamodel.FeatureStatus;
 import io.github.mzmine.datamodel.IsotopePattern;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.Scan;
-import io.github.mzmine.datamodel.featuredata.FeatureDataUtils;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.impl.SimpleDataPoint;
 import io.github.mzmine.datamodel.impl.SimpleFeatureInformation;
@@ -207,7 +206,6 @@ public class ADAPChromatogram {
   /**
    * This method adds a MzFeature to this Chromatogram. All values of this Chromatogram (rt, m/z,
    * intensity and ranges) are updated on request
-   *
    */
   public void addMzFeature(Scan scanNumber, DataPoint mzValue) {
     double curIntensity;
@@ -572,23 +570,25 @@ public class ADAPChromatogram {
     int nextDetectedScanIndex = 0;
     int currentGap = 0;
     int added;
-    for(allScansIndex=0; allScansIndex<scanNumbers.length; allScansIndex++) {
+    for (allScansIndex = 0; allScansIndex < scanNumbers.length; allScansIndex++) {
       added = 0;
       // was a DP detected in this scan?
-      if(scanNumbers[allScansIndex] == detectedScans[nextDetectedScanIndex]) {
-        if(currentGap >= minGap) {
+      if (scanNumbers[allScansIndex] == detectedScans[nextDetectedScanIndex]) {
+        if (currentGap >= minGap) {
           // add leading zeros before allScansIndex
           for (int i = 1; i <= zeros && i <= currentGap && (allScansIndex - i) >= 0; i++) {
             // add zero data points
-            dataPointsToAdd.put(scanNumbers[allScansIndex-i], new SimpleDataPoint(getMZ(), 0d));
+            dataPointsToAdd.put(scanNumbers[allScansIndex - i], new SimpleDataPoint(getMZ(), 0d));
             added++;
           }
           currentGap -= added;
           // add trailing zeros after last detected
-          if(currentGap>0 && nextDetectedScanInAllIndex>=0) {
-            for (int i = 1; i <= zeros && i <= currentGap && (nextDetectedScanInAllIndex + i) < scanNumbers.length; i++) {
+          if (currentGap > 0 && nextDetectedScanInAllIndex >= 0) {
+            for (int i = 1; i <= zeros && i <= currentGap
+                && (nextDetectedScanInAllIndex + i) < scanNumbers.length; i++) {
               // add zero data points after
-              dataPointsToAdd.put(scanNumbers[nextDetectedScanInAllIndex + i], new SimpleDataPoint(getMZ(), 0d));
+              dataPointsToAdd.put(scanNumbers[nextDetectedScanInAllIndex + i],
+                  new SimpleDataPoint(getMZ(), 0d));
             }
           }
         }
@@ -597,27 +597,30 @@ public class ADAPChromatogram {
         nextDetectedScanInAllIndex = allScansIndex;
 
         // no more detected scans
-        if(nextDetectedScanIndex==detectedScans.length) {
+        if (nextDetectedScanIndex == detectedScans.length) {
           // add trailing zeros after last detected
-            for (int i = 1; i <= zeros && (nextDetectedScanInAllIndex + i) < scanNumbers.length; i++) {
-              // add zero data points after
-              dataPointsToAdd.put(scanNumbers[nextDetectedScanInAllIndex + i], new SimpleDataPoint(getMZ(), 0d));
-            }
+          for (int i = 1; i <= zeros && (nextDetectedScanInAllIndex + i) < scanNumbers.length;
+              i++) {
+            // add zero data points after
+            dataPointsToAdd
+                .put(scanNumbers[nextDetectedScanInAllIndex + i], new SimpleDataPoint(getMZ(), 0d));
+          }
           break;
         }
-      }
-      else {
-        currentGap ++;
+      } else {
+        currentGap++;
       }
 
       // last datapoint
-      if(allScansIndex==scanNumbers.length-1) {
-        if(currentGap >= minGap) {
+      if (allScansIndex == scanNumbers.length - 1) {
+        if (currentGap >= minGap) {
           // add trailing zeros after last detected
-          if(currentGap>0 && nextDetectedScanInAllIndex>=0) {
-            for (int i = 1; i <= zeros && i <= currentGap && (nextDetectedScanInAllIndex + i) < scanNumbers.length; i++) {
+          if (currentGap > 0 && nextDetectedScanInAllIndex >= 0) {
+            for (int i = 1; i <= zeros && i <= currentGap
+                && (nextDetectedScanInAllIndex + i) < scanNumbers.length; i++) {
               // add zero data points after
-              dataPointsToAdd.put(scanNumbers[nextDetectedScanInAllIndex + i], new SimpleDataPoint(getMZ(), 0d));
+              dataPointsToAdd.put(scanNumbers[nextDetectedScanInAllIndex + i],
+                  new SimpleDataPoint(getMZ(), 0d));
             }
           }
         }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ADAPChromatogram.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ADAPChromatogram.java
@@ -60,11 +60,11 @@ public class ADAPChromatogram {
   private SimpleFeatureInformation featureInfo;
 
   // Data file of this chromatogram
-  private RawDataFile dataFile;
+  private final RawDataFile dataFile;
 
   // Data points of the chromatogram (map of scan number -> m/z feature)
   // private Hashtable<Integer, DataPoint> dataPointsMap;
-  private TreeMap<Scan, DataPoint> dataPointsMap;
+  private final TreeMap<Scan, DataPoint> dataPointsMap;
 
   // Chromatogram m/z, RT, height, area. The mz value will be the highest points mz value
   private double mz, rt, height, area, weightedMz;
@@ -108,7 +108,7 @@ public class ADAPChromatogram {
   private double highPointMZ = 0;
 
   // full stack of scans
-  private final Scan scanNumbers[];
+  private final Scan[] scanNumbers;
 
   public int tmp_see_same_scan_count = 0;
 
@@ -124,9 +124,9 @@ public class ADAPChromatogram {
 
     rawDataPointsRTRange = dataFile.getDataRTRange(1);
 
-    dataPointsMap = new TreeMap<Scan, DataPoint>();
-    buildingSegment = new Vector<Scan>();
-    chromScanList = new ArrayList<Scan>();
+    dataPointsMap = new TreeMap<>();
+    buildingSegment = new Vector<>();
+    chromScanList = new ArrayList<>();
   }
 
   public double getHighPointMZ() {
@@ -137,21 +137,19 @@ public class ADAPChromatogram {
     highPointMZ = toSet;
   }
 
-  public List getIntensitiesForCDFOut() {
+  public List<Double> getIntensitiesForCDFOut() {
     // Need all scans with no intensity to be set to zero
-
-    List intensityList = new ArrayList();
+    List<Double> intensityList = new ArrayList<>();
 
     for (int curScanNum = 0; curScanNum < scanNumbers.length; curScanNum++) {
-      if (dataPointsMap.get(curScanNum) == null) {
+      DataPoint dp = dataPointsMap.get(scanNumbers[curScanNum]);
+      if (dp == null) {
         intensityList.add(0.0);
       } else {
-        intensityList.add(dataPointsMap.get(curScanNum).getIntensity());
+        intensityList.add(dp.getIntensity());
       }
     }
-
     return intensityList;
-
   }
 
   public Collection<DataPoint> getDataPoints() {
@@ -169,7 +167,7 @@ public class ADAPChromatogram {
 
     int bestCount = 0;
     int curCount = 0;
-    Scan lastScanNum = null;
+    Scan lastScanNum;
     int scanListLength = chromScanList.size();
 
     Scan curScanNum;
@@ -209,7 +207,6 @@ public class ADAPChromatogram {
    * This method adds a MzFeature to this Chromatogram. All values of this Chromatogram (rt, m/z,
    * intensity and ranges) are updated on request
    *
-   * @param mzValue
    */
   public void addMzFeature(Scan scanNumber, DataPoint mzValue) {
     double curIntensity;
@@ -437,7 +434,7 @@ public class ADAPChromatogram {
       // retention time
       float scanRt = allScanNumbers[i].getRetentionTime();
 
-      if ((mzFeature != null) || (mzFeature.getIntensity() != 0.0)) {
+      if (mzFeature.getIntensity() != 0.0) {
         if (rawDataPointsRTRange == null) {
           rawDataPointsRTRange = Range.singleton(scanRt);
         } else {
@@ -582,7 +579,6 @@ public class ADAPChromatogram {
     assert minGap >= zeros;
 
     int allScansIndex = 0; // contains the index of the next dp after a gap
-    int lastScanIndex = 0; // contains the index of the last dp before a gap
     Map<Scan, DataPoint> dataPointsToAdd = new HashMap<>();
 
     Scan[] detectedScans = dataPointsMap.keySet().toArray(Scan[]::new);
@@ -591,7 +587,7 @@ public class ADAPChromatogram {
     int nextDetectedScanInAllIndex = -1;
     int nextDetectedScanIndex = 0;
     int currentGap = 0;
-    int added = 0;
+    int added;
     for(allScansIndex=0; allScansIndex<scanNumbers.length; allScansIndex++) {
       added = 0;
       // was a DP detected in this scan?
@@ -670,6 +666,6 @@ public class ADAPChromatogram {
 //    }
 //
 //    dataPointsMap.putAll(dataPointsToAdd);
-     logger.info(() -> String.format("mz: %f\t Added %d data points", getMZ(), dataPointsToAdd.size()));
+//     logger.info(() -> String.format("mz: %f\t Added %d data points", getMZ(), dataPointsToAdd.size()));
   }
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_groupms2/GroupMS2Task.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_groupms2/GroupMS2Task.java
@@ -19,6 +19,7 @@
 package io.github.mzmine.modules.dataprocessing.filter_groupms2;
 
 import com.google.common.collect.Range;
+import io.github.mzmine.datamodel.FeatureStatus;
 import io.github.mzmine.datamodel.Frame;
 import io.github.mzmine.datamodel.ImsMsMsInfo;
 import io.github.mzmine.datamodel.MZmineProject;
@@ -30,6 +31,7 @@ import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
+import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
 import io.github.mzmine.datamodel.features.types.ImsMsMsInfoType;
 import io.github.mzmine.parameters.ParameterSet;
@@ -141,7 +143,7 @@ public class GroupMS2Task extends AbstractTask {
           == io.github.mzmine.datamodel.MobilityType.TIMS) {
         processTimsFeature((ModularFeature) f);
       }
-      else {
+      else if(!f.getFeatureStatus().equals(FeatureStatus.UNKNOWN)) {
         RawDataFile raw = f.getRawDataFile();
         float frt = f.getRT();
         double fmz = f.getMZ();

--- a/src/main/java/io/github/mzmine/modules/io/import_all_data_files/AdvancedSpectraImportParameters.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_all_data_files/AdvancedSpectraImportParameters.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2006-2020 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package io.github.mzmine.modules.io.import_all_data_files;
+
+import io.github.mzmine.modules.dataprocessing.featdet_massdetection.MassDetectionParameters;
+import io.github.mzmine.parameters.Parameter;
+import io.github.mzmine.parameters.impl.SimpleParameterSet;
+import io.github.mzmine.parameters.parametertypes.submodules.OptionalModuleParameter;
+
+public class AdvancedSpectraImportParameters extends SimpleParameterSet {
+
+  public static final OptionalModuleParameter<MassDetectionSubParameters> msMassDetection = new OptionalModuleParameter<>(
+      "MS1 mass detection (ADVANCED)",
+      "Caution: Advanced option that applies mass detection (centroiding+thresholding) directly to imported scans (see help). Positive: Lower memory consumption; Caution: All processing steps will directly change the underlying data, with no way of retrieving raw data or inial results apart from the current state.",
+      new MassDetectionSubParameters(), true);
+
+  public static final OptionalModuleParameter<MassDetectionSubParameters> ms2MassDetection = new OptionalModuleParameter<>(
+      "MS2 mass detection (ADVANCED)",
+      "Caution: Advanced option that applies mass detection (centroiding+thresholding) directly to imported scans (see help). Positive: Lower memory consumption; Caution: All processing steps will directly change the underlying data, with no way of retrieving raw data or inial results apart from the current state.",
+      new MassDetectionSubParameters(), true);
+
+  public AdvancedSpectraImportParameters() {
+    super(new Parameter[]{msMassDetection, ms2MassDetection});
+  }
+
+}

--- a/src/main/java/io/github/mzmine/modules/io/import_all_data_files/AdvancedSpectraImportParameters.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_all_data_files/AdvancedSpectraImportParameters.java
@@ -38,11 +38,11 @@ public class AdvancedSpectraImportParameters extends SimpleParameterSet {
           new RecursiveMassDetector(), new WaveletMassDetector()};
 
   public static final OptionalParameter<ModuleComboParameter<MassDetector>> msMassDetection =
-      new OptionalParameter<>(new ModuleComboParameter<MassDetector>("MS1 detector",
+      new OptionalParameter<>(new ModuleComboParameter<MassDetector>("MS1 detector (Advanced)",
           "Algorithm to use on MS1 scans for mass detection and its parameters", massDetectors));
 
   public static final OptionalParameter<ModuleComboParameter<MassDetector>> ms2MassDetection =
-      new OptionalParameter<>(new ModuleComboParameter<MassDetector>("MS2 detector",
+      new OptionalParameter<>(new ModuleComboParameter<MassDetector>("MS2 detector (Advanced)",
           "Algorithm to use on MS2 scans for mass detection and its parameters", massDetectors));
 
   public AdvancedSpectraImportParameters() {

--- a/src/main/java/io/github/mzmine/modules/io/import_all_data_files/AdvancedSpectraImportParameters.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_all_data_files/AdvancedSpectraImportParameters.java
@@ -18,21 +18,32 @@
 package io.github.mzmine.modules.io.import_all_data_files;
 
 import io.github.mzmine.modules.dataprocessing.featdet_massdetection.MassDetectionParameters;
+import io.github.mzmine.modules.dataprocessing.featdet_massdetection.MassDetector;
+import io.github.mzmine.modules.dataprocessing.featdet_massdetection.centroid.CentroidMassDetector;
+import io.github.mzmine.modules.dataprocessing.featdet_massdetection.exactmass.ExactMassDetector;
+import io.github.mzmine.modules.dataprocessing.featdet_massdetection.localmaxima.LocalMaxMassDetector;
+import io.github.mzmine.modules.dataprocessing.featdet_massdetection.recursive.RecursiveMassDetector;
+import io.github.mzmine.modules.dataprocessing.featdet_massdetection.wavelet.WaveletMassDetector;
 import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
+import io.github.mzmine.parameters.parametertypes.ModuleComboParameter;
+import io.github.mzmine.parameters.parametertypes.OptionalParameter;
 import io.github.mzmine.parameters.parametertypes.submodules.OptionalModuleParameter;
 
 public class AdvancedSpectraImportParameters extends SimpleParameterSet {
 
-  public static final OptionalModuleParameter<MassDetectionSubParameters> msMassDetection = new OptionalModuleParameter<>(
-      "MS1 mass detection (ADVANCED)",
-      "Caution: Advanced option that applies mass detection (centroiding+thresholding) directly to imported scans (see help). Positive: Lower memory consumption; Caution: All processing steps will directly change the underlying data, with no way of retrieving raw data or inial results apart from the current state.",
-      new MassDetectionSubParameters(), true);
 
-  public static final OptionalModuleParameter<MassDetectionSubParameters> ms2MassDetection = new OptionalModuleParameter<>(
-      "MS2 mass detection (ADVANCED)",
-      "Caution: Advanced option that applies mass detection (centroiding+thresholding) directly to imported scans (see help). Positive: Lower memory consumption; Caution: All processing steps will directly change the underlying data, with no way of retrieving raw data or inial results apart from the current state.",
-      new MassDetectionSubParameters(), true);
+  public static final MassDetector massDetectors[] =
+      {new CentroidMassDetector(), new ExactMassDetector(), new LocalMaxMassDetector(),
+          new RecursiveMassDetector(), new WaveletMassDetector()};
+
+  public static final OptionalParameter<ModuleComboParameter<MassDetector>> msMassDetection =
+      new OptionalParameter<>(new ModuleComboParameter<MassDetector>("MS1 detector",
+          "Algorithm to use on MS1 scans for mass detection and its parameters", massDetectors));
+
+  public static final OptionalParameter<ModuleComboParameter<MassDetector>> ms2MassDetection =
+      new OptionalParameter<>(new ModuleComboParameter<MassDetector>("MS2 detector",
+          "Algorithm to use on MS2 scans for mass detection and its parameters", massDetectors));
 
   public AdvancedSpectraImportParameters() {
     super(new Parameter[]{msMassDetection, ms2MassDetection});

--- a/src/main/java/io/github/mzmine/modules/io/import_all_data_files/AllSpectralDataImportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_all_data_files/AllSpectralDataImportModule.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2006-2020 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package io.github.mzmine.modules.io.import_all_data_files;
+
+import com.google.common.base.Strings;
+import io.github.mzmine.datamodel.IMSRawDataFile;
+import io.github.mzmine.datamodel.ImagingRawDataFile;
+import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.modules.MZmineModuleCategory;
+import io.github.mzmine.modules.MZmineProcessingModule;
+import io.github.mzmine.modules.io.import_bruker_tdf.TDFImportTask;
+import io.github.mzmine.modules.io.import_icpms_csv.IcpMsCVSImportTask;
+import io.github.mzmine.modules.io.import_imzml.ImzMLImportTask;
+import io.github.mzmine.modules.io.import_mzml_msdk.MSDKmzMLImportTask;
+import io.github.mzmine.modules.io.import_mzxml.MzXMLImportTask;
+import io.github.mzmine.modules.io.import_netcdf.NetCDFImportTask;
+import io.github.mzmine.modules.io.import_thermo_raw.ThermoRawImportTask;
+import io.github.mzmine.modules.io.import_waters_raw.WatersRawImportTask;
+import io.github.mzmine.modules.io.import_zip.ZipImportTask;
+import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.taskcontrol.Task;
+import io.github.mzmine.util.ExitCode;
+import io.github.mzmine.util.MemoryMapStorage;
+import io.github.mzmine.util.RawDataFileType;
+import io.github.mzmine.util.RawDataFileTypeDetector;
+import io.github.mzmine.util.RawDataFileUtils;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+import javax.annotation.Nonnull;
+
+/**
+ * Raw data import module
+ */
+public class AllSpectralDataImportModule implements MZmineProcessingModule {
+
+  private static final Logger logger = Logger
+      .getLogger(AllSpectralDataImportModule.class.getName());
+
+  private static final String MODULE_NAME = "Import MS data";
+  private static final String MODULE_DESCRIPTION = "This module combines the import of different MS data formats and provides advanced options";
+
+  @Override
+  public @Nonnull
+  String getName() {
+    return MODULE_NAME;
+  }
+
+  @Nonnull
+  @Override
+  public String getDescription() {
+    return MODULE_DESCRIPTION;
+  }
+
+  @Nonnull
+  @Override
+  public MZmineModuleCategory getModuleCategory() {
+    return MZmineModuleCategory.RAWDATA;
+  }
+
+  @Nonnull
+  @Override
+  public Class<? extends ParameterSet> getParameterSetClass() {
+    return AllSpectralDataImportParameters.class;
+  }
+
+  @Nonnull
+  @Override
+  public ExitCode runModule(final @Nonnull MZmineProject project, @Nonnull ParameterSet parameters,
+      @Nonnull Collection<Task> tasks) {
+
+    File[] fileNames = parameters.getParameter(AllSpectralDataImportParameters.fileNames)
+        .getValue();
+    boolean useAdvancedOptions = parameters
+        .getParameter(AllSpectralDataImportParameters.advancedImport)
+        .getValue();
+    AdvancedSpectraImportParameters advancedParam = useAdvancedOptions ? parameters
+        .getParameter(AllSpectralDataImportParameters.advancedImport)
+        .getEmbeddedParameters() : null;
+
+    if (Arrays.asList(fileNames).contains(null)) {
+      logger.warning("List of filenames contains null");
+      return ExitCode.ERROR;
+    }
+
+    // Find common prefix in raw file names if in GUI mode
+    String commonPrefix = RawDataFileUtils.askToRemoveCommonPrefix(fileNames);
+
+    // one storage for all files imported in the same task as they are typically analyzed together
+    final MemoryMapStorage storage = MemoryMapStorage.forRawDataFile();
+
+    for (int i = 0; i < fileNames.length; i++) {
+
+      if ((!fileNames[i].exists()) || (!fileNames[i].canRead())) {
+        MZmineCore.getDesktop().displayErrorMessage("Cannot read file " + fileNames[i]);
+        logger.warning("Cannot read file " + fileNames[i]);
+        return ExitCode.ERROR;
+      }
+
+      // Set the new name by removing the common prefix
+      String newName;
+      if (!Strings.isNullOrEmpty(commonPrefix)) {
+        final String regex = "^" + Pattern.quote(commonPrefix);
+        newName = fileNames[i].getName().replaceFirst(regex, "");
+      } else {
+        newName = fileNames[i].getName();
+      }
+
+      RawDataFileType fileType = RawDataFileTypeDetector.detectDataFileType(fileNames[i]);
+      logger.finest("File " + fileNames[i] + " type detected as " + fileType);
+
+      try {
+        RawDataFile newMZmineFile = createDataFile(fileType, newName, storage);
+
+        final Task newTask = useAdvancedOptions && advancedParam!=null?
+            createAdvancedTask(fileType, project, fileNames[i], newMZmineFile, advancedParam) :
+            createTask(fileType, project, fileNames[i], newMZmineFile);
+
+        // add task to list
+        if (newTask != null) {
+          tasks.add(newTask);
+        }
+      } catch (IOException e) {
+        e.printStackTrace();
+        MZmineCore.getDesktop().displayErrorMessage("Could not create a new temporary file " + e);
+        logger.log(Level.SEVERE, "Could not create a new temporary file ", e);
+        return ExitCode.ERROR;
+      }
+    }
+
+    return ExitCode.OK;
+  }
+
+  private Task createTask(RawDataFileType fileType, MZmineProject project, File file,
+      RawDataFile newMZmineFile) {
+    return switch (fileType) {
+      // imaging
+      case IMZML -> new ImzMLImportTask(project, file, (ImagingRawDataFile) newMZmineFile);
+      case MZML_IMS -> new ImzMLImportTask(project, file, (ImagingRawDataFile) newMZmineFile);
+      // IMS
+      case BRUKER_TDF -> new TDFImportTask(project, file, (IMSRawDataFile) newMZmineFile);
+      // MS
+      case MZML -> new MSDKmzMLImportTask(project, file, newMZmineFile);
+      case MZXML -> new MzXMLImportTask(project, file, newMZmineFile);
+      case MZDATA -> new MzXMLImportTask(project, file, newMZmineFile);
+      case NETCDF -> new NetCDFImportTask(project, file, newMZmineFile);
+      case WATERS_RAW -> new WatersRawImportTask(project, file, newMZmineFile);
+      case THERMO_RAW -> new ThermoRawImportTask(project, file, newMZmineFile);
+      case ICPMSMS_CSV -> new IcpMsCVSImportTask(project, file, newMZmineFile);
+      default -> throw new IllegalStateException("Unexpected value: " + fileType);
+    };
+  }
+  private Task createAdvancedTask(RawDataFileType fileType, MZmineProject project, File file,
+      RawDataFile newMZmineFile, AdvancedSpectraImportParameters advancedParam) {
+    return switch (fileType) {
+      // MS
+      case MZML -> new MSDKmzMLImportTask(project, file, newMZmineFile, advancedParam);
+      case MZXML -> new MzXMLImportTask(project, file, newMZmineFile, advancedParam);
+      default -> throw new IllegalStateException("Advanced task not supported for data type: " + fileType);
+    };
+  }
+
+  private RawDataFile createDataFile(RawDataFileType fileType, String newName,
+      MemoryMapStorage storage) throws IOException {
+    return switch (fileType) {
+      case MZML, MZXML, MZDATA, THERMO_RAW, WATERS_RAW, NETCDF, GZIP, ICPMSMS_CSV -> MZmineCore
+          .createNewFile(newName, storage);
+      case IMZML, MZML_IMS -> MZmineCore.createNewImagingFile(newName, storage);
+      case BRUKER_TDF -> MZmineCore.createNewIMSFile(newName, storage);
+      default -> throw new IllegalStateException("Unexpected data type: " + fileType);
+    };
+  }
+
+}

--- a/src/main/java/io/github/mzmine/modules/io/import_all_data_files/AllSpectralDataImportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_all_data_files/AllSpectralDataImportModule.java
@@ -114,11 +114,11 @@ public class AllSpectralDataImportModule implements MZmineProcessingModule {
     // one storage for all files imported in the same task as they are typically analyzed together
     final MemoryMapStorage storage = MemoryMapStorage.forRawDataFile();
 
-    for (int i = 0; i < fileNames.length; i++) {
+    for (File fileName : fileNames) {
 
-      if ((!fileNames[i].exists()) || (!fileNames[i].canRead())) {
-        MZmineCore.getDesktop().displayErrorMessage("Cannot read file " + fileNames[i]);
-        logger.warning("Cannot read file " + fileNames[i]);
+      if ((!fileName.exists()) || (!fileName.canRead())) {
+        MZmineCore.getDesktop().displayErrorMessage("Cannot read file " + fileName);
+        logger.warning("Cannot read file " + fileName);
         return ExitCode.ERROR;
       }
 
@@ -126,20 +126,20 @@ public class AllSpectralDataImportModule implements MZmineProcessingModule {
       String newName;
       if (!Strings.isNullOrEmpty(commonPrefix)) {
         final String regex = "^" + Pattern.quote(commonPrefix);
-        newName = fileNames[i].getName().replaceFirst(regex, "");
+        newName = fileName.getName().replaceFirst(regex, "");
       } else {
-        newName = fileNames[i].getName();
+        newName = fileName.getName();
       }
 
-      RawDataFileType fileType = RawDataFileTypeDetector.detectDataFileType(fileNames[i]);
-      logger.finest("File " + fileNames[i] + " type detected as " + fileType);
+      RawDataFileType fileType = RawDataFileTypeDetector.detectDataFileType(fileName);
+      logger.finest("File " + fileName + " type detected as " + fileType);
 
       try {
         RawDataFile newMZmineFile = createDataFile(fileType, newName, storage);
 
         final Task newTask = useAdvancedOptions && advancedParam != null ?
-            createAdvancedTask(fileType, project, fileNames[i], newMZmineFile, advancedParam) :
-            createTask(fileType, project, fileNames[i], newMZmineFile);
+            createAdvancedTask(fileType, project, fileName, newMZmineFile, advancedParam) :
+            createTask(fileType, project, fileName, newMZmineFile);
 
         // add task to list
         if (newTask != null) {
@@ -202,7 +202,7 @@ public class AllSpectralDataImportModule implements MZmineProcessingModule {
     logger.warning("Advanced processing is not available for MS data type: " + fileType.toString()
         + " and file " + file.getAbsolutePath());
     // create wrapped task to apply import and mass detection
-    return new AllSpectralDataImportTask(
+    return new MsDataImportAndMassDetectWrapperTask(
         getMassListStorage(), newMZmineFile, createTask(fileType, project, file, newMZmineFile),
         advancedParam);
   }

--- a/src/main/java/io/github/mzmine/modules/io/import_all_data_files/AllSpectralDataImportParameters.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_all_data_files/AllSpectralDataImportParameters.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2006-2020 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package io.github.mzmine.modules.io.import_all_data_files;
+
+import io.github.mzmine.modules.dataprocessing.featdet_massdetection.MassDetectionParameters;
+import io.github.mzmine.parameters.Parameter;
+import io.github.mzmine.parameters.dialogs.ParameterSetupDialog;
+import io.github.mzmine.parameters.impl.SimpleParameterSet;
+import io.github.mzmine.parameters.parametertypes.BooleanParameter;
+import io.github.mzmine.parameters.parametertypes.filenames.FileNamesParameter;
+import io.github.mzmine.parameters.parametertypes.submodules.OptionalModuleParameter;
+import io.github.mzmine.util.ExitCode;
+import java.io.File;
+import java.util.List;
+import javafx.application.Platform;
+import javafx.stage.FileChooser;
+import javafx.stage.FileChooser.ExtensionFilter;
+
+public class AllSpectralDataImportParameters extends SimpleParameterSet {
+
+  private static final List<ExtensionFilter> extensions = List.of( //
+      new ExtensionFilter("MS data", "*.mzML", "*.mzml", "*.mzXML", "*.mzxml",
+          "*.imzML", "*.imzml", "*.d", "*.raw", "*.RAW", "*.mzData", "*.mzdata"), //
+      new ExtensionFilter("mzML MS data", "*.mzML", "*.mzml"), //
+      new ExtensionFilter("mzXML MS data", "*.mzXML", "*.mzxml"), //
+      new ExtensionFilter("imzML MS imaging data", "*.imzML", "*.imzml"), //
+      new ExtensionFilter("Bruker tdf files", "*.d"), //
+      new ExtensionFilter("Thermo RAW files", "*.raw", "*.RAW"), //
+      new ExtensionFilter("Waters RAW folders", "*.raw", "*.RAW"), //
+      new ExtensionFilter("mzData MS data", "*.mzData", "*.mzdata"), //
+      new ExtensionFilter("All files", "*.*") //
+  );
+
+
+  private static final List<ExtensionFilter> extensionsFolders = List.of( //
+      new ExtensionFilter("Bruker tdf files", "*.d"), //
+      new ExtensionFilter("Waters RAW folders", "*.raw"), //
+      new ExtensionFilter("All files", "*.*") //
+  );
+
+  public static final FileNamesParameter fileNames =
+      new FileNamesParameter("File names", "", extensions);
+
+  public static final OptionalModuleParameter<AdvancedSpectraImportParameters> advancedImport = new OptionalModuleParameter<>(
+      "Advanced import", "Caution: Advanced option that applies mass detection (centroiding+thresholding) directly to imported scans (see help). Positive: Lower memory consumption; Caution: All processing steps will directly change the underlying data, with no way of retrieving raw data or inial results apart from the current state.", new AdvancedSpectraImportParameters(), true
+  );
+
+  public AllSpectralDataImportParameters() {
+    super(new Parameter[]{fileNames, advancedImport});
+  }
+
+}

--- a/src/main/java/io/github/mzmine/modules/io/import_all_data_files/AllSpectralDataImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_all_data_files/AllSpectralDataImportTask.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2006-2020 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package io.github.mzmine.modules.io.import_all_data_files;
+
+import com.google.common.collect.Range;
+import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.MassSpectrumType;
+import io.github.mzmine.datamodel.PolarityType;
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.datamodel.impl.SimpleScan;
+import io.github.mzmine.taskcontrol.AbstractTask;
+import io.github.mzmine.taskcontrol.TaskStatus;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Scanner;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class AllSpectralDataImportTask extends AbstractTask {
+
+  private Logger logger = Logger.getLogger(
+      AllSpectralDataImportTask.class.getName());
+
+  protected String dataSource;
+  private File file;
+  private MZmineProject project;
+  private RawDataFile newMZmineFile;
+  private RawDataFile finalRawDataFile;
+
+  private int totalScans, parsedScans;
+
+  public AllSpectralDataImportTask(MZmineProject project, File fileToOpen, RawDataFile newMZmineFile) {
+    super(null); // storage in raw data file
+    this.project = project;
+    this.file = fileToOpen;
+    this.newMZmineFile = newMZmineFile;
+  }
+
+  @Override
+  public String getTaskDescription() {
+    return null;
+  }
+
+  @Override
+  public double getFinishedPercentage() {
+    return 0;
+  }
+
+  @Override
+  public void run() {
+    setStatus(TaskStatus.PROCESSING);
+    Scanner scanner;
+
+    logger.setLevel(Level.ALL);
+
+    try {
+      scanner = new Scanner(file);
+
+      dataSource = getFileName(scanner);
+      if (dataSource == null) {
+        setErrorMessage("Could not open data file " + file.getAbsolutePath());
+        setStatus(TaskStatus.ERROR);
+        return;
+      }
+      logger.info("opening raw file " + dataSource);
+
+      String acquisitionDate = getAcqusitionDate(scanner);
+      if (acquisitionDate == null) {
+        setErrorMessage("Could not find acquisition date in file " + file.getAbsolutePath());
+        setStatus(TaskStatus.ERROR);
+        return;
+      }
+
+      logger.info("Date of acquisition " + acquisitionDate);
+
+      // scanner.useDelimiter(",");
+
+      List<String> mzsList = new ArrayList<String>();
+      String mstype = "";
+      String ions = "";
+      while (scanner.hasNextLine()) {
+        String line = scanner.nextLine();
+        logger.fine("checking line: " + line + " for 'Time'...");
+        if (line.startsWith("Time")) {
+          String[] axes = line.split(",");
+          logger.fine("Found axes" + Arrays.toString(axes));
+          for (int i = 1; i < axes.length; i++) {
+            String axis = axes[i];
+            ions += axis + ", ";
+            if (axis.contains("->")) {
+              mstype = "MS/MS";
+              logger.fine("axis " + axis + " is an ms^2 scan");
+              String mz = axis.substring(axis.indexOf("-> ") + 3);
+              mz.trim();
+              logger.fine("Axis " + axis + " was scanned at m/z = '" + mz + "'");
+              mzsList.add(mz);
+            } else {
+              String mz = axis.replaceAll("[^0-9]", "");
+              logger.fine("axis " + axis + " was scanned at " + mz);
+              mzsList.add(mz);
+            }
+          }
+          break;
+        }
+      }
+
+      double[] mzValues = new double[mzsList.size()];
+      for (int i = 0; i < mzsList.size(); i++)
+        mzValues[i] = Integer.valueOf(mzsList.get(i));
+
+      Range<Double> mzRange = Range.closed(mzValues[0] - 10, mzValues[1] + 10);
+
+      int scanNumber = 1;
+
+      while (scanner.hasNextLine()) {
+        String line = scanner.nextLine();
+        if (line == null || line.trim().equals(""))
+          continue;
+        String[] columns = line.split(",");
+        if (columns == null || columns.length != mzValues.length + 1)
+          continue;
+
+        float rt = (float) (Double.valueOf(columns[0]) / 60);
+
+        double intensityValues[] = new double[mzValues.length];
+        for (int i = 0; i < intensityValues.length; i++) {
+          String intensity = columns[i + 1];
+          intensityValues[i] = Double.valueOf(intensity);
+        }
+
+        Scan scan = new SimpleScan(newMZmineFile, scanNumber, 1, rt, 0.0, 1, mzValues,
+            intensityValues, MassSpectrumType.CENTROIDED, PolarityType.POSITIVE,
+            "ICP-" + mstype + " " + ions.substring(0, ions.length() - 2), mzRange);
+
+        newMZmineFile.addScan(scan);
+        scanNumber++;
+      }
+
+      project.addFile(newMZmineFile);
+
+    } catch (Exception e) {
+      setErrorMessage(e.getMessage());
+      setStatus(TaskStatus.ERROR);
+      return;
+    }
+
+    this.setStatus(TaskStatus.FINISHED);
+  }
+
+  private @Nullable String getFileName(@Nonnull Scanner scanner) {
+    String path = null;
+    while (scanner.hasNextLine()) {
+      String line = scanner.nextLine();
+      if (line.contains(":") && line.contains("\\")) {
+        path = line;
+        return path;
+      }
+    }
+    return path;
+  }
+
+  private @Nullable String getAcqusitionDate(@Nonnull Scanner scanner) {
+    String acquisitionDate = null;
+
+    while (scanner.hasNextLine()) {
+      String line = scanner.nextLine();
+      if (line.startsWith("Acquired")) {
+        int begin = line.indexOf(":") + 2;
+        line.subSequence(begin, begin + (new String("00/00/0000 00:00:00")).length());
+        return line;
+      }
+    }
+    return acquisitionDate;
+  }
+
+}

--- a/src/main/java/io/github/mzmine/modules/io/import_all_data_files/AllSpectralDataImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_all_data_files/AllSpectralDataImportTask.java
@@ -39,7 +39,6 @@ public class AllSpectralDataImportTask extends AbstractTask {
 
   private final RawDataFile newMZmineFile;
   private final AbstractTask importTask;
-  private final AdvancedSpectraImportParameters advancedParam;
   private MZmineProcessingStep<MassDetector> ms1Detector = null;
   private MZmineProcessingStep<MassDetector> ms2Detector = null;
   private Logger logger = Logger.getLogger(
@@ -65,7 +64,6 @@ public class AllSpectralDataImportTask extends AbstractTask {
     super(storageMassLists);
     this.newMZmineFile = newMZmineFile;
     this.importTask = importTask;
-    this.advancedParam = advancedParam;
 
     if (advancedParam.getParameter(AdvancedSpectraImportParameters.msMassDetection).getValue()) {
       this.ms1Detector = advancedParam.getParameter(AdvancedSpectraImportParameters.msMassDetection)

--- a/src/main/java/io/github/mzmine/modules/io/import_all_data_files/MassDetectionSubParameters.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_all_data_files/MassDetectionSubParameters.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2006-2020 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package io.github.mzmine.modules.io.import_all_data_files;
+
+import io.github.mzmine.datamodel.IMSRawDataFile;
+import io.github.mzmine.datamodel.MassSpectrumType;
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.modules.dataprocessing.featdet_massdetection.MassDetector;
+import io.github.mzmine.modules.dataprocessing.featdet_massdetection.centroid.CentroidMassDetector;
+import io.github.mzmine.modules.dataprocessing.featdet_massdetection.exactmass.ExactMassDetector;
+import io.github.mzmine.modules.dataprocessing.featdet_massdetection.localmaxima.LocalMaxMassDetector;
+import io.github.mzmine.modules.dataprocessing.featdet_massdetection.recursive.RecursiveMassDetector;
+import io.github.mzmine.modules.dataprocessing.featdet_massdetection.wavelet.WaveletMassDetector;
+import io.github.mzmine.parameters.Parameter;
+import io.github.mzmine.parameters.impl.IonMobilitySupport;
+import io.github.mzmine.parameters.impl.SimpleParameterSet;
+import io.github.mzmine.parameters.parametertypes.ModuleComboParameter;
+import io.github.mzmine.parameters.parametertypes.OptionalParameter;
+import io.github.mzmine.parameters.parametertypes.filenames.FileNameParameter;
+import io.github.mzmine.parameters.parametertypes.filenames.FileSelectionType;
+import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesParameter;
+import io.github.mzmine.parameters.parametertypes.selectors.ScanSelection;
+import io.github.mzmine.parameters.parametertypes.selectors.ScanSelectionParameter;
+import io.github.mzmine.util.ExitCode;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.logging.Logger;
+import javafx.scene.control.ButtonType;
+
+/**
+ * @author Robin Schmid (https://github.com/robinschmid)
+ */
+public class MassDetectionSubParameters extends SimpleParameterSet {
+
+  private final Logger logger = Logger.getLogger(this.getClass().getName());
+
+  public static final MassDetector massDetectors[] =
+      {new CentroidMassDetector(), new ExactMassDetector(), new LocalMaxMassDetector(),
+          new RecursiveMassDetector(), new WaveletMassDetector()};
+
+  public static final ScanSelectionParameter scanSelection =
+      new ScanSelectionParameter(new ScanSelection());
+
+  public static final ModuleComboParameter<MassDetector> massDetector =
+      new ModuleComboParameter<MassDetector>("Mass detector",
+          "Algorithm to use for mass detection and its parameters", massDetectors);
+
+  public MassDetectionSubParameters() {
+    super(new Parameter[]{scanSelection, massDetector});
+  }
+
+  @Override
+  public IonMobilitySupport getIonMobilitySupport() {
+    return IonMobilitySupport.SUPPORTED;
+  }
+}

--- a/src/main/java/io/github/mzmine/modules/io/import_all_data_files/MassDetectionSubParameters.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_all_data_files/MassDetectionSubParameters.java
@@ -55,15 +55,12 @@ public class MassDetectionSubParameters extends SimpleParameterSet {
       {new CentroidMassDetector(), new ExactMassDetector(), new LocalMaxMassDetector(),
           new RecursiveMassDetector(), new WaveletMassDetector()};
 
-  public static final ScanSelectionParameter scanSelection =
-      new ScanSelectionParameter(new ScanSelection());
-
   public static final ModuleComboParameter<MassDetector> massDetector =
       new ModuleComboParameter<MassDetector>("Mass detector",
           "Algorithm to use for mass detection and its parameters", massDetectors);
 
   public MassDetectionSubParameters() {
-    super(new Parameter[]{scanSelection, massDetector});
+    super(new Parameter[]{massDetector});
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/modules/io/import_all_data_files/MsDataImportAndMassDetectWrapperTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_all_data_files/MsDataImportAndMassDetectWrapperTask.java
@@ -24,7 +24,6 @@ import io.github.mzmine.datamodel.data_access.ScanDataAccess;
 import io.github.mzmine.datamodel.impl.masslist.SimpleMassList;
 import io.github.mzmine.modules.MZmineProcessingStep;
 import io.github.mzmine.modules.dataprocessing.featdet_massdetection.MassDetector;
-import io.github.mzmine.parameters.parametertypes.selectors.ScanSelection;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.MemoryMapStorage;
@@ -35,14 +34,14 @@ import javax.annotation.Nonnull;
  * This import task wraps other data import tasks that do not support application of mass detection
  * during data import. This task calls the data import and applies mass detection afterwards.
  */
-public class AllSpectralDataImportTask extends AbstractTask {
+public class MsDataImportAndMassDetectWrapperTask extends AbstractTask {
 
   private final RawDataFile newMZmineFile;
   private final AbstractTask importTask;
   private MZmineProcessingStep<MassDetector> ms1Detector = null;
   private MZmineProcessingStep<MassDetector> ms2Detector = null;
   private Logger logger = Logger.getLogger(
-      AllSpectralDataImportTask.class.getName());
+      MsDataImportAndMassDetectWrapperTask.class.getName());
 
   private int totalScans = 1;
   private int parsedScans = 0;
@@ -59,7 +58,7 @@ public class AllSpectralDataImportTask extends AbstractTask {
    *                         to directly centroid/threshold)
    * @param advancedParam    advanced parameters to apply mass detection
    */
-  public AllSpectralDataImportTask(MemoryMapStorage storageMassLists, RawDataFile newMZmineFile,
+  public MsDataImportAndMassDetectWrapperTask(MemoryMapStorage storageMassLists, RawDataFile newMZmineFile,
       AbstractTask importTask, @Nonnull AdvancedSpectraImportParameters advancedParam) {
     super(storageMassLists);
     this.newMZmineFile = newMZmineFile;
@@ -84,7 +83,7 @@ public class AllSpectralDataImportTask extends AbstractTask {
 
   @Override
   public double getFinishedPercentage() {
-    return totalScans > 0 ? (importTask.getFinishedPercentage() + parsedScans / totalScans) / 2d
+    return totalScans > 0 ? (importTask.getFinishedPercentage() + parsedScans / (double)totalScans) / 2d
         : importTask.getFinishedPercentage() / 2d;
   }
 
@@ -113,7 +112,7 @@ public class AllSpectralDataImportTask extends AbstractTask {
           Scan scan = data.nextScan();
 
           double[][] mzIntensities = null;
-          if (ms1Detector != null && scan.getMSLevel() == 1) {
+          if (ms1Detector != null && scan.getMSLevel() <= 1) {
             mzIntensities = ms1Detector.getModule()
                 .getMassValues(data, ms1Detector.getParameterSet());
           } else if (ms2Detector != null && scan.getMSLevel() >= 2) {

--- a/src/main/java/io/github/mzmine/modules/io/import_all_data_files/help/help.html
+++ b/src/main/java/io/github/mzmine/modules/io/import_all_data_files/help/help.html
@@ -1,0 +1,55 @@
+<html>
+<head>
+  <title>Import - Advanced data import</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <link rel="stylesheet" type="text/css"
+        href="/net/sf/mzmine/desktop/impl/helpsystem/HelpStyles.css">
+</head>
+
+<body>
+
+<h1>Advanced data import</h1>
+
+<h2>Description</h2>
+
+<p>
+  Imports MS data files in different MS data formats in one module. Either choose files directly or
+  use the buttons to list all files with a specific file format in a directory or in all sub
+  directories.
+</p>
+
+<h4>Method parameters</h4>
+
+<dl>
+
+  <dt>File names</dt>
+  <dd>List of all MS data files to be imported in different MS data formats</dd>
+
+  <dt>Advanced import</dt>
+  <dd>Apply mass detection (centroiding and thresholding) to all scans directly. CAUTION: While
+    it is slightly more efficient to do this during data import, only the processed data is stored
+    and the unprocessed data is discarded. Only use this method if you have tested that the final
+    results are the same, compared to splitting the data import and mass detection into two separate
+    steps.
+  </dd>
+
+  <dt>MS1 detector (Advanced)</dt>
+  <dd>Apply mass detection (centroiding and thresholding) to all MS1 scans directly. CAUTION: While
+    it is slightly more efficient to do this during data import, only the processed data is stored
+    and the unprocessed data is discarded. Only use this method if you have tested that the final
+    results are the same, compared to splitting the data import and mass detection into two separate
+    steps.
+  </dd>
+
+  <dt>MS2 detector (Advanced)</dt>
+  <dd>Apply mass detection (centroiding and thresholding) to all MS2 scans directly (all ms level>1
+    scans). CAUTION: While it is slightly more efficient to do this during data import, only the
+    processed data is stored and the unprocessed data is discarded. Only use this method if you have
+    tested that the final results are the same, compared to splitting the data import and mass
+    detection into two separate steps.
+  </dd>
+
+</dl>
+
+</body>
+</html>

--- a/src/main/java/io/github/mzmine/modules/io/import_mzml_msdk/MSDKmzMLImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_mzml_msdk/MSDKmzMLImportTask.java
@@ -67,14 +67,8 @@ public class MSDKmzMLImportTask extends AbstractTask {
 
   // advanced processing will apply mass detection directly to the scans
   private final boolean applyMassDetection;
-  @Nullable
-  private MassDetectionSubParameters ms1MassDetection = null;
-  @Nullable
-  private MassDetectionSubParameters ms2MassDetection = null;
   private MZmineProcessingStep<MassDetector> ms1Detector = null;
   private MZmineProcessingStep<MassDetector> ms2Detector = null;
-  private ScanSelection scan1Selection = null;
-  private ScanSelection scan2Selection = null;
 
   public MSDKmzMLImportTask(MZmineProject project, File fileToOpen, RawDataFile newMZmineFile) {
     this(project, fileToOpen, newMZmineFile, null);
@@ -89,23 +83,15 @@ public class MSDKmzMLImportTask extends AbstractTask {
     description = "Importing raw data file: " + fileToOpen.getName();
 
     if (advancedParam.getParameter(AdvancedSpectraImportParameters.msMassDetection).getValue()) {
-      ms1MassDetection = advancedParam
-          .getParameter(AdvancedSpectraImportParameters.msMassDetection).getEmbeddedParameters();
-      this.ms1Detector = ms1MassDetection.getParameter(MassDetectionParameters.massDetector)
-          .getValue();
-      this.scan1Selection = ms1MassDetection.getParameter(MassDetectionParameters.scanSelection)
-          .getValue();
+      this.ms1Detector = advancedParam.getParameter(AdvancedSpectraImportParameters.msMassDetection)
+          .getEmbeddedParameter().getValue();
     }
     if (advancedParam.getParameter(AdvancedSpectraImportParameters.ms2MassDetection).getValue()) {
-      ms2MassDetection = advancedParam
-          .getParameter(AdvancedSpectraImportParameters.ms2MassDetection).getEmbeddedParameters();
-      this.ms2Detector = ms2MassDetection.getParameter(MassDetectionParameters.massDetector)
-          .getValue();
-      this.scan2Selection = ms2MassDetection.getParameter(MassDetectionParameters.scanSelection)
-          .getValue();
+      this.ms2Detector = advancedParam.getParameter(AdvancedSpectraImportParameters.msMassDetection)
+          .getEmbeddedParameter().getValue();
     }
 
-    this.applyMassDetection = ms1MassDetection != null || ms2MassDetection != null;
+    this.applyMassDetection = ms1Detector != null || ms2Detector != null;
   }
 
 
@@ -183,9 +169,9 @@ public class MSDKmzMLImportTask extends AbstractTask {
         double[][] mzIntensities = null;
 
         // apply mass detection
-        if (ms1Detector != null && scan1Selection.matches(wrapper)) {
+        if (ms1Detector != null && wrapper.getMSLevel() == 1) {
           mzIntensities = applyMassDetection(ms1Detector, wrapper);
-        } else if (ms2Detector != null && scan2Selection.matches(wrapper)) {
+        } else if (ms2Detector != null && wrapper.getMSLevel() == 2) {
           mzIntensities = applyMassDetection(ms2Detector, wrapper);
         }
 

--- a/src/main/java/io/github/mzmine/modules/io/import_mzml_msdk/MSDKmzMLImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_mzml_msdk/MSDKmzMLImportTask.java
@@ -82,13 +82,17 @@ public class MSDKmzMLImportTask extends AbstractTask {
     this.newMZmineFile = newMZmineFile;
     description = "Importing raw data file: " + fileToOpen.getName();
 
-    if (advancedParam.getParameter(AdvancedSpectraImportParameters.msMassDetection).getValue()) {
-      this.ms1Detector = advancedParam.getParameter(AdvancedSpectraImportParameters.msMassDetection)
-          .getEmbeddedParameter().getValue();
-    }
-    if (advancedParam.getParameter(AdvancedSpectraImportParameters.ms2MassDetection).getValue()) {
-      this.ms2Detector = advancedParam.getParameter(AdvancedSpectraImportParameters.msMassDetection)
-          .getEmbeddedParameter().getValue();
+    if(advancedParam != null) {
+      if (advancedParam.getParameter(AdvancedSpectraImportParameters.msMassDetection).getValue()) {
+        this.ms1Detector = advancedParam
+            .getParameter(AdvancedSpectraImportParameters.msMassDetection)
+            .getEmbeddedParameter().getValue();
+      }
+      if (advancedParam.getParameter(AdvancedSpectraImportParameters.ms2MassDetection).getValue()) {
+        this.ms2Detector = advancedParam
+            .getParameter(AdvancedSpectraImportParameters.msMassDetection)
+            .getEmbeddedParameter().getValue();
+      }
     }
 
     this.applyMassDetection = ms1Detector != null || ms2Detector != null;
@@ -171,7 +175,7 @@ public class MSDKmzMLImportTask extends AbstractTask {
         // apply mass detection
         if (ms1Detector != null && wrapper.getMSLevel() == 1) {
           mzIntensities = applyMassDetection(ms1Detector, wrapper);
-        } else if (ms2Detector != null && wrapper.getMSLevel() == 2) {
+        } else if (ms2Detector != null && wrapper.getMSLevel() >= 2) {
           mzIntensities = applyMassDetection(ms2Detector, wrapper);
         }
 

--- a/src/main/java/io/github/mzmine/modules/io/import_mzxml/MzXMLImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_mzxml/MzXMLImportTask.java
@@ -124,13 +124,17 @@ public class MzXMLImportTask extends AbstractTask {
     this.file = fileToOpen;
     this.newMZmineFile = newMZmineFile;
 
-    if (advancedParam.getParameter(AdvancedSpectraImportParameters.msMassDetection).getValue()) {
-      this.ms1Detector = advancedParam.getParameter(AdvancedSpectraImportParameters.msMassDetection)
-          .getEmbeddedParameter().getValue();
-    }
-    if (advancedParam.getParameter(AdvancedSpectraImportParameters.ms2MassDetection).getValue()) {
-      this.ms2Detector = advancedParam.getParameter(AdvancedSpectraImportParameters.msMassDetection)
-          .getEmbeddedParameter().getValue();
+    if(advancedParam != null) {
+      if (advancedParam.getParameter(AdvancedSpectraImportParameters.msMassDetection).getValue()) {
+        this.ms1Detector = advancedParam
+            .getParameter(AdvancedSpectraImportParameters.msMassDetection)
+            .getEmbeddedParameter().getValue();
+      }
+      if (advancedParam.getParameter(AdvancedSpectraImportParameters.ms2MassDetection).getValue()) {
+        this.ms2Detector = advancedParam
+            .getParameter(AdvancedSpectraImportParameters.msMassDetection)
+            .getEmbeddedParameter().getValue();
+      }
     }
 
     this.applyMassDetection = ms1Detector != null || ms2Detector != null;

--- a/src/main/java/io/github/mzmine/modules/io/import_mzxml/MzXMLImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_mzxml/MzXMLImportTask.java
@@ -441,7 +441,7 @@ public class MzXMLImportTask extends AbstractTask {
           // apply mass detection
           if (ms1Detector != null && msLevel == 1) {
             mzIntensities = applyMassDetection(ms1Detector, mzValues, intensityValues);
-          } else if (ms2Detector != null && msLevel > 2) {
+          } else if (ms2Detector != null && msLevel >= 2) {
             mzIntensities = applyMassDetection(ms2Detector, mzValues, intensityValues);
           }
 

--- a/src/main/java/io/github/mzmine/modules/io/import_mzxml/MzXMLImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_mzxml/MzXMLImportTask.java
@@ -23,7 +23,15 @@ import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.datamodel.MassSpectrumType;
 import io.github.mzmine.datamodel.PolarityType;
 import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.impl.SimpleMassSpectrum;
 import io.github.mzmine.datamodel.impl.SimpleScan;
+import io.github.mzmine.datamodel.impl.masslist.ScanPointerMassList;
+import io.github.mzmine.modules.MZmineProcessingStep;
+import io.github.mzmine.modules.dataprocessing.featdet_massdetection.MassDetectionParameters;
+import io.github.mzmine.modules.dataprocessing.featdet_massdetection.MassDetector;
+import io.github.mzmine.modules.io.import_all_data_files.AdvancedSpectraImportParameters;
+import io.github.mzmine.modules.io.import_all_data_files.MassDetectionSubParameters;
+import io.github.mzmine.parameters.parametertypes.selectors.ScanSelection;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.CompressionUtils;
@@ -38,6 +46,7 @@ import java.util.Date;
 import java.util.LinkedList;
 import java.util.logging.Logger;
 import java.util.zip.DataFormatException;
+import javax.annotation.Nullable;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.Duration;
 import javax.xml.parsers.SAXParser;
@@ -88,13 +97,31 @@ public class MzXMLImportTask extends AbstractTask {
    */
   private LinkedList<SimpleScan> parentStack;
 
+
+  // advanced processing will apply mass detection directly to the scans
+  private final boolean applyMassDetection;
+  @Nullable
+  private MassDetectionSubParameters ms1MassDetection = null;
+  @Nullable
+  private MassDetectionSubParameters ms2MassDetection = null;
+  private MZmineProcessingStep<MassDetector> ms1Detector = null;
+  private MZmineProcessingStep<MassDetector> ms2Detector = null;
+  private ScanSelection scan1Selection = null;
+  private ScanSelection scan2Selection = null;
+
   /*
    * This variable hold the present scan or fragment, it is send to the stack when another
    * scan/fragment appears as a parser.startElement
    */
   private SimpleScan buildingScan;
 
+
   public MzXMLImportTask(MZmineProject project, File fileToOpen, RawDataFile newMZmineFile) {
+    this(project, fileToOpen, newMZmineFile, null);
+  }
+
+  public MzXMLImportTask(MZmineProject project, File fileToOpen, RawDataFile newMZmineFile,
+      AdvancedSpectraImportParameters advancedParam) {
     super(null); // storage in raw data file
     // 256 kilo-chars buffer
     charBuffer = new StringBuilder(1 << 18);
@@ -102,6 +129,25 @@ public class MzXMLImportTask extends AbstractTask {
     this.project = project;
     this.file = fileToOpen;
     this.newMZmineFile = newMZmineFile;
+
+    if (advancedParam.getParameter(AdvancedSpectraImportParameters.msMassDetection).getValue()) {
+      ms1MassDetection = advancedParam
+          .getParameter(AdvancedSpectraImportParameters.msMassDetection).getEmbeddedParameters();
+      this.ms1Detector = ms1MassDetection.getParameter(MassDetectionParameters.massDetector)
+          .getValue();
+      this.scan1Selection = ms1MassDetection.getParameter(MassDetectionParameters.scanSelection)
+          .getValue();
+    }
+    if (advancedParam.getParameter(AdvancedSpectraImportParameters.ms2MassDetection).getValue()) {
+      ms2MassDetection = advancedParam
+          .getParameter(AdvancedSpectraImportParameters.ms2MassDetection).getEmbeddedParameters();
+      this.ms2Detector = ms2MassDetection.getParameter(MassDetectionParameters.massDetector)
+          .getValue();
+      this.scan2Selection = ms2MassDetection.getParameter(MassDetectionParameters.scanSelection)
+          .getValue();
+    }
+
+    this.applyMassDetection = ms1MassDetection != null || ms2MassDetection != null;
   }
 
   /**
@@ -388,17 +434,58 @@ public class MzXMLImportTask extends AbstractTask {
           throw new SAXException("Parsing Cancelled");
         }
 
-        // Auto-detect whether this scan is centroided
-        MassSpectrumType spectrumType = ScanUtils.detectSpectrumType(mzValues, intensityValues);
+        if (applyMassDetection) {
+          // wrap scan
+          double[][] mzIntensities = null;
 
-        // Set the final data points to the scan
-        buildingScan = new SimpleScan(newMZmineFile, scanNumber, msLevel, retentionTime,
-            precursorMz,
-            precursorCharge, mzValues, intensityValues, spectrumType, polarity, scanId,
-            null);
+          // apply mass detection
+          if (ms1Detector != null && msLevel == 1) {
+            mzIntensities = applyMassDetection(ms1Detector, mzValues, intensityValues);
+          } else if (ms2Detector != null && msLevel > 2) {
+            mzIntensities = applyMassDetection(ms2Detector, mzValues, intensityValues);
+          }
+
+          if (mzIntensities != null) {
+            // Set the centroided / thresholded data points to the scan
+            buildingScan = new SimpleScan(newMZmineFile, scanNumber, msLevel, retentionTime,
+                precursorMz, precursorCharge, mzIntensities[0], mzIntensities[1],
+                MassSpectrumType.CENTROIDED, polarity, scanId, null);
+
+            // create mass list and scan. Override data points and spectrum type
+            ScanPointerMassList newMassList = new ScanPointerMassList(buildingScan);
+            buildingScan.addMassList(newMassList);
+          }
+        }
+
+        // if no mass dection was applied - just create the scan
+        if (buildingScan == null) {
+          // Auto-detect whether this scan is centroided
+          MassSpectrumType spectrumType = ScanUtils.detectSpectrumType(mzValues, intensityValues);
+
+          // Set the final data points to the scan
+          buildingScan = new SimpleScan(newMZmineFile, scanNumber, msLevel, retentionTime,
+              precursorMz,
+              precursorCharge, mzValues, intensityValues, spectrumType, polarity, scanId,
+              null);
+        }
 
         return;
       }
+    }
+
+    /**
+     * Apply mass detection
+     *
+     * @param msDetector  mass detection module
+     * @param mzs         input values for mass detection
+     * @param intensities input values
+     * @return new mzs: double[0]; new intensities: double[1] arrays
+     */
+    private double[][] applyMassDetection(MZmineProcessingStep<MassDetector> msDetector,
+        double[] mzs, double[] intensities) {
+      // wrap data points in a simple mass spectrum
+      return msDetector.getModule()
+          .getMassValues(new SimpleMassSpectrum(mzs, intensities), msDetector.getParameterSet());
     }
 
     private void reset() {

--- a/src/main/java/io/github/mzmine/modules/io/import_mzxml/MzXMLImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_mzxml/MzXMLImportTask.java
@@ -100,14 +100,8 @@ public class MzXMLImportTask extends AbstractTask {
 
   // advanced processing will apply mass detection directly to the scans
   private final boolean applyMassDetection;
-  @Nullable
-  private MassDetectionSubParameters ms1MassDetection = null;
-  @Nullable
-  private MassDetectionSubParameters ms2MassDetection = null;
   private MZmineProcessingStep<MassDetector> ms1Detector = null;
   private MZmineProcessingStep<MassDetector> ms2Detector = null;
-  private ScanSelection scan1Selection = null;
-  private ScanSelection scan2Selection = null;
 
   /*
    * This variable hold the present scan or fragment, it is send to the stack when another
@@ -131,23 +125,15 @@ public class MzXMLImportTask extends AbstractTask {
     this.newMZmineFile = newMZmineFile;
 
     if (advancedParam.getParameter(AdvancedSpectraImportParameters.msMassDetection).getValue()) {
-      ms1MassDetection = advancedParam
-          .getParameter(AdvancedSpectraImportParameters.msMassDetection).getEmbeddedParameters();
-      this.ms1Detector = ms1MassDetection.getParameter(MassDetectionParameters.massDetector)
-          .getValue();
-      this.scan1Selection = ms1MassDetection.getParameter(MassDetectionParameters.scanSelection)
-          .getValue();
+      this.ms1Detector = advancedParam.getParameter(AdvancedSpectraImportParameters.msMassDetection)
+          .getEmbeddedParameter().getValue();
     }
     if (advancedParam.getParameter(AdvancedSpectraImportParameters.ms2MassDetection).getValue()) {
-      ms2MassDetection = advancedParam
-          .getParameter(AdvancedSpectraImportParameters.ms2MassDetection).getEmbeddedParameters();
-      this.ms2Detector = ms2MassDetection.getParameter(MassDetectionParameters.massDetector)
-          .getValue();
-      this.scan2Selection = ms2MassDetection.getParameter(MassDetectionParameters.scanSelection)
-          .getValue();
+      this.ms2Detector = advancedParam.getParameter(AdvancedSpectraImportParameters.msMassDetection)
+          .getEmbeddedParameter().getValue();
     }
 
-    this.applyMassDetection = ms1MassDetection != null || ms2MassDetection != null;
+    this.applyMassDetection = ms1Detector != null || ms2Detector != null;
   }
 
   /**

--- a/src/main/java/io/github/mzmine/parameters/dialogs/ParameterSetupDialogWithScanPreview.java
+++ b/src/main/java/io/github/mzmine/parameters/dialogs/ParameterSetupDialogWithScanPreview.java
@@ -42,12 +42,12 @@ import javafx.scene.layout.VBox;
 public abstract class ParameterSetupDialogWithScanPreview extends ParameterSetupDialogWithPreview {
 
   // Dialog components
-  private final FlowPane pnlDataFile, pnlScanArrows, pnlScanNumber;
-  private final VBox pnlControls;
-  private final ComboBox<RawDataFile> comboDataFileName;
-  private final ComboBox<Scan> comboScanNumber;
+  private FlowPane pnlDataFile, pnlScanArrows, pnlScanNumber;
+  private VBox pnlControls;
+  private ComboBox<RawDataFile> comboDataFileName;
+  private ComboBox<Scan> comboScanNumber;
   // XYPlot
-  private final SpectraPlot spectrumPlot;
+  private SpectraPlot spectrumPlot;
   private RawDataFile[] dataFiles;
   private RawDataFile previewDataFile;
 
@@ -61,15 +61,16 @@ public abstract class ParameterSetupDialogWithScanPreview extends ParameterSetup
 
     dataFiles = MZmineCore.getProjectManager().getCurrentProject().getDataFiles();
 
-    // TODO: if (dataFiles.length == 0)
-    // return;
+    // if no data files, return the dialog without preview functions
     if (dataFiles.length == 0) {
-      this.hide();
-      MZmineCore.getDesktop()
-          .displayMessage("Please load a raw data file before selecting a " + "mass detector.");
-      throw new UnsupportedOperationException(
-          "Please load a raw data file before selecting a mass detector.");
+      return;
     }
+//      this.hide();
+//      MZmineCore.getDesktop()
+//          .displayMessage("Please load a raw data file before selecting a " + "mass detector.");
+//      throw new UnsupportedOperationException(
+//          "Please load a raw data file before selecting a mass detector.");
+//    }
 
     RawDataFile selectedFiles[] = MZmineCore.getDesktop().getSelectedDataFiles();
 

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/ModuleComboParameter.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/ModuleComboParameter.java
@@ -72,7 +72,6 @@ public class ModuleComboParameter<ModuleType extends MZmineModule>
   }
 
   /**
-   * @see io.github.mzmine.data.Parameter#getName()
    */
   @Override
   public String getName() {
@@ -80,7 +79,6 @@ public class ModuleComboParameter<ModuleType extends MZmineModule>
   }
 
   /**
-   * @see io.github.mzmine.data.Parameter#getDescription()
    */
   @Override
   public String getDescription() {
@@ -165,7 +163,7 @@ public class ModuleComboParameter<ModuleType extends MZmineModule>
         }
       }
     }
-    String selectedAttr = xmlElement.getAttribute("selected");
+    String selectedAttr = xmlElement.getAttribute("selected_item");
     for (int j = 0; j < modulesWithParams.length; j++) {
       if (modulesWithParams[j].getModule().getName().equals(selectedAttr)) {
         value = modulesWithParams[j];
@@ -176,7 +174,7 @@ public class ModuleComboParameter<ModuleType extends MZmineModule>
   @Override
   public void saveValueToXML(Element xmlElement) {
     if (value != null)
-      xmlElement.setAttribute("selected", value.toString());
+      xmlElement.setAttribute("selected_item", value.toString());
     Document parentDocument = xmlElement.getOwnerDocument();
     for (MZmineProcessingStep<?> item : modulesWithParams) {
       Element newElement = parentDocument.createElement("module");

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/filenames/FileNamesComponent.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/filenames/FileNamesComponent.java
@@ -1,16 +1,16 @@
 /*
  * Copyright 2006-2020 The MZmine Development Team
- * 
+ *
  * This file is part of MZmine.
- * 
+ *
  * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
  * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
  * Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
  * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
  * USA
@@ -18,16 +18,22 @@
 
 package io.github.mzmine.parameters.parametertypes.filenames;
 
+import com.google.common.collect.ImmutableList;
+import io.github.mzmine.util.files.FileAndPathUtil;
 import java.awt.event.ActionEvent;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
-import com.google.common.collect.ImmutableList;
 import javafx.scene.control.Button;
+import javafx.scene.control.CheckBox;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
 import javafx.scene.text.Font;
+import javafx.stage.DirectoryChooser;
 import javafx.stage.FileChooser;
 import javafx.stage.FileChooser.ExtensionFilter;
 
@@ -36,6 +42,7 @@ public class FileNamesComponent extends FlowPane {
   public static final Font smallFont = new Font("SansSerif", 10);
 
   private TextArea txtFilename;
+  private CheckBox useSubFolders;
 
   private final List<ExtensionFilter> filters;
 
@@ -50,7 +57,7 @@ public class FileNamesComponent extends FlowPane {
     txtFilename.setPrefRowCount(6);
     txtFilename.setFont(smallFont);
 
-    Button btnFileBrowser = new Button("...");
+    Button btnFileBrowser = new Button("Select");
     btnFileBrowser.setOnAction(e -> {
       // Create chooser.
       FileChooser fileChooser = new FileChooser();
@@ -62,34 +69,94 @@ public class FileNamesComponent extends FlowPane {
       if (currentPaths.length > 0) {
         File currentFile = new File(currentPaths[0].trim());
         File currentDir = currentFile.getParentFile();
-        if (currentDir != null && currentDir.exists())
+        if (currentDir != null && currentDir.exists()) {
           fileChooser.setInitialDirectory(currentDir);
+        }
       }
 
       // Open chooser.
       List<File> selectedFiles = fileChooser.showOpenMultipleDialog(null);
-      if (selectedFiles == null)
+      if (selectedFiles == null) {
         return;
+      }
       setValue(selectedFiles.toArray(new File[0]));
     });
-    getChildren().addAll(txtFilename, btnFileBrowser);
 
+    useSubFolders = new CheckBox("In sub folders");
+    useSubFolders.setSelected(false);
+
+    Button btnClear = new Button("Clear");
+    btnClear.setOnAction(e -> {
+      txtFilename.setText("");
+    });
+
+    VBox vbox = new VBox(btnFileBrowser, btnClear, useSubFolders);
+
+    List<Button> directoryButtons = createFromDirectoryBtns(filters);
+    vbox.getChildren().addAll(directoryButtons);
+
+    HBox hbox = new HBox(txtFilename, vbox);
+    getChildren().addAll(hbox);
+  }
+
+  private List<Button> createFromDirectoryBtns(List<ExtensionFilter> filters) {
+    List<Button> btns = new ArrayList<>();
+    for (ExtensionFilter filter : filters) {
+      if (filter.getExtensions().isEmpty() || filter.getExtensions().get(0).equals("*.*")) {
+        continue;
+      }
+      String name =
+          filter.getExtensions().size() > 3 ? "Multiple" : "All " + filter.getExtensions().get(0);
+
+      Button btnFromDirectory = new Button(name);
+      btnFromDirectory.setTooltip(new Tooltip("All files in folder (sub folders)"));
+      btns.add(btnFromDirectory);
+      btnFromDirectory.setOnAction(e -> {
+        // Create chooser.
+        DirectoryChooser fileChooser = new DirectoryChooser();
+        fileChooser.setTitle("Select a folder");
+
+        String currentPaths[] = txtFilename.getText().split("\n");
+        if (currentPaths.length > 0) {
+          File currentFile = new File(currentPaths[0].trim());
+          File currentDir = currentFile.getParentFile();
+          if (currentDir != null && currentDir.exists()) {
+            fileChooser.setInitialDirectory(currentDir);
+          }
+        }
+
+        // Open chooser.
+        File dir = fileChooser.showDialog(null);
+        if (dir == null) {
+          return;
+        }
+
+        List<File[]> filesInDir = FileAndPathUtil
+            .findFilesInDir(dir, filter, useSubFolders.isSelected());
+        // all files in dir or sub dirs
+        setValue(filesInDir.stream().flatMap(sub -> Arrays.stream(sub)).toArray(File[]::new));
+      });
+    }
+    return btns;
   }
 
   public File[] getValue() {
     String fileNameStrings[] = txtFilename.getText().split("\n");
     List<File> files = new ArrayList<>();
     for (String fileName : fileNameStrings) {
-      if (fileName.trim().equals(""))
+      if (fileName.trim().equals("")) {
         continue;
+      }
       files.add(new File(fileName.trim()));
     }
     return files.toArray(new File[0]);
   }
 
   public void setValue(File[] value) {
-    if (value == null)
+    if (value == null) {
+      txtFilename.setText("");
       return;
+    }
     StringBuilder b = new StringBuilder();
     for (File file : value) {
       b.append(file.getPath());
@@ -99,8 +166,6 @@ public class FileNamesComponent extends FlowPane {
   }
 
   public void actionPerformed(ActionEvent event) {
-
-
 
   }
 

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/filenames/FileNamesParameter.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/filenames/FileNamesParameter.java
@@ -48,7 +48,6 @@ public class FileNamesParameter implements UserParameter<File[], FileNamesCompon
   }
 
   /**
-   * @see io.github.mzmine.data.Parameter#getName()
    */
   @Override
   public String getName() {
@@ -56,7 +55,6 @@ public class FileNamesParameter implements UserParameter<File[], FileNamesCompon
   }
 
   /**
-   * @see io.github.mzmine.data.Parameter#getDescription()
    */
   @Override
   public String getDescription() {

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/ScanSelection.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/ScanSelection.java
@@ -20,6 +20,7 @@ package io.github.mzmine.parameters.parametertypes.selectors;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Range;
+import io.github.msdk.datamodel.MsScan;
 import io.github.mzmine.datamodel.Frame;
 import io.github.mzmine.datamodel.MassSpectrumType;
 import io.github.mzmine.datamodel.MobilityScan;

--- a/src/main/java/io/github/mzmine/project/impl/RawDataFileImpl.java
+++ b/src/main/java/io/github/mzmine/project/impl/RawDataFileImpl.java
@@ -75,7 +75,6 @@ public class RawDataFileImpl implements RawDataFile {
   protected final ObservableList<Scan> scans;
   // maximum number of data points and centroid data points in all scans
   protected int maxRawDataPoints = -1;
-  protected int maxCentroidDataPoints = -1;
 
   protected final ObservableList<FeatureListAppliedMethod> appliedMethods
       = FXCollections.observableArrayList();
@@ -113,11 +112,8 @@ public class RawDataFileImpl implements RawDataFile {
    */
   @Override
   public int getMaxCentroidDataPoints() {
-    if (maxCentroidDataPoints == -1) {
-      maxCentroidDataPoints = scans.stream().map(Scan::getMassList).filter(Objects::nonNull)
+      return scans.stream().map(Scan::getMassList).filter(Objects::nonNull)
           .mapToInt(MassList::getNumberOfDataPoints).max().orElse(0);
-    }
-    return maxCentroidDataPoints;
   }
 
   /**
@@ -300,11 +296,6 @@ public class RawDataFileImpl implements RawDataFile {
       // Scan will be unmodifiable - Frame is the average spectrum calculated from all MobilityScans
       // so data changes
       maxRawDataPoints = newScan.getNumberOfDataPoints();
-    }
-    MassList masses = newScan.getMassList();
-    if (masses != null && masses.getNumberOfDataPoints() > maxCentroidDataPoints) {
-      // mass list changes set this var to -1
-      maxCentroidDataPoints = masses.getNumberOfDataPoints();
     }
 
     // Remove cached values
@@ -489,7 +480,5 @@ public class RawDataFileImpl implements RawDataFile {
    * @param masses new mass list
    */
   public void applyMassListChanged(Scan scan, MassList old, MassList masses) {
-    // set to -1 to indicate change
-    maxCentroidDataPoints = -1;
   }
 }

--- a/src/main/java/io/github/mzmine/util/files/FileAndPathUtil.java
+++ b/src/main/java/io/github/mzmine/util/files/FileAndPathUtil.java
@@ -1,16 +1,16 @@
 /*
  * Copyright 2006-2020 The MZmine Development Team
- * 
+ *
  * This file is part of MZmine.
- * 
+ *
  * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
  * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
  * Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
  * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
  * USA
@@ -24,20 +24,19 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
-
+import javafx.stage.FileChooser.ExtensionFilter;
 import org.apache.commons.io.FilenameUtils;
 
 /**
  * Simple file operations
- * 
+ *
  * @author Robin Schmid (robinschmid@uni-muenster.de)
  */
 public class FileAndPathUtil {
 
   /**
    * Returns the real file path as path/filename.fileformat
-   * 
-   * @param file
+   *
    * @param name
    * @param format a format starting with a dot for example: .pdf ; or without a dot: pdf
    * @return
@@ -48,9 +47,7 @@ public class FileAndPathUtil {
 
   /**
    * Returns the real file path as path/filename.fileformat
-   * 
-   * @param file
-   * @param name
+   *
    * @param format a format starting with a dot for example: .pdf ; or without a dot: pdf
    * @return
    * @throws Exception if there is no filname (selected path = folder)
@@ -61,7 +58,7 @@ public class FileAndPathUtil {
 
   /**
    * Returns the real file name as filename.fileformat
-   * 
+   *
    * @param name
    * @param format a format starting with a dot for example .pdf
    * @return
@@ -74,7 +71,7 @@ public class FileAndPathUtil {
 
   /**
    * Returns the real file name as filename.fileformat
-   * 
+   *
    * @param name
    * @param format a format starting with a dot for example .pdf
    * @return
@@ -86,22 +83,22 @@ public class FileAndPathUtil {
   /**
    * erases the format. "image.png" will be returned as "image" this method is used by
    * getRealFilePath and getRealFileName
-   * 
-   * @param name
+   *
    * @return
    */
   public static File eraseFormat(File f) {
     int lastDot = f.getName().lastIndexOf(".");
-    if (lastDot != -1)
+    if (lastDot != -1) {
       return new File(f.getParent(), f.getName().substring(0, lastDot));
-    else
+    } else {
       return f;
+    }
   }
 
   /**
    * Adds the format. "image" will be returned as "image.format" Maybe use erase format first. this
    * method is used by getRealFilePath and getRealFileName
-   * 
+   *
    * @param name
    * @param format
    * @return
@@ -109,39 +106,42 @@ public class FileAndPathUtil {
   public static String addFormat(String name, String format) {
     if (format.startsWith(".")) {
       return name + format;
-    } else
+    } else {
       return name + "." + format;
+    }
   }
 
   /**
    * Returns the file if it is already a folder. Or the parent folder if the file is a data file
-   * 
+   *
    * @param file
    * @return
    */
   public static File getFolderOfFile(File file) {
     if (!isOnlyAFolder(file)) {
       return file.getParentFile();
-    } else
+    } else {
       return file;
+    }
   }
 
   /**
    * Returns the file name from a given file. If file is a folder an empty String is returned
-   * 
+   *
    * @param file
    * @return
    */
   public static String getFileNameFromPath(File file) {
     if (!isOnlyAFolder(file)) {
       return file.getAbsolutePath().substring(file.getAbsolutePath().lastIndexOf("\\") + 1);
-    } else
+    } else {
       return "";
+    }
   }
 
   /**
    * Returns the file name from a given file. If the file is a folder an empty String is returned
-   * 
+   *
    * @param file
    * @return
    */
@@ -158,7 +158,7 @@ public class FileAndPathUtil {
 
   /**
    * Creates a new directory.
-   * 
+   *
    * @param theDir
    * @return false if directory was not created
    */
@@ -173,13 +173,14 @@ public class FileAndPathUtil {
         // handle it
       }
       return result;
-    } else
+    } else {
       return true;
+    }
   }
 
   /**
    * Sort an array of files These files have to start or end with a number
-   * 
+   *
    * @param files
    * @return
    */
@@ -190,8 +191,9 @@ public class FileAndPathUtil {
       @Override
       public int compare(File o1, File o2) {
         try {
-          if (endsWithNumber == null)
+          if (endsWithNumber == null) {
             checkEndsWithNumber(o1.getName());
+          }
           int n1 = extractNumber(o1.getName());
           int n2 = extractNumber(o2.getName());
           return n1 - n2;
@@ -215,8 +217,9 @@ public class FileAndPathUtil {
               }
             }
             //
-            if (f < 0)
+            if (f < 0) {
               f = 0;
+            }
             String number = name.substring(f, e);
             i = Integer.parseInt(number);
           } else {
@@ -252,7 +255,7 @@ public class FileAndPathUtil {
 
   /**
    * Lists all directories in directory f
-   * 
+   *
    * @param f
    * @return
    */
@@ -267,8 +270,23 @@ public class FileAndPathUtil {
 
   // ###############################################################################################
   // search for files
+
+  public static List<File[]> findFilesInDir(File dir, ExtensionFilter fileFilter) {
+    String ext = fileFilter.getExtensions().get(0);
+    if(ext.startsWith("*."))
+      ext = ext.substring(2);
+    return findFilesInDir(dir, new FileNameExtFilter("", ext), true, false);
+  }
+
+  public static List<File[]> findFilesInDir(File dir, ExtensionFilter fileFilter,
+      boolean searchSubdir) {
+    String ext = fileFilter.getExtensions().get(0);
+    if(ext.startsWith("*."))
+      ext = ext.substring(2);
+    return findFilesInDir(dir, new FileNameExtFilter("", ext), searchSubdir, false);
+  }
+
   /**
-   * 
    * @param dir
    * @param fileFilter
    * @return
@@ -291,8 +309,9 @@ public class FileAndPathUtil {
     // sort all files and return them
     File[] files = dir.listFiles(fileFilter);
     files = FileAndPathUtil.sortFilesByNumber(files);
-    if (files != null && files.length > 0)
+    if (files != null && files.length > 0) {
       list.add(files);
+    }
 
     if (subDir == null || subDir.length <= 0 || !searchSubdir) {
       // no subdir end directly
@@ -314,8 +333,8 @@ public class FileAndPathUtil {
   /**
    * go into all subfolders and find all files and go in further subfolders files stored in separate
    * folders. one line in one folder
-   * 
-   * @param dir musst be sorted!
+   *
+   * @param dirs musst be sorted!
    * @param list
    * @return
    */
@@ -331,8 +350,9 @@ public class FileAndPathUtil {
       // create image of these
       // dirs
       if (subFiles.length > 0) {
-        if (img == null)
+        if (img == null) {
           img = new ArrayList<File>();
+        }
         // put them into the list
         for (int f = 0; f < subFiles.length; f++) {
           img.add(subFiles[f]);
@@ -354,8 +374,8 @@ public class FileAndPathUtil {
 
   /**
    * Go into all sub-folders and find all files files stored one image in one folder!
-   * 
-   * @param dir musst be sorted!
+   *
+   * @param dirs musst be sorted!
    * @param list
    * @return
    */
@@ -366,8 +386,9 @@ public class FileAndPathUtil {
       // find all suiting files
       File[] subFiles = FileAndPathUtil.sortFilesByNumber(dirs[i].listFiles(fileFilter));
       // put them into the list
-      if (subFiles != null && subFiles.length > 0)
+      if (subFiles != null && subFiles.length > 0) {
         list.add(subFiles);
+      }
       // find all subfolders, sort them and do the same iterative
       File[] subDir = FileAndPathUtil.sortFilesByNumber(FileAndPathUtil.getSubDirectories(dirs[i]));
       // call this method
@@ -377,7 +398,7 @@ public class FileAndPathUtil {
 
   /**
    * The Path of the Jar.
-   * 
+   *
    * @return
    */
   public static File getPathOfJar() {

--- a/src/main/java/io/github/mzmine/util/scans/ScanUtils.java
+++ b/src/main/java/io/github/mzmine/util/scans/ScanUtils.java
@@ -18,7 +18,6 @@
 
 package io.github.mzmine.util.scans;
 
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
 import io.github.mzmine.datamodel.DataPoint;
@@ -75,7 +74,8 @@ public class ScanUtils {
    * @param scan Scan to be converted to String
    * @return String representation of the scan
    */
-  public static @Nonnull String scanToString(@Nonnull Scan scan, @Nonnull Boolean includeFileName) {
+  public static @Nonnull
+  String scanToString(@Nonnull Scan scan, @Nonnull Boolean includeFileName) {
     StringBuffer buf = new StringBuffer();
     Format rtFormat = MZmineCore.getConfiguration().getRTFormat();
     Format mzFormat = MZmineCore.getConfiguration().getMZFormat();
@@ -106,7 +106,7 @@ public class ScanUtils {
     buf.append(" ");
     buf.append(scan.getPolarity().asSingleChar());
 
-    if(scan instanceof MergedMsMsSpectrum) {
+    if (scan instanceof MergedMsMsSpectrum) {
       buf.append(" merged ");
       buf.append(((MergedMsMsSpectrum) scan).getSourceSpectra().size());
       buf.append(" spectra, CE: ");
@@ -159,7 +159,7 @@ public class ScanUtils {
   /**
    * Calculate the total ion count of a scan within a given mass range.
    *
-   * @param scan the scan.
+   * @param scan    the scan.
    * @param mzRange mass range.
    * @return the total ion count of the scan within the mass range.
    */
@@ -203,13 +203,14 @@ public class ScanUtils {
    * This method bins values on x-axis. Each bin is assigned biggest y-value of all values in the
    * same bin.
    *
-   * @param x X-coordinates of the data
-   * @param y Y-coordinates of the data
-   * @param binRange x coordinates of the left and right edge of the first bin
+   * @param x            X-coordinates of the data
+   * @param y            Y-coordinates of the data
+   * @param binRange     x coordinates of the left and right edge of the first bin
    * @param numberOfBins Number of bins
-   * @param interpolate If true, then empty bins will be filled with interpolation using other bins
-   * @param binningType Type of binning (sum of all 'y' within a bin, max of 'y', min of 'y', avg of
-   *        'y')
+   * @param interpolate  If true, then empty bins will be filled with interpolation using other
+   *                     bins
+   * @param binningType  Type of binning (sum of all 'y' within a bin, max of 'y', min of 'y', avg
+   *                     of 'y')
    * @return Values for each bin
    */
   public static double[] binValues(double[] x, double[] y, Range<Double> binRange, int numberOfBins,
@@ -374,7 +375,7 @@ public class ScanUtils {
    * the given mass range
    *
    * @param dataPoints sorted(!) list of datapoints
-   * @param mzRange m/z range to search in
+   * @param mzRange    m/z range to search in
    * @return index of datapoint or -1, if no datapoint is in range
    */
   public static int findFirstFeatureWithin(DataPoint[] dataPoints, Range<Double> mzRange) {
@@ -398,7 +399,7 @@ public class ScanUtils {
    * the given mass range
    *
    * @param dataPoints sorted(!) list of datapoints
-   * @param mzRange m/z range to search in
+   * @param mzRange    m/z range to search in
    * @return index of datapoint or -1, if no datapoint is in range
    */
   public static int findLastFeatureWithin(DataPoint[] dataPoints, Range<Double> mzRange) {
@@ -422,7 +423,7 @@ public class ScanUtils {
    * within the given mass range
    *
    * @param dataPoints sorted(!) list of datapoints
-   * @param mzRange m/z range to search in
+   * @param mzRange    m/z range to search in
    * @return index of datapoint or -1, if no datapoint is in range
    */
   public static int findMostIntenseFeatureWithin(DataPoint[] dataPoints, Range<Double> mzRange) {
@@ -561,7 +562,8 @@ public class ScanUtils {
     assert mzRange != null;
 
     return dataFile.getScanNumbers(2).stream()
-        .filter(s -> rtRange.contains(s.getRetentionTime()) && mzRange.contains(s.getPrecursorMZ()))
+        .filter(s -> s.getBasePeakIntensity() != null && rtRange.contains(s.getRetentionTime())
+            && mzRange.contains(s.getPrecursorMZ()))
         .max(Comparator.comparingDouble(s -> s.getBasePeakIntensity())).orElse(null);
   }
 
@@ -576,14 +578,14 @@ public class ScanUtils {
     assert mzRange != null;
 
     return dataFile.getScanNumbers(2).stream()
-        .filter(s -> rtRange.contains(s.getRetentionTime()) && mzRange.contains(s.getPrecursorMZ()))
+        .filter(s -> rtRange.contains(s.getRetentionTime())
+            && mzRange.contains(s.getPrecursorMZ()))
         .toArray(Scan[]::new);
   }
 
   /**
-   *
    * @param dataFile
-   * @param msLevel 0 for all scans
+   * @param msLevel  0 for all scans
    * @return
    */
   public static Stream<Scan> streamScans(RawDataFile dataFile, int msLevel) {
@@ -612,7 +614,8 @@ public class ScanUtils {
   /**
    * Find the highest data point in array
    */
-  public static @Nonnull DataPoint findTopDataPoint(@Nonnull DataPoint dataPoints[]) {
+  public static @Nonnull
+  DataPoint findTopDataPoint(@Nonnull DataPoint dataPoints[]) {
 
     DataPoint topDP = null;
 
@@ -644,7 +647,8 @@ public class ScanUtils {
    * Find the m/z range of the data points in the array. We assume there is at least one data point,
    * and the data points are sorted by m/z.
    */
-  public static @Nonnull Range<Double> findMzRange(@Nonnull DataPoint dataPoints[]) {
+  public static @Nonnull
+  Range<Double> findMzRange(@Nonnull DataPoint dataPoints[]) {
 
     assert dataPoints.length > 0;
 
@@ -667,7 +671,8 @@ public class ScanUtils {
    * Find the m/z range of the data points in the array. We assume there is at least one data point,
    * and the data points are sorted by m/z.
    */
-  public static @Nonnull Range<Double> findMzRange(@Nonnull double mzValues[]) {
+  public static @Nonnull
+  Range<Double> findMzRange(@Nonnull double mzValues[]) {
 
     assert mzValues.length > 0;
 
@@ -689,7 +694,8 @@ public class ScanUtils {
   /**
    * Find the RT range of given scans. We assume there is at least one scan.
    */
-  public static @Nonnull Range<Float> findRtRange(@Nonnull Scan scans[]) {
+  public static @Nonnull
+  Range<Float> findRtRange(@Nonnull Scan scans[]) {
 
     assert scans.length > 0;
 
@@ -767,10 +773,10 @@ public class ScanUtils {
    * Sorted list (best first) of all MS2 fragmentation scans with n signals >= noiseLevel in the
    * specified or first massList, if none was specified
    *
-   * @param row all MS2 scans of all features in this row
+   * @param row                all MS2 scans of all features in this row
    * @param noiseLevel
    * @param minNumberOfSignals
-   * @param sort the sorting property (best first, index=0)
+   * @param sort               the sorting property (best first, index=0)
    * @return
    */
   @Nonnull
@@ -804,10 +810,10 @@ public class ScanUtils {
    * Sorted list of all MS1 {@link Feature#getRepresentativeScan()} of all features. scans with n
    * signals >= noiseLevel in the specified or first massList, if none was specified
    *
-   * @param row all representative MS1 scans of all features in this row
+   * @param row                all representative MS1 scans of all features in this row
    * @param noiseLevel
    * @param minNumberOfSignals
-   * @param sort the sorting property (best first, index=0)
+   * @param sort               the sorting property (best first, index=0)
    * @return
    */
   @Nonnull
@@ -956,10 +962,11 @@ public class ScanUtils {
   public static double getTIC(MassSpectrum spec, double noiseLevel) {
     int size = spec.getNumberOfDataPoints();
     double sum = 0;
-    for(int i=0; i<size; i++) {
+    for (int i = 0; i < size; i++) {
       double intensity = spec.getIntensityValue(i);
-      if(intensity >= noiseLevel)
+      if (intensity >= noiseLevel) {
         sum += intensity;
+      }
     }
     return sum;
   }
@@ -974,9 +981,10 @@ public class ScanUtils {
   public static int getNumberOfSignals(MassSpectrum spec, double noiseLevel) {
     int size = spec.getNumberOfDataPoints();
     int n = 0;
-    for(int i=0; i<size; i++) {
-      if(spec.getIntensityValue(i) >= noiseLevel)
+    for (int i = 0; i < size; i++) {
+      if (spec.getIntensityValue(i) >= noiseLevel) {
         n++;
+      }
     }
     return n;
   }
@@ -984,7 +992,8 @@ public class ScanUtils {
   /**
    * Finds the first MS1 scan preceding the given MS2 scan. If no such scan exists, returns null.
    */
-  public static @Nullable Scan findPrecursorScan(@Nonnull Scan scan) {
+  public static @Nullable
+  Scan findPrecursorScan(@Nonnull Scan scan) {
 
     assert scan != null;
     final RawDataFile dataFile = scan.getDataFile();
@@ -1028,7 +1037,8 @@ public class ScanUtils {
   /**
    * Selects best N MS/MS scans from a feature list row
    */
-  public static @Nonnull Collection<Scan> selectBestMS2Scans(@Nonnull FeatureListRow row,
+  public static @Nonnull
+  Collection<Scan> selectBestMS2Scans(@Nonnull FeatureListRow row,
       @Nonnull Integer topN) throws MissingMassListException {
     final @Nonnull List<Scan> allMS2Scans = row.getAllMS2Fragmentations();
     return selectBestMS2Scans(allMS2Scans, topN);
@@ -1037,7 +1047,8 @@ public class ScanUtils {
   /**
    * Selects best N MS/MS scans from a collection of scans
    */
-  public static @Nonnull Collection<Scan> selectBestMS2Scans(@Nonnull Collection<Scan> scans,
+  public static @Nonnull
+  Collection<Scan> selectBestMS2Scans(@Nonnull Collection<Scan> scans,
       @Nonnull Integer topN) throws MissingMassListException {
     assert scans != null;
     assert topN != null;
@@ -1060,8 +1071,8 @@ public class ScanUtils {
    * robust method to remove most noise in the spectrum without having to estimate any noise
    * intensity parameter.
    *
-   * @param dataPoints spectrum
-   * @param binRange sliding mass window. Is shifted in each step by its width.
+   * @param dataPoints             spectrum
+   * @param binRange               sliding mass window. Is shifted in each step by its width.
    * @param numberOfFeaturesPerBin number of features to keep within the sliding mass window
    * @return
    */
@@ -1098,13 +1109,14 @@ public class ScanUtils {
    * As for cosine similarity it is recommended to first take the square root of all feature
    * intensities, before calling this method.
    *
-   * @param scanLeft the first spectrum
-   * @param scanRight the second spectrum
+   * @param scanLeft                   the first spectrum
+   * @param scanRight                  the second spectrum
    * @param expectedMassDeviationInPPM the width of the gaussians (corresponds to the expected mass
-   *        deviation). Rather use a larger than a small value! Value is given in ppm and Dalton.
-   * @param noiseLevel the lowest intensity for a feature to be considered
-   * @param mzRange the m/z range in which the features are compared. use null for the whole
-   *        spectrum
+   *                                   deviation). Rather use a larger than a small value! Value is
+   *                                   given in ppm and Dalton.
+   * @param noiseLevel                 the lowest intensity for a feature to be considered
+   * @param mzRange                    the m/z range in which the features are compared. use null
+   *                                   for the whole spectrum
    */
   public static double probabilityProduct(DataPoint[] scanLeft, DataPoint[] scanRight,
       MZTolerance expectedMassDeviationInPPM, double noiseLevel, @Nullable Range<Double> mzRange) {
@@ -1213,7 +1225,7 @@ public class ScanUtils {
    * Function adapted from module: adap.mspexport.
    *
    * @param dataPoints spectra to convert.
-   * @param intMode conversion method: MAX or SUM.
+   * @param intMode    conversion method: MAX or SUM.
    * @return DataPoint array converted to integers.
    */
   public static DataPoint[] integerDataPoints(final DataPoint[] dataPoints,


### PR DESCRIPTION
This PR adds a module to import different data files at once.

User can select files in different formats. THe buttons next to the TextArea provide fast access to list all .mzML / mzXML / ... in a folder. There is also an option to list all files in all sub folders.

There is also an "Advanced processing" option to directly apply mass detection to MS1 and MS2. The help and tooltip warns that this is an advanced option that replaces the scan data with a centroided/thresholded version. No unprocessed data.

Already implemented for mzML and mzXML it does the following:
- import scan metadata and double[] mzs / intensities arrays
- apply mass detection to "raw data" and replace mz and intensity values with thresholded centroids
- then create the SimpleScan and directly add a MassList that just points to the scan data

I mostly want to use this advanced option for headless processing of large datasets. Speed and memory usage should be slightly better and we do not store raw data that is usually not used in most workflows (e.g., FBMN on GNPS).


![image](https://user-images.githubusercontent.com/10366914/109530284-d3253680-7ab6-11eb-8b34-ed45e1a48796.png)
