### PR TITLE
Feature table context menu conditions, open ims features in ims raw data overview

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/featuredata/FeatureDataUtils.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/FeatureDataUtils.java
@@ -50,13 +50,27 @@ public class FeatureDataUtils {
     double min = Double.MAX_VALUE;
     double max = Double.MIN_VALUE;
 
-    for (int i = 0; i < series.getNumberOfValues(); i++) {
-      final double mz = series.getMZ(i);
-      if (mz < min) {
-        min = mz;
+    if (series instanceof IonMobilogramTimeSeries ionTrace) {
+      for (IonMobilitySeries mobilogram : ionTrace.getMobilograms()) {
+        for (int i = 0; i < mobilogram.getNumberOfValues(); i++) {
+          final double mz = mobilogram.getMZ(i);
+          if (mz < min) {
+            min = mz;
+          }
+          if (mz > max) {
+            max = mz;
+          }
+        }
       }
-      if (mz > max) {
-        max = mz;
+    } else {
+      for (int i = 0; i < series.getNumberOfValues(); i++) {
+        final double mz = series.getMZ(i);
+        if (mz < min) {
+          min = mz;
+        }
+        if (mz > max) {
+          max = mz;
+        }
       }
     }
     return Range.closed(min, max);

--- a/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/series/IMSIonTraceHeatmapProvider.java
+++ b/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/series/IMSIonTraceHeatmapProvider.java
@@ -92,6 +92,7 @@ public class IMSIonTraceHeatmapProvider implements PlotXYZDataProvider,
       if (status.get() == TaskStatus.CANCELED) {
         return;
       }
+      // todo mobilityscandataaccess
       for (MobilityScan scan : frame.getMobilityScans()) {
         DataPoint[] dps =
             ScanUtils.selectDataPointsByMass(ScanUtils.extractDataPoints(scan), mzRange);

--- a/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableContextMenu.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableContextMenu.java
@@ -251,12 +251,11 @@ public class FeatureTableContextMenu extends ContextMenu {
             selectedFeature.getFeatureList(), selectedRows.toArray(new ModularFeatureListRow[0])));
 
     final MenuItem showInIMSRawDataOverviewItem = new ConditionalMenuItem(
-        "Show in IMS raw data overview",
+        "Show m/z ranges in IMS raw data overview",
         () -> selectedFeature != null && selectedFeature
             .getRawDataFile() instanceof IMSRawDataFile && !selectedFeatures.isEmpty());
-    showInIMSRawDataOverviewItem.setOnAction(
-        e -> IMSRawDataOverviewModule
-            .openIMSVisualizerTabWithFeatures(getFeaturesFromSelectedRaw(selectedFeatures)));
+    showInIMSRawDataOverviewItem.setOnAction(e -> IMSRawDataOverviewModule
+        .openIMSVisualizerTabWithFeatures(getFeaturesFromSelectedRaw(selectedFeatures)));
 
     final MenuItem showInIMSFeatureVisualizerItem = new ConditionalMenuItem(
         "Visualize ion mobility features", () -> !selectedFeatures.isEmpty());

--- a/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/IMSRawDataOverviewControlPanel.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/IMSRawDataOverviewControlPanel.java
@@ -29,6 +29,7 @@ import io.github.mzmine.parameters.parametertypes.tolerances.MZToleranceComponen
 import io.github.mzmine.util.color.SimpleColorPalette;
 import java.text.NumberFormat;
 import java.util.List;
+import javafx.beans.value.ChangeListener;
 import javafx.collections.FXCollections;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
@@ -42,6 +43,7 @@ import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.GridPane;
 import javafx.scene.shape.Rectangle;
+import javax.annotation.Nullable;
 
 public class IMSRawDataOverviewControlPanel extends GridPane {
 
@@ -221,6 +223,20 @@ public class IMSRawDataOverviewControlPanel extends GridPane {
 
   public List<Range<Double>> getMobilogramRangesList() {
     return mobilogramRangesList.getItems();
+  }
+
+  public void addRanges(List<Range<Double>> rangeList) {
+    rangeList.forEach(this::addRange);
+  }
+
+  public void addRange(@Nullable Range<Double> range) {
+    if (range != null) {
+      mobilogramRangesList.getItems().add(range);
+    }
+  }
+
+  public void addSelectedRangeListener(ChangeListener<Range<Double>> listener) {
+    mobilogramRangesList.getSelectionModel().selectedItemProperty().addListener(listener);
   }
 
   public double getFrameNoiseLevel() {

--- a/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/IMSRawDataOverviewModule.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/IMSRawDataOverviewModule.java
@@ -18,9 +18,12 @@
 
 package io.github.mzmine.modules.visualization.rawdataoverviewims;
 
+import io.github.mzmine.datamodel.Frame;
 import io.github.mzmine.datamodel.IMSRawDataFile;
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.features.Feature;
+import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.gui.mainwindow.MZmineTab;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.MZmineModuleCategory;
@@ -28,14 +31,47 @@ import io.github.mzmine.modules.MZmineRunnableModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesSelection;
+import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesSelectionType;
+import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class IMSRawDataOverviewModule implements MZmineRunnableModule {
+
+  public static void openIMSVisualizerTabWithFeatures(List<ModularFeature> features) {
+    if (features.isEmpty() || features.get(0) == null) {
+      return;
+    }
+
+    final ModularFeature feature = features.get(0);
+    final RawDataFilesSelection rawFileSelection = new RawDataFilesSelection(
+        RawDataFilesSelectionType.SPECIFIC_FILES);
+    rawFileSelection.setSpecificFiles(new RawDataFile[]{feature.getRawDataFile()});
+    final MZTolerance tolerance = MZTolerance
+        .getMaximumDataPointTolerance((List<Feature>) (List<? extends Feature>) features);
+
+    final ParameterSet parameterSet = MZmineCore.getConfiguration()
+        .getModuleParameters(IMSRawDataOverviewModule.class).cloneParameterSet();
+    parameterSet.getParameter(IMSRawDataOverviewParameters.rawDataFiles).setValue(rawFileSelection);
+    parameterSet.getParameter(IMSRawDataOverviewParameters.mzTolerance).setValue(tolerance);
+
+    final IMSRawDataOverviewTab tab = new IMSRawDataOverviewTab(parameterSet);
+
+    MZmineCore.runLater(() -> {
+      MZmineCore.getDesktop().addTab(tab);
+      tab.onRawDataFileSelectionChanged(List.of(feature.getRawDataFile()));
+      IMSRawDataOverviewPane pane = (IMSRawDataOverviewPane) tab.getContent();
+      pane.setSelectedFrame((Frame) feature.getRepresentativeScan());
+      pane.addRanges(
+          features.stream().map(f -> f.getRawDataPointsMZRange()).collect(Collectors.toList()));
+    });
+  }
 
   @Nonnull
   @Override

--- a/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/IMSRawDataOverviewModule.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/IMSRawDataOverviewModule.java
@@ -49,24 +49,39 @@ public class IMSRawDataOverviewModule implements MZmineRunnableModule {
       return;
     }
 
+    final List<MZmineTab> tabs = MZmineCore.getDesktop().getAllTabs();
+    IMSRawDataOverviewTab tab = null;
+    for (MZmineTab t : tabs) {
+      if (t instanceof IMSRawDataOverviewTab) {
+        tab = (IMSRawDataOverviewTab) t;
+        break;
+      }
+    }
+
     final ModularFeature feature = features.get(0);
-    final RawDataFilesSelection rawFileSelection = new RawDataFilesSelection(
-        RawDataFilesSelectionType.SPECIFIC_FILES);
-    rawFileSelection.setSpecificFiles(new RawDataFile[]{feature.getRawDataFile()});
-    final MZTolerance tolerance = MZTolerance
-        .getMaximumDataPointTolerance((List<Feature>) (List<? extends Feature>) features);
 
-    final ParameterSet parameterSet = MZmineCore.getConfiguration()
-        .getModuleParameters(IMSRawDataOverviewModule.class).cloneParameterSet();
-    parameterSet.getParameter(IMSRawDataOverviewParameters.rawDataFiles).setValue(rawFileSelection);
-    parameterSet.getParameter(IMSRawDataOverviewParameters.mzTolerance).setValue(tolerance);
+    // if no tab was found, make a new one.
+    if (tab == null) {
+      final RawDataFilesSelection rawFileSelection = new RawDataFilesSelection(
+          RawDataFilesSelectionType.SPECIFIC_FILES);
+      rawFileSelection.setSpecificFiles(new RawDataFile[]{feature.getRawDataFile()});
+      final MZTolerance tolerance = MZTolerance
+          .getMaximumDataPointTolerance((List<Feature>) (List<? extends Feature>) features);
 
-    final IMSRawDataOverviewTab tab = new IMSRawDataOverviewTab(parameterSet);
+      final ParameterSet parameterSet = MZmineCore.getConfiguration()
+          .getModuleParameters(IMSRawDataOverviewModule.class).cloneParameterSet();
+      parameterSet.getParameter(IMSRawDataOverviewParameters.rawDataFiles)
+          .setValue(rawFileSelection);
+      parameterSet.getParameter(IMSRawDataOverviewParameters.mzTolerance).setValue(tolerance);
 
+      tab = new IMSRawDataOverviewTab(parameterSet);
+    }
+
+    final var finalTab = tab;
     MZmineCore.runLater(() -> {
-      MZmineCore.getDesktop().addTab(tab);
-      tab.onRawDataFileSelectionChanged(List.of(feature.getRawDataFile()));
-      IMSRawDataOverviewPane pane = (IMSRawDataOverviewPane) tab.getContent();
+      MZmineCore.getDesktop().addTab(finalTab);
+      finalTab.onRawDataFileSelectionChanged(List.of(feature.getRawDataFile()));
+      IMSRawDataOverviewPane pane = (IMSRawDataOverviewPane) finalTab.getContent();
       pane.setSelectedFrame((Frame) feature.getRepresentativeScan());
       pane.addRanges(
           features.stream().map(f -> f.getRawDataPointsMZRange()).collect(Collectors.toList()));

--- a/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/IMSRawDataOverviewPane.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/IMSRawDataOverviewPane.java
@@ -323,9 +323,12 @@ public class IMSRawDataOverviewPane extends BorderPane {
   }
 
   private void initChartListeners() {
-    mobilogramChart.cursorPositionProperty()
-        .addListener(((observable, oldValue, newValue) -> selectedMobilityScan
-            .set(cachedFrame.getSortedMobilityScans().get(newValue.getValueIndex()))));
+    mobilogramChart.cursorPositionProperty().addListener(((observable, oldValue, newValue) -> {
+      if (newValue.getValueIndex() != -1) {
+        selectedMobilityScan
+            .set(cachedFrame.getSortedMobilityScans().get(newValue.getValueIndex()));
+      }
+    }));
     singleSpectrumChart.cursorPositionProperty().addListener(
         ((observable, oldValue, newValue) -> selectedMz
             .set(mzTolerance.getToleranceRange(newValue.getDomainValue()))));
@@ -342,6 +345,9 @@ public class IMSRawDataOverviewPane extends BorderPane {
     ticChart.cursorPositionProperty().addListener(
         ((observable, oldValue, newValue) -> setSelectedFrame((Frame) newValue.getScan())));
     ionTraceChart.cursorPositionProperty().addListener(((observable, oldValue, newValue) -> {
+      if (newValue.getDataset() == null || newValue.getValueIndex() == -1) {
+        return;
+      }
       MobilityScan selectedScan =
           ((IMSIonTraceHeatmapProvider) ((ColoredXYZDataset) newValue.getDataset())
               .getXyzValueProvider())

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/tolerances/MZTolerance.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/tolerances/MZTolerance.java
@@ -1,16 +1,16 @@
 /*
  * Copyright 2006-2020 The MZmine Development Team
- * 
+ *
  * This file is part of MZmine.
- * 
+ *
  * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
  * General Public License as published by the Free Software Foundation; either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
  * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
  * Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
  * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
  * USA
@@ -19,6 +19,8 @@
 package io.github.mzmine.parameters.parametertypes.tolerances;
 
 import com.google.common.collect.Range;
+import io.github.mzmine.datamodel.features.Feature;
+import java.util.Collection;
 
 /**
  * This class represents m/z tolerance. Tolerance is set using absolute (m/z) and relative (ppm)
@@ -36,6 +38,27 @@ public class MZTolerance {
   public MZTolerance(final double toleranceMZ, final double tolerancePPM) {
     mzTolerance = toleranceMZ;
     ppmTolerance = tolerancePPM;
+  }
+
+  public static MZTolerance getMaximumDataPointTolerance(Collection<Feature> features) {
+    double maxPPM = 0d;
+    double maxAbs = 0d;
+
+    for (Feature f : features) {
+      final Range<Double> mzRange = f.getRawDataPointsMZRange();
+      final double mz = f.getMZ();
+      final double abs = Math
+          .max(Math.abs(mzRange.lowerEndpoint() - mz), Math.abs(mzRange.upperEndpoint() - mz));
+      final double ppm = abs / mz * MILLION;
+      if (abs > maxAbs) {
+        maxAbs = abs;
+      }
+      if (ppm > maxPPM) {
+        maxPPM = ppm;
+      }
+    }
+
+    return new MZTolerance(maxAbs, maxPPM);
   }
 
   public double getMzTolerance() {

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/tolerances/MZToleranceComponent.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/tolerances/MZToleranceComponent.java
@@ -18,10 +18,13 @@
 
 package io.github.mzmine.parameters.parametertypes.tolerances;
 
+import io.github.mzmine.main.MZmineCore;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
+import javafx.scene.control.TextFormatter;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.FlowPane;
+import javafx.util.converter.NumberStringConverter;
 
 public class MZToleranceComponent extends FlowPane {
 
@@ -32,19 +35,16 @@ public class MZToleranceComponent extends FlowPane {
     // setBorder(BorderFactory.createEmptyBorder(0, 4, 0, 0));
 
     mzToleranceField = new TextField();
-    mzToleranceField.setPrefColumnCount(12);
-
+    mzToleranceField.setTextFormatter(new TextFormatter<>(
+        new NumberStringConverter(MZmineCore.getConfiguration().getMZFormat())));
 
     ppmToleranceField = new TextField();
     ppmToleranceField.setPrefColumnCount(6);
+    ppmToleranceField.setTextFormatter(new TextFormatter<>(
+        new NumberStringConverter(MZmineCore.getConfiguration().getPPMFormat())));
 
     getChildren().addAll(mzToleranceField, new Label("m/z  or"), ppmToleranceField,
         new Label("ppm"));
-  }
-
-  public void setValue(MZTolerance value) {
-    mzToleranceField.setText(String.valueOf(value.getMzTolerance()));
-    ppmToleranceField.setText(String.valueOf(value.getPpmTolerance()));
   }
 
   public MZTolerance getValue() {
@@ -56,7 +56,11 @@ public class MZToleranceComponent extends FlowPane {
     } catch (NumberFormatException e) {
       return null;
     }
+  }
 
+  public void setValue(MZTolerance value) {
+    mzToleranceField.setText(String.valueOf(value.getMzTolerance()));
+    ppmToleranceField.setText(String.valueOf(value.getPpmTolerance()));
   }
 
   public void setToolTipText(String toolTip) {


### PR DESCRIPTION
- MZTolerance gets a factory method
- MZToleranceComponent uses the built in formatters
- Adjusted some conditions in the menu items
- IMS Features can be opened in the ims raw data overview (more precisely, their m/z ranges)
- mz ranges can now be clicked to select them
![grafik](https://user-images.githubusercontent.com/37407705/110211017-d7759900-7e94-11eb-9cf0-dec95100d3a2.png)


https://user-images.githubusercontent.com/37407705/110211077-2de2d780-7e95-11eb-97c4-241ed621a248.mp4

