### PR TITLE
fix raw data saving on linux and possibly mac

### DIFF
--- a/src/main/java/io/github/mzmine/modules/io/projectsave/RawDataFileSaveHandler.java
+++ b/src/main/java/io/github/mzmine/modules/io/projectsave/RawDataFileSaveHandler.java
@@ -289,7 +289,8 @@ public class RawDataFileSaveHandler extends AbstractTask {
       path.append(prefix);
     }
     path.append(DATA_FILES_FOLDER);
-    path.append(file.getAbsolutePath().substring(file.getAbsolutePath().lastIndexOf("\\") + 1));
+    final String separator = System.getProperty("file.separator");
+    path.append(file.getAbsolutePath().substring(file.getAbsolutePath().lastIndexOf(separator) + 1));
     if (suffix != null) {
       path.append(suffix);
     }


### PR DESCRIPTION
I used the "\\" separator from windows instead of System.getProperty("file.separator") which caused problems on linux an probably mac