### PR TITLE
Added stacktrace to logging (JUL)

### DIFF
--- a/src/main/resources/logging.properties
+++ b/src/main/resources/logging.properties
@@ -59,4 +59,4 @@ java.util.logging.ConsoleHandler.level = FINEST
 
 java.util.logging.ConsoleHandler.formatter = io.github.mzmine.util.logging.ConsoleFormatter
 
-java.util.logging.SimpleFormatter.format= %2$[%1$tF %1$tT] [%4$s] %5$s %n
+java.util.logging.SimpleFormatter.format= %2$[%1$tF %1$tT] [%4$s] %5$s %6$s %n


### PR DESCRIPTION
Stack trace was missing

Exception ex ....
now use logger.log(level, ex.getMessage), ex)