### PR TITLE
Add uppercase extension version to netCDF filter

### DIFF
--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_netcdf/NetCDFImportParameters.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_netcdf/NetCDFImportParameters.java
@@ -30,7 +30,7 @@ import javafx.stage.FileChooser.ExtensionFilter;
 public class NetCDFImportParameters extends SimpleParameterSet {
 
   private static final List<ExtensionFilter> extensions = List.of( //
-      new ExtensionFilter("netCDF files", "*.cdf", "*.netcdf", "*.nc"), //
+      new ExtensionFilter("netCDF files", "*.cdf", "*.CDF", "*.netcdf", "*.nc"), //
       new ExtensionFilter("All files", "*.*") //
   );
 

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_netcdf/NetCDFImportParameters.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_netcdf/NetCDFImportParameters.java
@@ -30,7 +30,7 @@ import javafx.stage.FileChooser.ExtensionFilter;
 public class NetCDFImportParameters extends SimpleParameterSet {
 
   private static final List<ExtensionFilter> extensions = List.of( //
-      new ExtensionFilter("netCDF files", "*.cdf", "*.CDF", "*.netcdf", "*.nc"), //
+      new ExtensionFilter("netCDF files", "*.cdf", "*.CDF", "*.netcdf", "*.NETCDF", "*.nc", "*.NC"), //
       new ExtensionFilter("All files", "*.*") //
   );
 


### PR DESCRIPTION
Adds uppercase version (".CDF") as valid file extension for netCFD files. This allows importing sample netCFD data (from https://drive.google.com/drive/folders/1HlMT0WPPjJ1VKCbz6qXYWvnsegcjn1pG), without changing to "any" allowed extension.

While this is minor change, I believe it could improve the experience for newcomers who use the sample data. 