### PR TITLE
All ms ms - added mobilogram

### DIFF
--- a/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/features/FeatureRawMobilogramProvider.java
+++ b/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/features/FeatureRawMobilogramProvider.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2006-2020 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ * USA
+ */
+
+package io.github.mzmine.gui.chartbasics.simplechart.providers.impl.features;
+
+import com.google.common.collect.Range;
+import io.github.mzmine.datamodel.Frame;
+import io.github.mzmine.datamodel.IMSRawDataFile;
+import io.github.mzmine.datamodel.data_access.BinningMobilogramDataAccess;
+import io.github.mzmine.datamodel.featuredata.IonMobilitySeries;
+import io.github.mzmine.datamodel.featuredata.IonMobilogramTimeSeries;
+import io.github.mzmine.datamodel.featuredata.impl.SummedIntensityMobilitySeries;
+import io.github.mzmine.datamodel.features.ModularFeature;
+import io.github.mzmine.datamodel.features.ModularFeatureList;
+import io.github.mzmine.gui.chartbasics.simplechart.providers.PlotXYDataProvider;
+import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.taskcontrol.TaskStatus;
+import io.github.mzmine.util.FeatureUtils;
+import io.github.mzmine.util.IonMobilityUtils;
+import io.github.mzmine.util.IonMobilityUtils.MobilogramType;
+import java.awt.Color;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.List;
+import javafx.beans.property.SimpleObjectProperty;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Goes to the raw data and builds a mobilogram for the m/z and mobility range of the feature.
+ * Useful for comparing the processed to the actual raw data.
+ */
+public class FeatureRawMobilogramProvider implements PlotXYDataProvider {
+
+  private final NumberFormat rtFormat = MZmineCore.getConfiguration().getRTFormat();
+  private final NumberFormat mzFormat = MZmineCore.getConfiguration().getMZFormat();
+  private final NumberFormat mobilityFormat = MZmineCore.getConfiguration().getMobilityFormat();
+  private final NumberFormat intensityFormat = MZmineCore.getConfiguration().getIntensityFormat();
+  private final ModularFeature f;
+  private final IonMobilogramTimeSeries featureData;
+  private SummedIntensityMobilitySeries rawMobilogram;
+  private final Range<Double> mzRange;
+  private double percentage = 0d;
+
+  public FeatureRawMobilogramProvider(@NotNull final ModularFeature f,
+      @NotNull final Range<Double> mzRange) {
+    this.f = f;
+    this.mzRange = mzRange;
+    if (f.getFeatureData() instanceof IonMobilogramTimeSeries) {
+      featureData = (IonMobilogramTimeSeries) f.getFeatureData();
+    } else {
+      throw new IllegalArgumentException("Feature does not have mobility data.");
+    }
+  }
+
+  @NotNull
+  @Override
+  public Color getAWTColor() {
+    return f.getRawDataFile().getColorAWT();
+  }
+
+  @NotNull
+  @Override
+  public javafx.scene.paint.Color getFXColor() {
+    return f.getRawDataFile().getColor();
+  }
+
+  @Override
+  public @Nullable String getLabel(int index) {
+    return mobilityFormat.format(rawMobilogram.getMobility(index));
+  }
+
+  @Override
+  public @NotNull Comparable<?> getSeriesKey() {
+    return FeatureUtils.featureToString(f) + " (raw)";
+  }
+
+  @Override
+  public @Nullable String getToolTipText(int itemIndex) {
+    return null;
+  }
+
+  @Override
+  public void computeValues(SimpleObjectProperty<TaskStatus> status) {
+    final List<Frame> frames = featureData.getSpectra();
+    final List<IonMobilitySeries> mobilograms = new ArrayList<>();
+    for (int i = 0; i < frames.size(); i++) {
+      percentage = i / ((double) frames.size() - 1);
+
+      final Frame frame = frames.get(i);
+      mobilograms.add(IonMobilityUtils
+          .buildMobilogramForMzRange(frame, mzRange, MobilogramType.BASE_PEAK, null));
+      if (status.get() == TaskStatus.CANCELED) {
+        return;
+      }
+    }
+
+    final int binningWith = BinningMobilogramDataAccess
+        .getPreviousBinningWith((ModularFeatureList) f.getFeatureList(), f.getMobilityUnit());
+    var binner = new BinningMobilogramDataAccess((IMSRawDataFile) f.getRawDataFile(), binningWith);
+    binner.setMobilogram(mobilograms);
+    rawMobilogram = binner.toSummedMobilogram(null);
+    percentage = 1d;
+  }
+
+  @Override
+  public double getDomainValue(int index) {
+    return rawMobilogram.getMobility(index);
+  }
+
+  @Override
+  public double getRangeValue(int index) {
+    return rawMobilogram.getIntensity(index);
+  }
+
+  @Override
+  public int getValueCount() {
+    return rawMobilogram.getNumberOfValues();
+  }
+
+  @Override
+  public double getComputationFinishedPercentage() {
+    return percentage;
+  }
+}

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/MultiSpectraVisualizerPane.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/MultiSpectraVisualizerPane.java
@@ -19,21 +19,35 @@
 package io.github.mzmine.modules.visualization.spectra.simplespectra;
 
 import com.google.common.collect.Range;
