### PR TITLE
fix tic plot crash due to too many points at one rt (imzml)

### DIFF
--- a/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICDataSet.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICDataSet.java
@@ -363,10 +363,10 @@ public class TICDataSet extends AbstractXYZDataset implements Task {
     final TICPlotType plotType = this.plotType;
 
     // fix for imZML files without a retention time in their scans -> crashes TIC Plot
-    boolean useFakeRt = Double
+    boolean useScanNumberAsRt = Double
         .compare(scans.get(0).getRetentionTime(), scans.get(scans.size() - 1).getRetentionTime())
         == 0;
-    if(useFakeRt && window != null) {
+    if(useScanNumberAsRt && window != null) {
       final NumberAxis axis = (NumberAxis) window.getTICPlot().getXYPlot().getDomainAxis();
       MZmineCore.runLater(() -> axis.setLabel("Scan number"));
     }
@@ -400,7 +400,7 @@ public class TICDataSet extends AbstractXYZDataset implements Task {
       }
 
       intensityValues[index] = intensity;
-      rtValues[index] = useFakeRt ? index : scan.getRetentionTime();
+      rtValues[index] = useScanNumberAsRt ? scan.getScanNumber() : scan.getRetentionTime();
 
       // Update min and max.
       if (index == 0) {

--- a/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICDataSet.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICDataSet.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jfree.chart.axis.NumberAxis;
 import org.jfree.data.xy.AbstractXYZDataset;
 import com.google.common.collect.Range;
 import com.google.common.primitives.Ints;
@@ -44,7 +45,7 @@ import javafx.collections.ObservableList;
 /**
  * TIC visualizer data set. One data set is created per file shown in this visualizer. We need to
  * create separate data set for each file because the user may add/remove files later.
- *
+ * <p>
  * Added the possibility to switch to TIC plot type from a "non-TICVisualizerWindow" context.
  */
 public class TICDataSet extends AbstractXYZDataset implements Task {
@@ -75,6 +76,7 @@ public class TICDataSet extends AbstractXYZDataset implements Task {
   private final Range<Double> mzRange;
   private double intensityMin;
   private double intensityMax;
+  private TICVisualizerTab window;
 
   private TaskStatus status;
   private String errorMessage;
@@ -87,10 +89,10 @@ public class TICDataSet extends AbstractXYZDataset implements Task {
   /**
    * Create the data set.
    *
-   * @param file data file to plot.
-   * @param scans scans to plot.
+   * @param file    data file to plot.
+   * @param scans   scans to plot.
    * @param rangeMZ range of m/z to plot.
-   * @param window visualizer window.
+   * @param window  visualizer window.
    */
   public TICDataSet(final RawDataFile file, final ObservableList<Scan> scans,
       final Range<Double> rangeMZ, final TICVisualizerTab window) {
@@ -102,10 +104,10 @@ public class TICDataSet extends AbstractXYZDataset implements Task {
    * Create the data set + possibility to specify a plot type, even outside a "TICVisualizerWindow"
    * context.
    *
-   * @param file data file to plot.
-   * @param scans scans to plot.
-   * @param rangeMZ range of m/z to plot.
-   * @param window visualizer window.
+   * @param file     data file to plot.
+   * @param scans    scans to plot.
+   * @param rangeMZ  range of m/z to plot.
+   * @param window   visualizer window.
    * @param plotType plot type.
    */
   public TICDataSet(final RawDataFile file, final List<Scan> scans, final Range<Double> rangeMZ,
@@ -121,6 +123,7 @@ public class TICDataSet extends AbstractXYZDataset implements Task {
     processedScans = 0;
     intensityMin = 0.0;
     intensityMax = 0.0;
+    this.window = window;
 
     status = TaskStatus.WAITING;
     errorMessage = null;
@@ -248,7 +251,7 @@ public class TICDataSet extends AbstractXYZDataset implements Task {
    * Returns index of data point which exactly matches given X and Y values
    *
    * @param retentionTime retention time.
-   * @param intensity intensity.
+   * @param intensity     intensity.
    * @return the nearest data point index.
    */
   public int getIndex(final double retentionTime, final double intensity) {
@@ -359,6 +362,15 @@ public class TICDataSet extends AbstractXYZDataset implements Task {
     // Determine plot type (now done from constructor).
     final TICPlotType plotType = this.plotType;
 
+    // fix for imZML files without a retention time in their scans -> crashes TIC Plot
+    boolean useFakeRt = Double
+        .compare(scans.get(0).getRetentionTime(), scans.get(scans.size() - 1).getRetentionTime())
+        == 0;
+    if(useFakeRt && window != null) {
+      final NumberAxis axis = (NumberAxis) window.getTICPlot().getXYPlot().getDomainAxis();
+      MZmineCore.runLater(() -> axis.setLabel("Scan number"));
+    }
+
     // Process each scan.
     for (int index = 0; status != TaskStatus.CANCELED && index < totalScans; index++) {
 
@@ -388,7 +400,7 @@ public class TICDataSet extends AbstractXYZDataset implements Task {
       }
 
       intensityValues[index] = intensity;
-      rtValues[index] = scan.getRetentionTime();
+      rtValues[index] = useFakeRt ? index : scan.getRetentionTime();
 
       // Update min and max.
       if (index == 0) {


### PR DESCRIPTION
In shimadzu imzml files no retention time is given. In TIC plots every data point was plotted at RT = 0, which probably lead to rendering issues due to the transparancy oder so (just a guess). 

I introduced a kind of dirty hack to compensate for that in TIC charts, cause they are displayed at some occacions (e.g. KMD feature investigator). Under these circumstances, the Retention time is replaced with the scan number.