### PR TITLE
Switched to jfrog artifactory for jmztab 3.0.9 due to bintray discontinuation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ repositories {
     // local libraries
     maven { url = "file://" + projectDir + "/src/main/lib" }
     // For jmztab 3.0.9+ (https://github.com/PRIDE-Utilities/jmzTab)
-    maven { url = "https://dl.bintray.com/lifs/maven/" }
+    maven { url = "https://lifstools.jfrog.io/artifactory/ebi-tools/" }
     // For jmzml, etc.
     maven { url = "https://www.ebi.ac.uk/Tools/maven/repos/content/groups/ebi-repo/" }
     // For SIRIUS ID modules


### PR DESCRIPTION
Updated repository location to new lifs artifactory cloud-hosted location.