+import io.github.mzmine.datamodel.MergedMsMsSpectrum;
+import io.github.mzmine.datamodel.MobilityScan;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.datamodel.featuredata.IonMobilogramTimeSeries;
 import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.FeatureListRow;
+import io.github.mzmine.datamodel.features.ModularFeature;
+import io.github.mzmine.gui.chartbasics.simplechart.SimpleXYChart;
+import io.github.mzmine.gui.chartbasics.simplechart.providers.PlotXYDataProvider;
+import io.github.mzmine.gui.chartbasics.simplechart.providers.impl.features.FeatureRawMobilogramProvider;
+import io.github.mzmine.gui.chartbasics.simplechart.providers.impl.series.SummedMobilogramXYProvider;
+import io.github.mzmine.gui.preferences.UnitFormat;
+import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.visualization.chromatogram.TICPlot;
 import io.github.mzmine.modules.visualization.chromatogram.TICPlotType;
 import io.github.mzmine.modules.visualization.chromatogram.TICVisualizerTab;
 import io.github.mzmine.parameters.parametertypes.selectors.ScanSelection;
+import io.github.mzmine.util.FeatureUtils;
+import io.github.mzmine.util.color.ColorUtils;
+import io.github.mzmine.util.color.SimpleColorPalette;
 import java.awt.BasicStroke;
-import java.awt.Color;
+import java.text.NumberFormat;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.ObservableList;
 import javafx.geometry.Orientation;
 import javafx.geometry.Pos;
@@ -46,6 +60,8 @@ import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.GridPane;
+import org.jetbrains.annotations.NotNull;
+import org.jfree.chart.plot.IntervalMarker;
 import org.jfree.chart.plot.ValueMarker;
 import org.jfree.chart.plot.XYPlot;
 
