### PR TITLE
More efficient ADAPChromatogramBuilder

### DIFF
--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ADAPChromatogram.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ADAPChromatogram.java
@@ -27,6 +27,7 @@ import io.github.mzmine.datamodel.FeatureStatus;
 import io.github.mzmine.datamodel.IsotopePattern;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.datamodel.featuredata.FeatureDataUtils;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.impl.SimpleDataPoint;
 import io.github.mzmine.datamodel.impl.SimpleFeatureInformation;
@@ -66,8 +67,8 @@ public class ADAPChromatogram {
   // private Hashtable<Integer, DataPoint> dataPointsMap;
   private final TreeMap<Scan, DataPoint> dataPointsMap;
 
-  // Chromatogram m/z, RT, height, area. The mz value will be the highest points mz value
-  private double mz, rt, height, area, weightedMz;
+  // Chromatogram m/z, RT, height. The mz value will be the highest points mz value
+  private double mz, rt, height, weightedMz;
   private Double fwhm = null, tf = null, af = null;
 
   // Top intensity scan, fragment scan
@@ -279,10 +280,6 @@ public class ADAPChromatogram {
     return "Chromatogram " + MZmineCore.getConfiguration().getMZFormat().format(mz) + " m/z";
   }
 
-  public double getArea() {
-    return area;
-  }
-
   public double getHeight() {
     return height;
   }
@@ -397,10 +394,8 @@ public class ADAPChromatogram {
 
     // Update raw data point ranges, height, rt and representative scan
     height = Double.MIN_VALUE;
-    area = 0;
     rawDataPointsRTRange = null;
 
-    DataPoint last = null;
     for (int i = 0; i < allScanNumbers.length; i++) {
 
       DataPoint mzFeature = dataPointsMap.get(allScanNumbers[i]);
@@ -419,17 +414,6 @@ public class ADAPChromatogram {
         rt = allScanNumbers[i].getRetentionTime();
         representativeScan = allScanNumbers[i];
       }
-
-      // update area
-      if(last!=null) {
-        // For area calculation, we use retention time in seconds
-        double previousRT = allScanNumbers[i - 1].getRetentionTime() * 60d;
-        double currentRT = allScanNumbers[i].getRetentionTime() * 60d;
-        double previousHeight = last.getIntensity();
-        double currentHeight = mzFeature.getIntensity();
-        area += (currentRT - previousRT) * (currentHeight + previousHeight) / 2;
-      }
-      last = mzFeature;
 
       // retention time
       float scanRt = allScanNumbers[i].getRetentionTime();
@@ -640,32 +624,5 @@ public class ADAPChromatogram {
       }
     }
     dataPointsMap.putAll(dataPointsToAdd);
-
-
-
-//    for (Entry<Scan, DataPoint> entry : dataPointsMap.entrySet()) {
-//      Scan nextScan = entry.getKey();
-//      while (allScansIndex < numScans && scans[allScansIndex] != nextScan) { // find the next scan
-//        allScansIndex++;
-//      }
-//      if (allScansIndex - lastScanIndex >= minGap) { // check if gap was big enough
-//        for (int i = 1; i <= zeros; i++) {
-//          if (lastScanIndex + i < numScans && lastScanIndex != 0) {
-//            dataPointsToAdd.put(scans[lastScanIndex + i], new SimpleDataPoint(getMZ(), 0d));
-//          }
-//          if (allScansIndex - i >= 0) {
-//            dataPointsToAdd.put(scans[allScansIndex - 1], new SimpleDataPoint(getMZ(), 0d));
-//          }
-//        }
-//      }
-//      lastScanIndex = allScansIndex;
-//    }
-//
-//    if (lastScanIndex + 1 < numScans) {
-//      dataPointsToAdd.put(scans[lastScanIndex + 1], new SimpleDataPoint(getMZ(), 0d));
-//    }
-//
-//    dataPointsMap.putAll(dataPointsToAdd);
-//     logger.info(() -> String.format("mz: %f\t Added %d data points", getMZ(), dataPointsToAdd.size()));
   }
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ADAPChromatogram.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ADAPChromatogram.java
@@ -60,11 +60,11 @@ public class ADAPChromatogram {
   private SimpleFeatureInformation featureInfo;
 
   // Data file of this chromatogram
-  private RawDataFile dataFile;
+  private final RawDataFile dataFile;
 
   // Data points of the chromatogram (map of scan number -> m/z feature)
   // private Hashtable<Integer, DataPoint> dataPointsMap;
-  private TreeMap<Scan, DataPoint> dataPointsMap;
+  private final TreeMap<Scan, DataPoint> dataPointsMap;
 
   // Chromatogram m/z, RT, height, area. The mz value will be the highest points mz value
   private double mz, rt, height, area, weightedMz;
@@ -108,7 +108,7 @@ public class ADAPChromatogram {
   private double highPointMZ = 0;
 
   // full stack of scans
-  private final Scan scanNumbers[];
+  private final Scan[] scanNumbers;
 
   public int tmp_see_same_scan_count = 0;
 
@@ -124,9 +124,9 @@ public class ADAPChromatogram {
 
     rawDataPointsRTRange = dataFile.getDataRTRange(1);
 
-    dataPointsMap = new TreeMap<Scan, DataPoint>();
-    buildingSegment = new Vector<Scan>();
-    chromScanList = new ArrayList<Scan>();
+    dataPointsMap = new TreeMap<>();
+    buildingSegment = new Vector<>();
+    chromScanList = new ArrayList<>();
   }
 
   public double getHighPointMZ() {
@@ -137,21 +137,19 @@ public class ADAPChromatogram {
     highPointMZ = toSet;
   }
 
-  public List getIntensitiesForCDFOut() {
+  public List<Double> getIntensitiesForCDFOut() {
     // Need all scans with no intensity to be set to zero
-
-    List intensityList = new ArrayList();
+    List<Double> intensityList = new ArrayList<>();
 
     for (int curScanNum = 0; curScanNum < scanNumbers.length; curScanNum++) {
-      if (dataPointsMap.get(curScanNum) == null) {
+      DataPoint dp = dataPointsMap.get(scanNumbers[curScanNum]);
+      if (dp == null) {
         intensityList.add(0.0);
       } else {
-        intensityList.add(dataPointsMap.get(curScanNum).getIntensity());
+        intensityList.add(dp.getIntensity());
       }
     }
-
     return intensityList;
-
   }
 
   public Collection<DataPoint> getDataPoints() {
@@ -169,7 +167,7 @@ public class ADAPChromatogram {
 
     int bestCount = 0;
     int curCount = 0;
-    Scan lastScanNum = null;
+    Scan lastScanNum;
     int scanListLength = chromScanList.size();
 
     Scan curScanNum;
@@ -209,7 +207,6 @@ public class ADAPChromatogram {
    * This method adds a MzFeature to this Chromatogram. All values of this Chromatogram (rt, m/z,
    * intensity and ranges) are updated on request
    *
-   * @param mzValue
    */
   public void addMzFeature(Scan scanNumber, DataPoint mzValue) {
     double curIntensity;
@@ -437,7 +434,7 @@ public class ADAPChromatogram {
       // retention time
       float scanRt = allScanNumbers[i].getRetentionTime();
 
-      if ((mzFeature != null) || (mzFeature.getIntensity() != 0.0)) {
+      if (mzFeature.getIntensity() != 0.0) {
         if (rawDataPointsRTRange == null) {
           rawDataPointsRTRange = Range.singleton(scanRt);
         } else {
@@ -582,7 +579,6 @@ public class ADAPChromatogram {
     assert minGap >= zeros;
 
     int allScansIndex = 0; // contains the index of the next dp after a gap
-    int lastScanIndex = 0; // contains the index of the last dp before a gap
     Map<Scan, DataPoint> dataPointsToAdd = new HashMap<>();
 
     Scan[] detectedScans = dataPointsMap.keySet().toArray(Scan[]::new);
@@ -591,7 +587,7 @@ public class ADAPChromatogram {
     int nextDetectedScanInAllIndex = -1;
     int nextDetectedScanIndex = 0;
     int currentGap = 0;
-    int added = 0;
+    int added;
     for(allScansIndex=0; allScansIndex<scanNumbers.length; allScansIndex++) {
       added = 0;
       // was a DP detected in this scan?
@@ -670,6 +666,6 @@ public class ADAPChromatogram {
 //    }
 //
 //    dataPointsMap.putAll(dataPointsToAdd);
-     logger.info(() -> String.format("mz: %f\t Added %d data points", getMZ(), dataPointsToAdd.size()));
+//     logger.info(() -> String.format("mz: %f\t Added %d data points", getMZ(), dataPointsToAdd.size()));
   }
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ModularADAPChromatogramBuilderTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ModularADAPChromatogramBuilderTask.java
@@ -231,17 +231,13 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
     // Integer[] simpleCorespondingScanNums = new Integer[corespondingScanNum.size()];
     // corespondingScanNum.toArray(simpleCorespondingScanNums );
 
-    ExpandedDataPoint[] simpleAllMzVals = new ExpandedDataPoint[allMzValues.size()];
-    allMzValues.toArray(simpleAllMzVals);
-
     // sort data points by intensity
-    Arrays.sort(simpleAllMzVals,
-        new DataPointSorter(SortingProperty.Intensity, SortingDirection.Descending));
+    allMzValues.sort(new DataPointSorter(SortingProperty.Intensity, SortingDirection.Descending));
 
     // Set<Chromatogram> buildingChromatograms;
     // buildingChromatograms = new LinkedHashSet<Chromatogram>();
 
-    double maxIntensity = simpleAllMzVals[0].getIntensity();
+    double maxIntensity = allMzValues.get(0).getIntensity();
 
     // count starts at 1 since we already have added one with a single point.
 
@@ -251,9 +247,9 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
 
 
     progress = 0.0;
-    double progressStep = (simpleAllMzVals.length > 0) ? 0.5 / simpleAllMzVals.length : 0.0;
+    double progressStep = (allMzValues.size() > 0) ? 0.5 / allMzValues.size() : 0.0;
 
-    for (ExpandedDataPoint mzFeature : simpleAllMzVals) {
+    for (ExpandedDataPoint mzFeature : allMzValues) {
 
       progress += progressStep;
 
@@ -380,12 +376,9 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
 
     }
 
-    buildingChromatograms.forEach(c -> c.addNZeros(scans, 2, 1));
-
-    ADAPChromatogram[] chromatograms = buildingChromatograms.toArray(new ADAPChromatogram[0]);
-
+    buildingChromatograms.forEach(c -> c.addNZeros(1, 1));
     // Sort the final chromatograms by m/z
-    Arrays.sort(chromatograms, new ADAPChromatogramSorter(SortingProperty.MZ, SortingDirection.Ascending));
+    buildingChromatograms.sort(new ADAPChromatogramSorter(SortingProperty.MZ, SortingDirection.Ascending));
 
     // Create new feature list
     newFeatureList = new ModularFeatureList(dataFile + " " + suffix, getMemoryMapStorage(), dataFile);
@@ -393,7 +386,7 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
     DataTypeUtils.addDefaultChromatographicTypeColumns(newFeatureList);
 
     // Add the chromatograms to the new feature list
-    for (ADAPChromatogram finishedFeature : chromatograms) {
+    for (ADAPChromatogram finishedFeature : buildingChromatograms) {
       finishedFeature.setFeatureList(newFeatureList);
       ModularFeature modular = FeatureConvertors.ADAPChromatogramToModularFeature(finishedFeature);
       ModularFeatureListRow newRow =

--- a/src/main/java/io/github/mzmine/util/ADAPChromatogramSorter.java
+++ b/src/main/java/io/github/mzmine/util/ADAPChromatogramSorter.java
@@ -1,16 +1,16 @@
 /*
  * Copyright 2006-2020 The MZmine Development Team
- * 
+ *
  * This file is part of MZmine.
- * 
+ *
  * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
  * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
  * Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
  * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
  * USA
@@ -40,17 +40,15 @@ public class ADAPChromatogramSorter implements Comparator<ADAPChromatogram> {
     Double peak1Value = getValue(peak1);
     Double peak2Value = getValue(peak2);
 
-    if (direction == SortingDirection.Ascending)
+    if (direction == SortingDirection.Ascending) {
       return peak1Value.compareTo(peak2Value);
-    else
+    } else {
       return peak2Value.compareTo(peak1Value);
-
+    }
   }
 
   private double getValue(ADAPChromatogram peak) {
     switch (property) {
-      case Area:
-        return peak.getArea();
       case Height:
         return peak.getHeight();
       case MZ:

--- a/src/main/java/io/github/mzmine/util/FeatureConvertors.java
+++ b/src/main/java/io/github/mzmine/util/FeatureConvertors.java
@@ -26,6 +26,7 @@ import io.github.mzmine.datamodel.Frame;
 import io.github.mzmine.datamodel.IMSRawDataFile;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.datamodel.featuredata.FeatureDataUtils;
 import io.github.mzmine.datamodel.featuredata.IonMobilitySeries;
 import io.github.mzmine.datamodel.featuredata.IonMobilogramTimeSeries;
 import io.github.mzmine.datamodel.featuredata.IonTimeSeries;
@@ -112,11 +113,6 @@ public class FeatureConvertors {
 
     modularFeature.set(RawFileType.class, chromatogram.getDataFile());
     modularFeature.set(DetectionType.class, chromatogram.getFeatureStatus());
-    modularFeature.set(MZType.class, chromatogram.getMZ());
-    modularFeature.set(RTType.class, (float) chromatogram.getRT());
-    modularFeature.set(HeightType.class, (float) chromatogram.getHeight());
-    modularFeature.set(AreaType.class, (float) chromatogram.getArea());
-    modularFeature.set(BestScanNumberType.class, chromatogram.getRepresentativeScanNumber());
 
     // Data points of feature
 //    modularFeature.set(DataPointsType.class, new ArrayList<>(chromatogram.getDataPoints()));
@@ -131,20 +127,12 @@ public class FeatureConvertors {
         Arrays.asList(chromatogram.getScanNumbers()));
     modularFeature.set(FeatureDataType.class, timeSeries);
 
-    // Ranges
-    Range<Float> rtRange = Range.closed(chromatogram.getRawDataPointsRTRange().lowerEndpoint(),
-        chromatogram.getRawDataPointsRTRange().upperEndpoint());
-    Range<Double> mzRange = Range.closed(chromatogram.getRawDataPointsMZRange().lowerEndpoint(),
-        chromatogram.getRawDataPointsMZRange().upperEndpoint());
-    Range<Float> intensityRange =
-        Range.closed(chromatogram.getRawDataPointsIntensityRange().lowerEndpoint().floatValue(),
-            chromatogram.getRawDataPointsIntensityRange().upperEndpoint().floatValue());
-    modularFeature.set(MZRangeType.class, mzRange);
-    modularFeature.set(RTRangeType.class, rtRange);
-    modularFeature.set(IntensityRangeType.class, intensityRange);
+    // recalculate data dependet types
+    FeatureDataUtils.recalculateIonSeriesDependingTypes(modularFeature);
 
     ObservableList<Scan> allMS2 = Arrays
-        .stream(ScanUtils.findAllMS2FragmentScans(chromatogram.getDataFile(), rtRange, mzRange))
+        .stream(ScanUtils.findAllMS2FragmentScans(chromatogram.getDataFile(),
+            modularFeature.getRawDataPointsRTRange(), modularFeature.getRawDataPointsMZRange()))
         .collect(Collectors.toCollection(FXCollections::observableArrayList));
     modularFeature.setAllMS2FragmentScans(allMS2);
 

--- a/src/main/java/io/github/mzmine/util/FeatureConvertors.java
+++ b/src/main/java/io/github/mzmine/util/FeatureConvertors.java
@@ -64,6 +64,7 @@ import io.github.mzmine.modules.dataprocessing.featdet_ionmobilitytracebuilder.R
 import io.github.mzmine.modules.dataprocessing.featdet_manual.ManualFeature;
 import io.github.mzmine.modules.dataprocessing.gapfill_samerange.SameRangePeak;
 import io.github.mzmine.modules.tools.qualityparameters.QualityParameters;
+import io.github.mzmine.util.maths.CenterMeasure;
 import io.github.mzmine.util.scans.ScanUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -128,7 +129,7 @@ public class FeatureConvertors {
     modularFeature.set(FeatureDataType.class, timeSeries);
 
     // recalculate data dependet types
-    FeatureDataUtils.recalculateIonSeriesDependingTypes(modularFeature);
+    FeatureDataUtils.recalculateIonSeriesDependingTypes(modularFeature, CenterMeasure.AUTO);
 
     ObservableList<Scan> allMS2 = Arrays
         .stream(ScanUtils.findAllMS2FragmentScans(chromatogram.getDataFile(),

--- a/src/main/java/io/github/mzmine/util/FeatureConvertors.java
+++ b/src/main/java/io/github/mzmine/util/FeatureConvertors.java
@@ -129,7 +129,7 @@ public class FeatureConvertors {
     modularFeature.set(FeatureDataType.class, timeSeries);
 
     // recalculate data dependet types
-    FeatureDataUtils.recalculateIonSeriesDependingTypes(modularFeature, CenterMeasure.AUTO);
+    FeatureDataUtils.recalculateIonSeriesDependingTypes(modularFeature);
 
     ObservableList<Scan> allMS2 = Arrays
         .stream(ScanUtils.findAllMS2FragmentScans(chromatogram.getDataFile(),


### PR DESCRIPTION
I tried to optimize a bit the ADAPChromatogramBuilder and reduce the created objects. 

- optimized the "list all data points of all scans" part
- removed unused arrays
- maybe optimized the add zeros method (at least it feels optimized)
- clean up methods

Seems to work fine for my LC-MS test data.