### PR TITLE
fix ModuleComboParameter cloning

### DIFF
--- a/src/main/java/io/github/mzmine/parameters/parametertypes/ModuleComboParameter.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/ModuleComboParameter.java
@@ -135,6 +135,13 @@ public class ModuleComboParameter<ModuleType extends MZmineModule> implements
   @Override
   public void setValue(MZmineProcessingStep<ModuleType> value) {
     this.value = value;
+    // also copy the parameter set to our internal parameter set
+    for (int i = 0; i < modulesWithParams.length; i++) {
+      if (modulesWithParams[i].getModule().equals(value.getModule())) {
+        modulesWithParams[i] = new MZmineProcessingStepImpl<>(value.getModule(),
+            value.getParameterSet().cloneParameterSet());
+      }
+    }
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
When setting a new processing step to the parameter, the internal processing step (pair of module+param) was not updated. This lead to issues when cloning the parameter.