@@ -55,6 +71,12 @@ import org.jfree.chart.plot.XYPlot;
  * @author Ansgar Korf (ansgar.korf@uni-muenster.de)
  */
 public class MultiSpectraVisualizerPane extends BorderPane {
+
+  private final NumberFormat rtFormat = MZmineCore.getConfiguration().getRTFormat();
+  private final NumberFormat mzFormat = MZmineCore.getConfiguration().getMZFormat();
+  private final NumberFormat mobilityFormat = MZmineCore.getConfiguration().getMobilityFormat();
+  private final NumberFormat intensityFormat = MZmineCore.getConfiguration().getIntensityFormat();
+  private final UnitFormat unitFormat = MZmineCore.getConfiguration().getUnitFormat();
 
   private Logger logger = Logger.getLogger(this.getClass().getName());
 
@@ -173,8 +195,9 @@ public class MultiSpectraVisualizerPane extends BorderPane {
     Feature peak = row.getFeature(raw);
     // no peak / no ms2 - return false
     if (peak == null || peak.getAllMS2FragmentScans() == null
-        || peak.getAllMS2FragmentScans().size() == 0)
+        || peak.getAllMS2FragmentScans().size() == 0) {
       return false;
+    }
 
     this.activeRaw = raw;
     // clear
@@ -190,8 +213,9 @@ public class MultiSpectraVisualizerPane extends BorderPane {
 
     int n = indexOfRaw(raw);
     lbRaw.setText(n + ": " + raw.getName());
-    logger.finest("All MS/MS scans window: Added " + numbers.size()
-        + " spectra of raw file " + n + ": " + raw.getName());
+    logger.finest(
+        "All MS/MS scans window: Added " + numbers.size() + " spectra of raw file " + n + ": " + raw
+            .getName());
     // show
 //    pnGrid.revalidate();
 //    pnGrid.repaint();
@@ -204,6 +228,7 @@ public class MultiSpectraVisualizerPane extends BorderPane {
 
   private BorderPane addSpectra(Scan scan) {
     BorderPane panel = new BorderPane();
+    panel.setPrefHeight(600);
     // Split pane for eic plot (top) and spectrum (bottom)
     SplitPane bottomPane = new SplitPane();
     bottomPane.setOrientation(Orientation.VERTICAL);
@@ -212,7 +237,7 @@ public class MultiSpectraVisualizerPane extends BorderPane {
     // labels for TIC visualizer
     Map<Feature, String> labelsMap = new HashMap<Feature, String>(0);
 
-    Feature peak = row.getFeature(activeRaw);
+    ModularFeature peak = (ModularFeature) row.getFeature(activeRaw);
 
     // scan selection
     ScanSelection scanSelection = new ScanSelection(activeRaw.getDataRTRange(1), 1);
@@ -243,18 +268,28 @@ public class MultiSpectraVisualizerPane extends BorderPane {
     // ticPlot.setPreferredSize(new Dimension(600, 200));
     ticPlot.getChart().getLegend().setVisible(false);
 
+    final SimpleColorPalette palette = MZmineCore.getConfiguration().getDefaultColorPalette();
+
     // add a retention time Marker to the EIC
     ValueMarker marker = new ValueMarker(scan.getRetentionTime());
-    marker.setPaint(Color.RED);
+    marker.setPaint(palette.getPositiveColorAWT());
     marker.setStroke(new BasicStroke(3.0f));
 
     XYPlot plot = (XYPlot) ticPlot.getChart().getPlot();
     plot.addDomainMarker(marker);
-    bottomPane.getItems().add(ticPlot);
-//    bottomPane.setResizeWeight(0.5);
-//    bottomPane.setEnabled(true);
-//    bottomPane.setDividerSize(5);
-//    bottomPane.setDividerLocation(200);
+
+    SplitPane ticAndMobilogram = new SplitPane();
+    ticAndMobilogram.setOrientation(Orientation.HORIZONTAL);
+    ticAndMobilogram.getItems().add(ticPlot);
+
+    if (peak.getFeatureData() instanceof IonMobilogramTimeSeries series && peak
+        .getMostIntenseFragmentScan() instanceof MergedMsMsSpectrum mergedMsMs) {
+      SimpleXYChart<PlotXYDataProvider> mobilogramChart = createMobilogramChart(peak,
+          mzRange, palette, series, mergedMsMs);
+      ticAndMobilogram.getItems().add(mobilogramChart);
+    }
+
+    bottomPane.getItems().add(ticAndMobilogram);
 
     SplitPane spectrumPane = new SplitPane();
     spectrumPane.setOrientation(Orientation.HORIZONTAL);
@@ -266,15 +301,38 @@ public class MultiSpectraVisualizerPane extends BorderPane {
     // get MS/MS spectra plot
     SpectraPlot spectrumPlot = spectraTab.getSpectrumPlot();
     spectrumPlot.getChart().getLegend().setVisible(false);
-    // spectrumPlot.setPreferredSize(new Dimension(600, 400));
     spectrumPane.getItems().add(spectrumPlot);
     spectrumPane.getItems().add(spectraTab.getToolBar());
-//    spectrumPane.setResizeWeight(1);
-//    spectrumPane.setEnabled(false);
-//    spectrumPane.setDividerSize(0);
     bottomPane.getItems().add(spectrumPane);
     panel.setCenter(bottomPane);
-//    panel.setBorder(BorderFactory.createLineBorder(Color.black));
     return panel;
+  }
+
+  @NotNull
+  private SimpleXYChart<PlotXYDataProvider> createMobilogramChart(ModularFeature peak,
+      Range<Double> mzRange, SimpleColorPalette palette, IonMobilogramTimeSeries series,
+      MergedMsMsSpectrum mergedMsMs) {
+    SimpleXYChart<PlotXYDataProvider> mobilogramChart = new SimpleXYChart<>();
+    mobilogramChart.addDataset(new FeatureRawMobilogramProvider(peak, mzRange));
+    mobilogramChart.addDataset(new SummedMobilogramXYProvider(series.getSummedMobilogram(),
+        new SimpleObjectProperty<>(
+            ColorUtils.getContrastPaletteColor(peak.getRawDataFile().getColor(), palette)),
+        FeatureUtils.featureToString(peak)));
+    mobilogramChart.setDomainAxisNumberFormatOverride(mobilityFormat);
+    mobilogramChart.setRangeAxisNumberFormatOverride(intensityFormat);
+    mobilogramChart.setDomainAxisLabel(peak.getMobilityUnit().getAxisLabel());
+    mobilogramChart.setRangeAxisLabel(unitFormat.format("Summed intensity", "a.u."));
+
+    var optMin = mergedMsMs.getSourceSpectra().stream()
+        .mapToDouble(s -> ((MobilityScan) s).getMobility()).min();
+    var optMax = mergedMsMs.getSourceSpectra().stream()
+        .mapToDouble(s -> ((MobilityScan) s).getMobility()).max();
+    if (optMin.isPresent() && optMax.isPresent()) {
+      IntervalMarker msmsInterval = new IntervalMarker(optMin.getAsDouble(), optMax.getAsDouble(),
+          palette.getPositiveColorAWT(), new BasicStroke(1f), palette.getPositiveColorAWT(),
+          new BasicStroke(1f), 0.2f);
+      mobilogramChart.getXYPlot().addDomainMarker(msmsInterval);
+    }
+    return mobilogramChart;
   }
 }

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/SpectraPlot.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/SpectraPlot.java
@@ -170,13 +170,14 @@ public class SpectraPlot extends EChartViewer implements LabelColorMatch {
     // set the X axis (retention time) properties
     NumberAxis xAxis = (NumberAxis) plot.getDomainAxis();
     xAxis.setNumberFormatOverride(mzFormat);
-    xAxis.setUpperMargin(0.001);
-    xAxis.setLowerMargin(0.001);
+    xAxis.setUpperMargin(0.01); // have some margin so m/z labels are not cut off
+    xAxis.setLowerMargin(0.01);
     xAxis.setTickLabelInsets(new RectangleInsets(0, 0, 20, 20));
 
     // set the Y axis (intensity) properties
     NumberAxis yAxis = (NumberAxis) plot.getRangeAxis();
     yAxis.setNumberFormatOverride(intensityFormat);
+    yAxis.setUpperMargin(0.1); // some margin for m/z labels
 
     // only allow positive values for the axes
     ChartLogics.setAxesTypesPositive(chart);

--- a/src/main/java/io/github/mzmine/util/color/ColorUtils.java
+++ b/src/main/java/io/github/mzmine/util/color/ColorUtils.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.util.color;
 
+import io.github.mzmine.util.javafx.FxColorUtil;
 import javafx.scene.paint.Color;
 
 public class ColorUtils {
@@ -25,39 +26,49 @@ public class ColorUtils {
   /**
    * Returns tinted version of the given color.
    *
-   * @param color input color
+   * @param color  input color
    * @param factor tint factor, must be from [0, 1], higher value is, brighter output color is
    * @return new color
    */
   public static Color tintColor(Color color, double factor) {
-    return new Color(
-        color.getRed() + (1d - color.getRed()) * factor,
+    return new Color(color.getRed() + (1d - color.getRed()) * factor,
         color.getGreen() + (1d - color.getGreen()) * factor,
-        color.getBlue() + (1d - color.getBlue()) * factor,
-        color.getOpacity()
-    );
+        color.getBlue() + (1d - color.getBlue()) * factor, color.getOpacity());
   }
 
   /**
-   * Returns an absolute distance of rgb values between two colors. Can be treated as a metric on colors.
+   * Returns an absolute distance of rgb values between two colors. Can be treated as a metric on
+   * colors.
    */
   public static double getColorDistance(Color color1, Color color2) {
-    return Math.abs(color1.getRed() - color2.getRed())
-        + Math.abs(color1.getGreen() - color2.getGreen())
-        + Math.abs(color1.getBlue() - color2.getBlue());
+    return Math.abs(color1.getRed() - color2.getRed()) + Math
+        .abs(color1.getGreen() - color2.getGreen()) + Math.abs(color1.getBlue() - color2.getBlue());
   }
 
   /**
-   * Returns either positive or negative color from the given palette depending on which one is
-   * more contrast to the given color.
+   * Returns either positive or negative color from the given palette depending on which one is more
+   * contrast to the given color.
    */
   public static Color getContrastPaletteColor(Color color, SimpleColorPalette palette) {
     Color positiveColor = palette.getPositiveColor();
     Color negativeColor = palette.getNegativeColor();
 
     return getColorDistance(color, positiveColor) > getColorDistance(color, negativeColor)
-        ? positiveColor
-        : negativeColor;
+        ? positiveColor : negativeColor;
+  }
+
+  public static Color getContrastPaletteColor(java.awt.Color color, SimpleColorPalette palette) {
+    return getContrastPaletteColor(FxColorUtil.awtColorToFX(color), palette);
+  }
+
+  public static java.awt.Color getContrastPaletteColorAWT(java.awt.Color color, SimpleColorPalette palette) {
+    return FxColorUtil
+        .fxColorToAWT(getContrastPaletteColor(FxColorUtil.awtColorToFX(color), palette));
+  }
+
+  public static java.awt.Color getContrastPaletteColorAWT(Color color, SimpleColorPalette palette) {
+    return FxColorUtil
+        .fxColorToAWT(getContrastPaletteColor(color, palette));
   }
 
 }


### PR DESCRIPTION
The "Show all MS/MS" window now also shows a mobilogram for the precursor. 

1. A raw mobilogram is summed over the retention time of the feature and the features' m/z **range** +- 5 ppm, (just like the EIC). 
2. The actual mobilogram of the feature is also displayed.

![grafik](https://user-images.githubusercontent.com/37407705/125691132-0c55fae4-6dcb-4934-a39f-ce23c262e2cc.png)

 The blue marker in the mobilogram shows the width of MS/MS window.