### PR TITLE
fixed image dimensions not set if shimadzu imzml was imported

### DIFF
--- a/src/main/java/io/github/mzmine/modules/io/import_imzml/ImagingParameters.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_imzml/ImagingParameters.java
@@ -166,6 +166,13 @@ public class ImagingParameters {
           scanDirection = ScanDirection.HORIZONTAL;
         }
       }
+
+      if(Double.compare(lateralHeight, 0d) == 0) {
+        lateralHeight = maxNumberOfPixelY * pixelHeight;
+      }
+      if(Double.compare(lateralWidth, 0d) == 0) {
+        lateralWidth = maxNumberOfPixelX * pixelWidth;
+      }
     }
   }
 

--- a/src/main/java/io/github/mzmine/util/FeatureConvertors.java
+++ b/src/main/java/io/github/mzmine/util/FeatureConvertors.java
@@ -346,6 +346,8 @@ public class FeatureConvertors {
     modularFeature.set(AsymmetryFactorType.class, -1f);
     // }
 
+    FeatureDataUtils.recalculateIonSeriesDependingTypes(modularFeature);
+
     return modularFeature;
   }
 


### PR DESCRIPTION
shimadzu imzml converter does not save the absolute dimensions of the image, therefore we need to calculate it