### PR TITLE
scaling of FeatureShapeChart and FeatureShapeMobilogramChart

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/features/types/graphicalnodes/FeatureShapeChart.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/graphicalnodes/FeatureShapeChart.java
@@ -31,12 +31,14 @@ import io.github.mzmine.gui.chartbasics.simplechart.datasets.RunOption;
 import io.github.mzmine.gui.chartbasics.simplechart.providers.impl.series.IonTimeSeriesToXYProvider;
 import io.github.mzmine.gui.preferences.UnitFormat;
 import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.util.RangeUtils;
 import java.awt.Color;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import javafx.application.Platform;
 import javafx.scene.layout.StackPane;
 import org.jetbrains.annotations.NotNull;
+import org.jfree.data.Range;
 
 public class FeatureShapeChart extends StackPane {
 
@@ -46,8 +48,7 @@ public class FeatureShapeChart extends StackPane {
     UnitFormat uf = MZmineCore.getConfiguration().getUnitFormat();
 
     SimpleXYChart<IonTimeSeriesToXYProvider> chart = new SimpleXYChart<>(
-        uf.format("Retention time", "min"),
-        uf.format("Intensity", "a.u."));
+        uf.format("Retention time", "min"), uf.format("Intensity", "a.u."));
     chart.setRangeAxisNumberFormatOverride(MZmineCore.getConfiguration().getIntensityFormat());
     chart.setDomainAxisNumberFormatOverride(MZmineCore.getConfiguration().getRTFormat());
     chart.setLegendItemsVisible(false);
@@ -69,10 +70,33 @@ public class FeatureShapeChart extends StackPane {
     chart.getChart().setBackgroundPaint((new Color(0, 0, 0, 0)));
     chart.getXYPlot().setBackgroundPaint((new Color(0, 0, 0, 0)));
 
+    final ModularFeature bestFeature = row.getBestFeature();
+    final org.jfree.data.Range defaultRange;
+    if (bestFeature != null) {
+      final Float rt = bestFeature.getRT();
+
+      if (bestFeature.getFWHM() != null) {
+        final Float fwhm = bestFeature.getFWHM();
+        defaultRange = new org.jfree.data.Range(Math.max(rt - 5 * fwhm, 0),
+            Math.min(rt + 5 * fwhm, bestFeature.getRawDataFile().getDataRTRange().upperEndpoint()));
+
+      } else {
+        final Float length = RangeUtils.rangeLength(bestFeature.getRawDataPointsRTRange());
+        defaultRange = new org.jfree.data.Range(Math.max(rt - 3 * length, 0),
+            Math.min(rt + 3 * length,
+                bestFeature.getRawDataFile().getDataRTRange().upperEndpoint()));
+      }
+    } else {
+      defaultRange = new Range(0, 1);
+    }
+
     setPrefHeight(GraphicalColumType.DEFAULT_GRAPHICAL_CELL_HEIGHT);
     Platform.runLater(() -> {
       getChildren().add(chart);
       chart.addDatasets(datasets);
+
+      chart.getXYPlot().getDomainAxis().setRange(defaultRange);
+      chart.getXYPlot().getDomainAxis().setDefaultAutoRange(defaultRange);
     });
   }
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/graphicalnodes/FeatureShapeMobilogramChart.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/graphicalnodes/FeatureShapeMobilogramChart.java
@@ -74,26 +74,29 @@ public class FeatureShapeMobilogramChart extends StackPane {
     chart.getXYPlot().setBackgroundPaint((new Color(0, 0, 0, 0)));
 
     final ModularFeature bestFeature = row.getBestFeature();
-    final org.jfree.data.Range defaultRange;
-    com.google.common.collect.Range<Float> mobilityRange = bestFeature.getMobilityRange();
-    final Float mobility = bestFeature.getMobility();
-    if (bestFeature != null && bestFeature.getRawDataFile() instanceof IMSRawDataFile imsRaw
-        && mobilityRange != null && mobility != null && !Float.isNaN(mobility)) {
-      final Float length = RangeUtils.rangeLength(mobilityRange);
-
-      defaultRange = new org.jfree.data.Range(
-          Math.max(mobility - 3 * length, imsRaw.getDataMobilityRange().lowerEndpoint()),
-          Math.min(mobility + 3 * length, imsRaw.getDataMobilityRange().upperEndpoint()));
-    } else {
+    org.jfree.data.Range defaultRange = null;
+    if (bestFeature != null && bestFeature.getRawDataFile() instanceof IMSRawDataFile imsRaw) {
+      com.google.common.collect.Range<Float> mobilityRange = bestFeature.getMobilityRange();
+      final Float mobility = bestFeature.getMobility();
+      if (mobilityRange != null && mobility != null && !Float.isNaN(mobility)) {
+        final Float length = RangeUtils.rangeLength(mobilityRange);
+        defaultRange = new org.jfree.data.Range(
+            Math.max(mobility - 3 * length, imsRaw.getDataMobilityRange().lowerEndpoint()),
+            Math.min(mobility + 3 * length, imsRaw.getDataMobilityRange().upperEndpoint()));
+      }
+    }
+    if (defaultRange == null) {
       defaultRange = new Range(0, 1);
     }
+
+    final var finalRange = defaultRange;
 
     setPrefHeight(GraphicalColumType.DEFAULT_GRAPHICAL_CELL_HEIGHT);
     Platform.runLater(() -> {
       getChildren().add(chart);
       chart.addDatasets(datasets);
-      chart.getXYPlot().getDomainAxis().setDefaultAutoRange(defaultRange);
-      chart.getXYPlot().getDomainAxis().setRange(defaultRange);
+      chart.getXYPlot().getDomainAxis().setDefaultAutoRange(finalRange);
+      chart.getXYPlot().getDomainAxis().setRange(finalRange);
     });
   }
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/graphicalnodes/FeatureShapeMobilogramChart.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/graphicalnodes/FeatureShapeMobilogramChart.java
@@ -78,12 +78,12 @@ public class FeatureShapeMobilogramChart extends StackPane {
     com.google.common.collect.Range<Float> mobilityRange = bestFeature.getMobilityRange();
     final Float mobility = bestFeature.getMobility();
     if (bestFeature != null && bestFeature.getRawDataFile() instanceof IMSRawDataFile imsRaw
-        && mobilityRange != null && mobility != null && !Float.isNaN(mobility)){
+        && mobilityRange != null && mobility != null && !Float.isNaN(mobility)) {
       final Float length = RangeUtils.rangeLength(mobilityRange);
 
-      defaultRange = new org.jfree.data.Range(Math.max(mobility - 3 * length, 0),
-          Math.min(mobility + 3 * length,
-              bestFeature.getRawDataFile().getDataRTRange().upperEndpoint()));
+      defaultRange = new org.jfree.data.Range(
+          Math.max(mobility - 3 * length, imsRaw.getDataMobilityRange().lowerEndpoint()),
+          Math.min(mobility + 3 * length, imsRaw.getDataMobilityRange().upperEndpoint()));
     } else {
       defaultRange = new Range(0, 1);
     }


### PR DESCRIPTION
The FeatureShapeChart now uses 5 FWHM or 3 * rtRange of the feature as default domain axis range and the Mobilogram chart uses 3 * mobilityRange. This should make it clearer if something is an actual chromatographic peak or noise.

![grafik](https://user-images.githubusercontent.com/37407705/133076979-7883c4b6-0840-4021-8b63-9fcae7e269e1.png)
