### PR TITLE
Fixes: Contextmenu MSMS, Common Prefix, NPE

### DIFF
--- a/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/features/RowToMobilityMzHeatmapProvider.java
+++ b/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/features/RowToMobilityMzHeatmapProvider.java
@@ -128,7 +128,7 @@ public class RowToMobilityMzHeatmapProvider implements PieXYZDataProvider<IMSRaw
       final ModularFeatureListRow row = rows.get(i);
       for (final IMSRawDataFile file : files) {
         final ModularFeature feature = row.getFeature(file);
-        if (feature.getFeatureStatus() != FeatureStatus.UNKNOWN) {
+        if (feature != null && feature.getFeatureStatus() != FeatureStatus.UNKNOWN) {
           summedValues[i] += feature.getHeight();
         }
         minValue = Math.min(summedValues[i], minValue);
@@ -177,7 +177,7 @@ public class RowToMobilityMzHeatmapProvider implements PieXYZDataProvider<IMSRaw
   public double getZValue(int series, int item) {
     final ModularFeatureListRow row = rows.get(item);
     final ModularFeature f = row.getFeature(files[series]);
-    if (f.getFeatureStatus() != FeatureStatus.UNKNOWN) {
+    if (f != null && f.getFeatureStatus() != FeatureStatus.UNKNOWN) {
       return f.getHeight();
     }
     return 0d;

--- a/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableContextMenu.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableContextMenu.java
@@ -21,11 +21,13 @@ package io.github.mzmine.modules.visualization.featurelisttable_modular;
 
 import com.google.common.collect.Range;
 import io.github.mzmine.datamodel.FeatureIdentity;
+import io.github.mzmine.datamodel.FeatureStatus;
 import io.github.mzmine.datamodel.Frame;
 import io.github.mzmine.datamodel.IMSRawDataFile;
 import io.github.mzmine.datamodel.MergedMassSpectrum;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.featuredata.IonMobilogramTimeSeries;
+import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.datamodel.features.types.DataType;
@@ -97,6 +99,7 @@ public class FeatureTableContextMenu extends ContextMenu {
   private List<ModularFeatureListRow> selectedRows;
   @Nullable
   private ModularFeature selectedFeature;
+  @Nullable ModularFeatureListRow selectedRow;
 
   private List<FeatureIdentity> copiedIDs;
 
@@ -135,8 +138,8 @@ public class FeatureTableContextMenu extends ContextMenu {
     final MenuItem openCompoundIdUrl = new ConditionalMenuItem("Open compound ID URL (disabled)",
         () -> false);
 
-    final MenuItem copyIdsItem = new ConditionalMenuItem("Copy identities", () ->
-        !selectedRows.isEmpty() && !selectedRows.get(0).getPeakIdentities().isEmpty());
+    final MenuItem copyIdsItem = new ConditionalMenuItem("Copy identities",
+        () -> !selectedRows.isEmpty() && !selectedRows.get(0).getPeakIdentities().isEmpty());
     copyIdsItem.setOnAction(e -> copiedIDs = selectedRows.get(0).getPeakIdentities());
 
     final MenuItem pasteIdsItem = new ConditionalMenuItem("Paste identities",
@@ -170,7 +173,7 @@ public class FeatureTableContextMenu extends ContextMenu {
     exportToSirius.setOnAction(e -> SiriusExportModule
         .exportSingleRows(selectedRows.toArray(new ModularFeatureListRow[0])));
 
-    final MenuItem exportMS1Library = new ConditionalMenuItem("Export to MS1 library (Swing)",
+    final MenuItem exportMS1Library = new ConditionalMenuItem("Export to MS1 library",
         () -> !selectedRows.isEmpty());
     exportMS1Library.setOnAction(e -> MZmineCore.runLater(() -> {
       MSMSLibrarySubmissionWindow window = new MSMSLibrarySubmissionWindow();
@@ -179,7 +182,7 @@ public class FeatureTableContextMenu extends ContextMenu {
       window.show();
     }));
 
-    final MenuItem exportMSMSLibrary = new ConditionalMenuItem("Export to MS/MS library (Swing)",
+    final MenuItem exportMSMSLibrary = new ConditionalMenuItem("Export to MS/MS library",
         () -> !selectedRows.isEmpty());
     exportMSMSLibrary.setOnAction(e -> MZmineCore.runLater(() -> {
       MSMSLibrarySubmissionWindow window = new MSMSLibrarySubmissionWindow();
@@ -253,28 +256,28 @@ public class FeatureTableContextMenu extends ContextMenu {
 
     final MenuItem show2DItem = new ConditionalMenuItem("Feature in 2D",
         () -> selectedFeature != null);
-    show2DItem.setOnAction(
-        e -> TwoDVisualizerModule.show2DVisualizerSetupDialog(selectedFeature.getRawDataFile(),
+    show2DItem.setOnAction(e -> TwoDVisualizerModule
+        .show2DVisualizerSetupDialog(selectedFeature.getRawDataFile(),
             selectedFeature.getRawDataPointsMZRange(), selectedFeature.getRawDataPointsRTRange()));
 
     final MenuItem show3DItem = new ConditionalMenuItem("Feature in 3D",
         () -> selectedFeature != null);
-    show3DItem.setOnAction(
-        e -> Fx3DVisualizerModule.setupNew3DVisualizer(selectedFeature.getRawDataFile(),
+    show3DItem.setOnAction(e -> Fx3DVisualizerModule
+        .setupNew3DVisualizer(selectedFeature.getRawDataFile(),
             selectedFeature.getRawDataPointsMZRange(), selectedFeature.getRawDataPointsRTRange(),
             selectedFeature));
 
     final MenuItem showIntensityPlotItem = new ConditionalMenuItem(
         "Plot using Intensity plot module",
         () -> !selectedRows.isEmpty() && selectedFeature != null);
-    showIntensityPlotItem.setOnAction(e ->
-        IntensityPlotModule.showIntensityPlot(MZmineCore.getProjectManager().getCurrentProject(),
+    showIntensityPlotItem.setOnAction(e -> IntensityPlotModule
+        .showIntensityPlot(MZmineCore.getProjectManager().getCurrentProject(),
             selectedFeature.getFeatureList(), selectedRows.toArray(new ModularFeatureListRow[0])));
 
     final MenuItem showInIMSRawDataOverviewItem = new ConditionalMenuItem(
         "Show m/z ranges in IMS raw data overview",
-        () -> selectedFeature != null && selectedFeature
-            .getRawDataFile() instanceof IMSRawDataFile && !selectedFeatures.isEmpty());
+        () -> selectedFeature != null && selectedFeature.getRawDataFile() instanceof IMSRawDataFile
+            && !selectedFeatures.isEmpty());
     showInIMSRawDataOverviewItem.setOnAction(e -> IMSRawDataOverviewModule
         .openIMSVisualizerTabWithFeatures(getFeaturesFromSelectedRaw(selectedFeatures)));
 
@@ -283,32 +286,30 @@ public class FeatureTableContextMenu extends ContextMenu {
     showInMobilityMzVisualizerItem.setOnAction(e -> {
       boolean useMobilograms = true;
       if (selectedFeatures.size() > 1000) {
-        useMobilograms = MZmineCore.getDesktop()
-                             .displayConfirmation("You selected " + selectedFeatures.size()
-                                                  + " to visualize. This might take a long time or crash MZmine.\nWould you like to "
-                                                  + "visualize points instead of mobilograms for features?",
-                                 ButtonType.YES,
-                                 ButtonType.NO) == ButtonType.NO;
+        useMobilograms = MZmineCore.getDesktop().displayConfirmation(
+            "You selected " + selectedFeatures.size()
+                + " to visualize. This might take a long time or crash MZmine.\nWould you like to "
+                + "visualize points instead of mobilograms for features?", ButtonType.YES,
+            ButtonType.NO) == ButtonType.NO;
       }
       IMSMobilityMzPlotModule.visualizeFeaturesInNewTab(selectedRows, useMobilograms);
     });
 
     final MenuItem showSpectrumItem = new ConditionalMenuItem("Mass spectrum",
         () -> selectedFeature != null && selectedFeature.getRepresentativeScan() != null);
-    showSpectrumItem.setOnAction(
-        e -> SpectraVisualizerModule.addNewSpectrumTab(selectedFeature.getRawDataFile(),
+    showSpectrumItem.setOnAction(e -> SpectraVisualizerModule
+        .addNewSpectrumTab(selectedFeature.getRawDataFile(),
             selectedFeature.getRepresentativeScan(), selectedFeature));
 
     final MenuItem showBestMobilityScanItem = new ConditionalMenuItem("Best mobility scan",
         () -> selectedFeature != null && selectedFeature.getRepresentativeScan() instanceof Frame
-              && selectedFeature.getFeatureData() instanceof IonMobilogramTimeSeries);
-    showBestMobilityScanItem.setOnAction(e -> SpectraVisualizerModule.addNewSpectrumTab(
-        IonMobilityUtils.getBestMobilityScan(selectedFeature)));
+            && selectedFeature.getFeatureData() instanceof IonMobilogramTimeSeries);
+    showBestMobilityScanItem.setOnAction(e -> SpectraVisualizerModule
+        .addNewSpectrumTab(IonMobilityUtils.getBestMobilityScan(selectedFeature)));
 
     final MenuItem extractSumSpectrumFromMobScans = new ConditionalMenuItem(
-        "Extract spectrum from mobility FWHM",
-        () -> selectedFeature != null && selectedFeature
-            .getFeatureData() instanceof IonMobilogramTimeSeries);
+        "Extract spectrum from mobility FWHM", () -> selectedFeature != null && selectedFeature
+        .getFeatureData() instanceof IonMobilogramTimeSeries);
     extractSumSpectrumFromMobScans.setOnAction(e -> {
       Range<Float> fwhm = IonMobilityUtils.getMobilityFWHM(
           ((IonMobilogramTimeSeries) selectedFeature.getFeatureData()).getSummedMobilogram());
@@ -322,14 +323,18 @@ public class FeatureTableContextMenu extends ContextMenu {
 
     // TODO this should display selected features instead of rows. MultiMSMSWindow does not support that, however.
     final MenuItem showMSMSItem = new ConditionalMenuItem("Most intense MS/MS",
-        () -> getNumberOfRowsWithFragmentScans(selectedRows) >= 1 && selectedFeature != null);
+        () -> (selectedRow != null && getNumberOfFeaturesWithFragmentScans(selectedRow) >= 1) || (
+            selectedFeature != null && selectedFeature.getMostIntenseFragmentScan() != null)
+            || (selectedRows.size() > 1 && getNumberOfRowsWithFragmentScans(selectedRows) > 1));
     showMSMSItem.setOnAction(e -> {
-      if (getNumberOfRowsWithFragmentScans(selectedRows) > 1) {
+      if (selectedFeature != null && selectedFeature.getMostIntenseFragmentScan() != null) {
+        SpectraVisualizerModule.addNewSpectrumTab(selectedFeature.getMostIntenseFragmentScan());
+      } else if (selectedRows.size() > 1 && getNumberOfRowsWithFragmentScans(selectedRows) > 1) {
         MultiMsMsTab multi = new MultiMsMsTab(selectedRows,
             table.getFeatureList().getRawDataFiles(), selectedRows.get(0).getRawDataFiles().get(0));
         MZmineCore.getDesktop().addTab(multi);
-      } else {
-        SpectraVisualizerModule.addNewSpectrumTab(selectedFeature.getMostIntenseFragmentScan());
+      } else if (selectedRow != null && selectedRow.getBestFragmentation() != null) {
+        SpectraVisualizerModule.addNewSpectrumTab(selectedRow.getBestFragmentation());
       }
     });
 
@@ -342,7 +347,7 @@ public class FeatureTableContextMenu extends ContextMenu {
       mirrorScanTab.show();
     });
 
-    final MenuItem showAllMSMSItem = new ConditionalMenuItem("All MS/MS (still Swing)",
+    final MenuItem showAllMSMSItem = new ConditionalMenuItem("All MS/MS",
         () -> !selectedRows.isEmpty() && !selectedRows.get(0).getAllMS2Fragmentations().isEmpty());
     showAllMSMSItem.setOnAction(
         e -> MultiSpectraVisualizerTab.addNewMultiSpectraVisualizerTab(selectedRows.get(0)));
@@ -364,13 +369,10 @@ public class FeatureTableContextMenu extends ContextMenu {
     showMenu.getItems()
         .addAll(showXICItem, showXICSetupItem, showIMSFeatureItem, new SeparatorMenuItem(),
             show2DItem, show3DItem, showIntensityPlotItem, showInIMSRawDataOverviewItem,
-            showInMobilityMzVisualizerItem,
-            new SeparatorMenuItem(),
-            showSpectrumItem, showBestMobilityScanItem, extractSumSpectrumFromMobScans,
-            showMSMSItem, showMSMSMirrorItem,
-            showAllMSMSItem,
-            new SeparatorMenuItem(), showIsotopePatternItem, showSpectralDBResults,
-            new SeparatorMenuItem(), showPeakRowSummaryItem);
+            showInMobilityMzVisualizerItem, new SeparatorMenuItem(), showSpectrumItem,
+            showBestMobilityScanItem, extractSumSpectrumFromMobScans, showMSMSItem,
+            showMSMSMirrorItem, showAllMSMSItem, new SeparatorMenuItem(), showIsotopePatternItem,
+            showSpectralDBResults, new SeparatorMenuItem(), showPeakRowSummaryItem);
   }
 
   private void onShown() {
@@ -380,6 +382,7 @@ public class FeatureTableContextMenu extends ContextMenu {
     selectedFeatures = table.getSelectedFeatures();
     selectedRows = table.getSelectedRows();
     selectedFeature = table.getSelectedFeature();
+    selectedRow = table.getSelectedRow();
 
     // for single-raw-file-feature-lists it's intuitive to be able to click on the row columns, too
     if (selectedFeature == null && selectedRows.size() == 1
@@ -415,10 +418,24 @@ public class FeatureTableContextMenu extends ContextMenu {
     return numFragmentScans;
   }
 
+  private int getNumberOfFeaturesWithFragmentScans(@Nullable ModularFeatureListRow row) {
+    if (row == null) {
+      return 0;
+    }
+
+    int num = 0;
+    for (Feature feature : row.getFeatures()) {
+      if (feature != null && feature.getFeatureStatus() != FeatureStatus.UNKNOWN
+          && feature.getMostIntenseFragmentScan() != null) {
+        num++;
+      }
+    }
+    return num;
+  }
+
   private boolean rowHasSpectralDBMatchResults(ModularFeatureListRow row) {
-    return row.getPeakIdentities().stream()
-               .filter(pi -> pi instanceof SpectralDBFeatureIdentity)
-               .map(pi -> ((SpectralDBFeatureIdentity) pi)).count() > 0;
+    return row.getPeakIdentities().stream().filter(pi -> pi instanceof SpectralDBFeatureIdentity)
+        .map(pi -> ((SpectralDBFeatureIdentity) pi)).count() > 0;
   }
 
   @NotNull

--- a/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFX.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFX.java
@@ -46,7 +46,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
-import java.util.Random;
 import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -79,7 +78,8 @@ import org.jetbrains.annotations.Nullable;
  *
  * @author Robin Schmid (robinschmid@uni-muenster.de)
  */
-public class FeatureTableFX extends TreeTableView<ModularFeatureListRow> implements ListChangeListener<FeatureListRow> {
+public class FeatureTableFX extends TreeTableView<ModularFeatureListRow> implements
+    ListChangeListener<FeatureListRow> {
 
   private final FilteredList<TreeItem<ModularFeatureListRow>> filteredRowItems;
   private final ObservableList<TreeItem<ModularFeatureListRow>> rowItems;
@@ -124,8 +124,8 @@ public class FeatureTableFX extends TreeTableView<ModularFeatureListRow> impleme
     // fields
 
     // enable copy on selection
-    final KeyCodeCombination keyCodeCopy =
-        new KeyCodeCombination(KeyCode.C, KeyCombination.CONTROL_ANY);
+    final KeyCodeCombination keyCodeCopy = new KeyCodeCombination(KeyCode.C,
+        KeyCombination.CONTROL_ANY);
 
     this.setOnKeyPressed(event -> {
       if (keyCodeCopy.match(event)) {
@@ -150,8 +150,8 @@ public class FeatureTableFX extends TreeTableView<ModularFeatureListRow> impleme
 
   @SuppressWarnings("unchecked")
   private void editFocusedCell() {
-    TreeTablePosition<ModularFeatureListRow, ?> focusedCell =
-        this.focusModelProperty().get().focusedCellProperty().get();
+    TreeTablePosition<ModularFeatureListRow, ?> focusedCell = this.focusModelProperty().get()
+        .focusedCellProperty().get();
     this.edit(focusedCell.getRow(), focusedCell.getTableColumn());
   }
 
@@ -175,8 +175,7 @@ public class FeatureTableFX extends TreeTableView<ModularFeatureListRow> impleme
       }
       if (c.wasRemoved()) {
         List<TreeItem<io.github.mzmine.datamodel.features.ModularFeatureListRow>> removedItems = TreeViewUtils
-            .getTreeItemsByValue((Collection<ModularFeatureListRow>) c.getRemoved(),
-                rowItems);
+            .getTreeItemsByValue((Collection<ModularFeatureListRow>) c.getRemoved(), rowItems);
         if (removedItems.contains(getSelectionModel().getSelectedItem())) {
           getSelectionModel().clearSelection();
         }
@@ -199,8 +198,8 @@ public class FeatureTableFX extends TreeTableView<ModularFeatureListRow> impleme
     assert flist instanceof ModularFeatureList : "Feature list is not modular";
     ModularFeatureList featureList = (ModularFeatureList) flist;
     // add row types
-    featureList.getRowTypes().values().stream()
-        .filter(t -> !(t instanceof FeaturesType)).forEach(this::addColumn);
+    featureList.getRowTypes().values().stream().filter(t -> !(t instanceof FeaturesType))
+        .forEach(this::addColumn);
     // add features
     if (featureList.getRowTypes().containsKey(FeaturesType.class)) {
       addColumn(featureList.getRowTypes().get(FeaturesType.class));
@@ -247,8 +246,7 @@ public class FeatureTableFX extends TreeTableView<ModularFeatureListRow> impleme
   }
 
   private void setupExpandableColumn(DataType<?> dataType,
-      TreeTableColumn<ModularFeatureListRow, ?> col,
-      ColumnType colType, RawDataFile dataFile) {
+      TreeTableColumn<ModularFeatureListRow, ?> col, ColumnType colType, RawDataFile dataFile) {
     // Initialize buddy(expanded/hidden for hidden/expanded respectively) column and it's data type
     TreeTableColumn<ModularFeatureListRow, ?> buddyCol = null;
     DataType<?> buddyDataType = null;
@@ -256,9 +254,9 @@ public class FeatureTableFX extends TreeTableView<ModularFeatureListRow> impleme
     for (Entry<TreeTableColumn<ModularFeatureListRow, ?>, ColumnID> entry : newColumnMap
         .entrySet()) {
       if (Objects.equals(entry.getValue().getDataType().getClass(),
-          ((ExpandableType) dataType).getBuddyTypeClass())
-          && Objects.equals(entry.getValue().getType(), colType)
-          && Objects.equals(entry.getValue().getRaw(), dataFile)) {
+          ((ExpandableType) dataType).getBuddyTypeClass()) && Objects
+          .equals(entry.getValue().getType(), colType) && Objects
+          .equals(entry.getValue().getRaw(), dataFile)) {
         buddyCol = entry.getKey();
         buddyDataType = entry.getValue().getDataType();
       }
@@ -407,8 +405,7 @@ public class FeatureTableFX extends TreeTableView<ModularFeatureListRow> impleme
 
     // Add feature columns for each raw file
     for (RawDataFile dataFile : getFeatureList().getRawDataFiles()) {
-      TreeTableColumn<ModularFeatureListRow, String> sampleCol =
-          new TreeTableColumn<>();
+      TreeTableColumn<ModularFeatureListRow, String> sampleCol = new TreeTableColumn<>();
 
       // Add raw data file label
       Label headerLabel = new Label(dataFile.getName());
@@ -448,7 +445,7 @@ public class FeatureTableFX extends TreeTableView<ModularFeatureListRow> impleme
 
         TreeTablePosition<ModularFeatureListRow, ?> focusedCell = getFocusModel().getFocusedCell();
         TreeTableColumn<ModularFeatureListRow, ?> tableColumn = focusedCell.getTableColumn();
-        if(tableColumn == null) {
+        if (tableColumn == null) {
           // double click on header (happens when sorting)
           return;
         }
@@ -469,8 +466,7 @@ public class FeatureTableFX extends TreeTableView<ModularFeatureListRow> impleme
             }
           }
 
-          ModularFeatureListRow row = getSelectionModel().getSelectedItem()
-              .getValue();
+          ModularFeatureListRow row = getSelectionModel().getSelectedItem().getValue();
           Runnable runnable = ((DataType<?>) userData).getDoubleClickAction(row, files);
           if (runnable != null) {
             runnable.run();
@@ -483,6 +479,12 @@ public class FeatureTableFX extends TreeTableView<ModularFeatureListRow> impleme
   public List<ModularFeatureListRow> getSelectedRows() {
     return getSelectionModel().getSelectedItems().stream().map(TreeItem::getValue)
         .collect(Collectors.toList());
+  }
+
+  @Nullable
+  public ModularFeatureListRow getSelectedRow() {
+    return getSelectionModel().getSelectedItem() != null ? getSelectionModel().getSelectedItem()
+        .getValue() : null;
   }
 
   /**

--- a/src/main/java/io/github/mzmine/util/RawDataFileUtils.java
+++ b/src/main/java/io/github/mzmine/util/RawDataFileUtils.java
@@ -200,8 +200,7 @@ public class RawDataFileUtils {
       commonPrefix = textField.getText();
     }
 
-    return commonPrefix;
-
+    return null;
   }
 
   public static @NotNull Range<Float> findTotalRTRange(RawDataFile dataFiles[], int msLevel) {


### PR DESCRIPTION
- if a row type is selected in the feature table, "show most intense ms/ms" will not be disabled, but show the most intense msms of the row
- common prefix removal always removed prefixes, no matter which button was pressed
- npe in a chart provider