### PR TITLE
add ReducedIonMobilogramTimeSeries + reducer module

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/featuredata/impl/ReducedIonMobilogramTimeSeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/impl/ReducedIonMobilogramTimeSeries.java
@@ -1,0 +1,204 @@
+package io.github.mzmine.datamodel.featuredata.impl;
+
+import io.github.mzmine.datamodel.Frame;
+import io.github.mzmine.datamodel.IMSRawDataFile;
+import io.github.mzmine.datamodel.data_access.BinningMobilogramDataAccess;
+import io.github.mzmine.datamodel.featuredata.IntensitySeries;
+import io.github.mzmine.datamodel.featuredata.IonMobilitySeries;
+import io.github.mzmine.datamodel.featuredata.IonMobilogramTimeSeries;
+import io.github.mzmine.datamodel.featuredata.IonSeries;
+import io.github.mzmine.datamodel.featuredata.IonSpectrumSeries;
+import io.github.mzmine.datamodel.featuredata.MzSeries;
+import io.github.mzmine.modules.io.projectload.version_3_0.CONST;
+import io.github.mzmine.util.DataPointUtils;
+import io.github.mzmine.util.MemoryMapStorage;
+import io.github.mzmine.util.ParsingUtils;
+import java.nio.DoubleBuffer;
+import java.util.List;
+import java.util.Objects;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.XMLStreamWriter;
+import javax.xml.stream.events.XMLEvent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ *
+ */
+public class ReducedIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
+
+  public static final String XML_ELEMENT = "reducedionmobilogramtimeseries";
+
+  private final List<Frame> frames;
+  private final DoubleBuffer intensityValueBuffer;
+  private final DoubleBuffer mzValueBuffer;
+  private final SummedIntensityMobilitySeries summedMobilogram;
+
+  public ReducedIonMobilogramTimeSeries(@NotNull final IonMobilogramTimeSeries series) {
+    frames = series.getSpectraModifiable();
+    intensityValueBuffer = series.getIntensityValueBuffer();
+    summedMobilogram = series.getSummedMobilogram();
+    mzValueBuffer = series.getMZValueBuffer();
+  }
+
+  public ReducedIonMobilogramTimeSeries(MemoryMapStorage storage, List<Frame> frames,
+      double[] mzValues, double[] intensityValues, SummedIntensityMobilitySeries summed) {
+
+    if (frames.size() != mzValues.length || mzValues.length != intensityValues.length) {
+      throw new IllegalArgumentException(
+          "m/z, intensity and frames do not have the same number of values.");
+    }
+    this.frames = frames;
+    intensityValueBuffer = StorageUtils.storeValuesToDoubleBuffer(storage, intensityValues);
+    summedMobilogram = summed;
+    mzValueBuffer = StorageUtils.storeValuesToDoubleBuffer(storage, mzValues);
+  }
+
+  @Override
+  public DoubleBuffer getIntensityValueBuffer() {
+    return intensityValueBuffer;
+  }
+
+  @Override
+  public IonMobilogramTimeSeries subSeries(@Nullable MemoryMapStorage storage,
+      @NotNull List<Frame> subset, @NotNull BinningMobilogramDataAccess mobilogramBinning) {
+    throw new UnsupportedOperationException(
+        "Reduced traces do not support this operation. Please apply this module before reducing ion mobility traces.");
+  }
+
+  @Override
+  public List<IonMobilitySeries> getMobilograms() {
+    throw new UnsupportedOperationException(
+        "Reduced traces do not support this operation. Please apply this module before reducing ion mobility traces.");
+  }
+
+  @Override
+  public SummedIntensityMobilitySeries getSummedMobilogram() {
+    return summedMobilogram;
+  }
+
+  @Override
+  public IonMobilogramTimeSeries copyAndReplace(@Nullable MemoryMapStorage storage,
+      @NotNull SummedIntensityMobilitySeries summedMobilogram) {
+    return new ReducedIonMobilogramTimeSeries(storage, frames,
+        DataPointUtils.getDoubleBufferAsArray(mzValueBuffer),
+        DataPointUtils.getDoubleBufferAsArray(intensityValueBuffer), summedMobilogram);
+  }
+
+  @Override
+  public List<Frame> getSpectra() {
+    return frames;
+  }
+
+  @Override
+  public IonMobilogramTimeSeries subSeries(@Nullable MemoryMapStorage storage,
+      @NotNull List<Frame> subset) {
+    throw new UnsupportedOperationException(
+        "Reduced traces do not support this operation. Please apply this module before reducing ion mobility traces.");
+  }
+
+  @Override
+  public IonSpectrumSeries<Frame> copyAndReplace(@Nullable MemoryMapStorage storage,
+      @NotNull double[] newMzValues, @NotNull double[] newIntensityValues) {
+    return new ReducedIonMobilogramTimeSeries(storage, frames, newMzValues, newIntensityValues,
+        summedMobilogram.copy(storage));
+  }
+
+  @Override
+  public void saveValueToXML(XMLStreamWriter writer, List<Frame> allScans)
+      throws XMLStreamException {
+    writer.writeStartElement(ReducedIonMobilogramTimeSeries.XML_ELEMENT);
+
+    IntensitySeries.saveIntensityValuesToXML(writer, this);
+    MzSeries.saveMzValuesToXML(writer, this);
+    IonSpectrumSeries.saveSpectraIndicesToXML(writer, this, allScans);
+
+    summedMobilogram.saveValueToXML(writer);
+
+    writer.writeEndElement();
+  }
+
+  @Override
+  public IonSeries copy(MemoryMapStorage storage) {
+    return new ReducedIonMobilogramTimeSeries(storage, frames,
+        DataPointUtils.getDoubleBufferAsArray(mzValueBuffer),
+        DataPointUtils.getDoubleBufferAsArray(intensityValueBuffer),
+        summedMobilogram.copy(storage));
+  }
+
+  @Override
+  public DoubleBuffer getMZValueBuffer() {
+    return mzValueBuffer;
+  }
+
+  @Override
+  public List<Frame> getSpectraModifiable() {
+    return frames;
+  }
+
+  public static IonMobilogramTimeSeries loadFromXML(@NotNull XMLStreamReader reader,
+      @Nullable MemoryMapStorage storage, @NotNull IMSRawDataFile file) throws XMLStreamException {
+
+    if (!reader.isStartElement() || !reader.getLocalName()
+        .equals(ReducedIonMobilogramTimeSeries.XML_ELEMENT)) {
+      throw new IllegalStateException("Wrong element position.");
+    }
+
+    List<Frame> scans = null;
+    double[] mzs = null;
+    double[] intensities = null;
+    SummedIntensityMobilitySeries summedMobilogram = null;
+
+    while (reader.hasNext()) {
+      if (reader.isEndElement() && reader.getLocalName()
+          .equals(ReducedIonMobilogramTimeSeries.XML_ELEMENT)) {
+        break;
+      }
+
+      final int next = reader.next();
+      if (next != XMLEvent.START_ELEMENT) {
+        continue;
+      }
+      switch (reader.getLocalName()) {
+        case CONST.XML_SCAN_LIST_ELEMENT -> {
+          int[] indices = ParsingUtils.stringToIntArray(reader.getElementText());
+          scans = ParsingUtils.getSublistFromIndices((List<Frame>) file.getFrames(), indices);
+        }
+        case CONST.XML_MZ_VALUES_ELEMENT -> mzs = ParsingUtils.stringToDoubleArray(
+            reader.getElementText());
+        case CONST.XML_INTENSITY_VALUES_ELEMENT -> intensities = ParsingUtils.stringToDoubleArray(
+            reader.getElementText());
+        case SummedIntensityMobilitySeries.XML_ELEMENT -> summedMobilogram = SummedIntensityMobilitySeries.loadFromXML(
+            reader, storage);
+      }
+    }
+
+    if (scans == null || mzs == null || intensities == null || summedMobilogram == null) {
+      throw new IllegalStateException(
+          "Incomplete parsing of " + ReducedIonMobilogramTimeSeries.class.getName());
+    }
+
+    return new ReducedIonMobilogramTimeSeries(storage, scans, mzs, intensities, summedMobilogram);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ReducedIonMobilogramTimeSeries that = (ReducedIonMobilogramTimeSeries) o;
+    return Objects.equals(frames, that.frames) && Objects.equals(getIntensityValueBuffer(),
+        that.getIntensityValueBuffer()) && Objects.equals(mzValueBuffer, that.mzValueBuffer)
+        && Objects.equals(getSummedMobilogram(), that.getSummedMobilogram())
+        && MzSeries.seriesSubsetEqual(this, that) && IntensitySeries.seriesSubsetEqual(this, that);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(frames, getIntensityValueBuffer(), mzValueBuffer, getSummedMobilogram());
+  }
+}

--- a/src/main/java/io/github/mzmine/datamodel/featuredata/impl/ReducedIonMobilogramTimeSeries.java
+++ b/src/main/java/io/github/mzmine/datamodel/featuredata/impl/ReducedIonMobilogramTimeSeries.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2006-2021 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
 package io.github.mzmine.datamodel.featuredata.impl;
 
 import io.github.mzmine.datamodel.Frame;

--- a/src/main/java/io/github/mzmine/datamodel/features/types/FeatureDataType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/FeatureDataType.java
@@ -23,6 +23,7 @@ import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.featuredata.IonTimeSeries;
 import io.github.mzmine.datamodel.featuredata.impl.IonMobilogramTimeSeriesFactory;
+import io.github.mzmine.datamodel.featuredata.impl.ReducedIonMobilogramTimeSeries;
 import io.github.mzmine.datamodel.featuredata.impl.SimpleIonMobilogramTimeSeries;
 import io.github.mzmine.datamodel.featuredata.impl.SimpleIonTimeSeries;
 import io.github.mzmine.datamodel.features.ListRowBinding;
@@ -76,12 +77,13 @@ public class FeatureDataType extends
       @NotNull final ModularFeatureList flist, @NotNull final ModularFeatureListRow row,
       @Nullable final ModularFeature feature, @Nullable final RawDataFile file)
       throws XMLStreamException {
-    if(value == null) {
+    if (value == null) {
       return;
     }
     if (!(value instanceof IonTimeSeries series)) {
       throw new IllegalArgumentException(
-          "Wrong value type for data type: " + this.getClass().getName() + " value class: " + value.getClass());
+          "Wrong value type for data type: " + this.getClass().getName() + " value class: "
+              + value.getClass());
     }
     if (file == null) {
       throw new IllegalArgumentException("Cannot save feature data for file = null");
@@ -111,7 +113,8 @@ public class FeatureDataType extends
         return null;
       }
       if (reader.isStartElement() && (reader.getLocalName().equals(SimpleIonTimeSeries.XML_ELEMENT)
-          || reader.getLocalName().equals(SimpleIonMobilogramTimeSeries.XML_ELEMENT))) {
+          || reader.getLocalName().equals(SimpleIonMobilogramTimeSeries.XML_ELEMENT)
+          || reader.getLocalName().equals(ReducedIonMobilogramTimeSeries.XML_ELEMENT))) {
         // found start element
         break;
       }
@@ -123,10 +126,16 @@ public class FeatureDataType extends
         return SimpleIonTimeSeries.loadFromXML(reader, flist.getMemoryMapStorage(), file);
       }
       case SimpleIonMobilogramTimeSeries.XML_ELEMENT -> {
-        return IonMobilogramTimeSeriesFactory
-            .loadFromXML(reader, flist.getMemoryMapStorage(), (IMSRawDataFile) file);
+        return IonMobilogramTimeSeriesFactory.loadFromXML(reader, flist.getMemoryMapStorage(),
+            (IMSRawDataFile) file);
+      }
+      case ReducedIonMobilogramTimeSeries.XML_ELEMENT -> {
+        return ReducedIonMobilogramTimeSeries.loadFromXML(reader, flist.getMemoryMapStorage(),
+            (IMSRawDataFile) file);
+      }
+      default -> {
+        return null;
       }
     }
-    return null;
   }
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/FeatureShapeIonMobilityRetentionTimeHeatMapType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/FeatureShapeIonMobilityRetentionTimeHeatMapType.java
@@ -23,6 +23,8 @@ import io.github.mzmine.datamodel.IMSRawDataFile;
 import io.github.mzmine.datamodel.ImagingRawDataFile;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.featuredata.IonMobilogramTimeSeries;
+import io.github.mzmine.datamodel.featuredata.impl.ReducedIonMobilogramTimeSeries;
+import io.github.mzmine.datamodel.featuredata.impl.SimpleIonMobilogramTimeSeries;
 import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
@@ -76,8 +78,16 @@ public class FeatureShapeIonMobilityRetentionTimeHeatMapType extends LinkedDataT
       return null;
     }
 
-    if(!(feature.getFeatureData() instanceof IonMobilogramTimeSeries)) {
+    if (!(feature.getFeatureData() instanceof IonMobilogramTimeSeries)) {
       Label label = new Label("Processed with\nLC-MS workflow");
+      StackPane pane = new StackPane(label);
+      label.setTextAlignment(TextAlignment.CENTER);
+      pane.setAlignment(Pos.CENTER);
+      return pane;
+    }
+
+    if (!(feature.getFeatureData() instanceof SimpleIonMobilogramTimeSeries)) {
+      Label label = new Label("Reduced ion mobility trace.");
       StackPane pane = new StackPane(label);
       label.setTextAlignment(TextAlignment.CENTER);
       pane.setAlignment(Pos.CENTER);
@@ -110,8 +120,17 @@ public class FeatureShapeIonMobilityRetentionTimeHeatMapType extends LinkedDataT
   @Override
   public Runnable getDoubleClickAction(@NotNull ModularFeatureListRow row,
       @NotNull List<RawDataFile> file) {
-    return () -> MZmineCore.runLater(() -> MZmineCore.getDesktop()
-        .addTab(new IMSFeatureVisualizerTab(row.getFeature(file.get(0)))));
+
+    final ModularFeature feature = row.getFeature(file.get(0));
+
+    if (feature == null || feature.getFeatureStatus() == FeatureStatus.UNKNOWN
+        || !(feature.getFeatureData() instanceof IonMobilogramTimeSeries)
+        || (feature.getFeatureData() instanceof ReducedIonMobilogramTimeSeries)) {
+      return null;
+    }
+
+    return () -> MZmineCore.runLater(
+        () -> MZmineCore.getDesktop().addTab(new IMSFeatureVisualizerTab(feature)));
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/gui/mainwindow/MainMenu.fxml
+++ b/src/main/java/io/github/mzmine/gui/mainwindow/MainMenu.fxml
@@ -299,6 +299,9 @@
       <MenuItem onAction="#runModule"
         text="Calculate CCS values"
         userData="io.github.mzmine.modules.dataprocessing.id_ccscalc.CCSCalcModule"/>
+      <MenuItem onAction="#runModule"
+        text="Reduce ion mobility traces"
+        userData="io.github.mzmine.modules.dataprocessing.filter_tracereducer.IonMobilityTraceReducerModule"/>
     </Menu>
 
     <Menu text="Isotopes">

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/FeatureResolverSetupDialog.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/FeatureResolverSetupDialog.java
@@ -174,25 +174,30 @@ public class FeatureResolverSetupDialog extends ParameterSetupDialogWithPreview 
 
       if (newValue.getFeatureList() instanceof ModularFeatureList flist) {
         if (dimension == ResolvingDimension.RETENTION_TIME) {
-          // we can't use FeatureDataAccess to select a specific feature, so we need to remap manually.
-          final List<IonTimeSeries<? extends Scan>> resolved = resolver.resolve(IonTimeSeriesUtils
-              .remapRtAxis(newValue.getFeatureData(),
-                  flistBox.getValue().getSeletedScans(newValue.getRawDataFile())), null);
+          try {
+            // we can't use FeatureDataAccess to select a specific feature, so we need to remap manually.
+            final List<IonTimeSeries<? extends Scan>> resolved = resolver.resolve(IonTimeSeriesUtils.remapRtAxis(newValue.getFeatureData(),
+                flistBox.getValue().getSeletedScans(newValue.getRawDataFile())), null);
 
-          for (IonTimeSeries<? extends Scan> series : resolved) {
-            ColoredXYDataset ds = new ColoredXYDataset(new IonTimeSeriesToXYProvider(series, "",
-                new SimpleObjectProperty<>(palette.get(resolvedFeatureCounter++))));
-            MZmineCore.runLater(() -> previewChart.addDataset(ds, shapeRenderer));
+            for (IonTimeSeries<? extends Scan> series : resolved) {
+              ColoredXYDataset ds = new ColoredXYDataset(new IonTimeSeriesToXYProvider(series, "",
+                  new SimpleObjectProperty<>(palette.get(resolvedFeatureCounter++))));
+              MZmineCore.runLater(() -> previewChart.addDataset(ds, shapeRenderer));
+            }
+          } catch (UnsupportedOperationException e) {
+            MZmineCore.getDesktop().displayErrorMessage(e.getMessage());
           }
         } else {
           // for mobility dimension we don't need to remap RT
-          final List<IonTimeSeries<? extends Scan>> resolved = resolver
-              .resolve(newValue.getFeatureData(), null);
-          for (IonTimeSeries<? extends Scan> series : resolved) {
-            ColoredXYDataset ds = new ColoredXYDataset(new SummedMobilogramXYProvider(
-                ((IonMobilogramTimeSeries) series).getSummedMobilogram(),
-                new SimpleObjectProperty<>(palette.get(resolvedFeatureCounter++)), ""));
-            MZmineCore.runLater(() -> previewChart.addDataset(ds, shapeRenderer));
+          try {
+            final List<IonTimeSeries<? extends Scan>> resolved = resolver.resolve(newValue.getFeatureData(), null);
+            for (IonTimeSeries<? extends Scan> series : resolved) {
+              ColoredXYDataset ds = new ColoredXYDataset(new SummedMobilogramXYProvider(((IonMobilogramTimeSeries) series).getSummedMobilogram(),
+                  new SimpleObjectProperty<>(palette.get(resolvedFeatureCounter++)), ""));
+              MZmineCore.runLater(() -> previewChart.addDataset(ds, shapeRenderer));
+            }
+          } catch (UnsupportedOperationException e) {
+            MZmineCore.getDesktop().displayErrorMessage(e.getMessage());
           }
         }
       }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_mobilogram_summing/MobilogramBinningSetupDialog.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_mobilogram_summing/MobilogramBinningSetupDialog.java
@@ -21,6 +21,7 @@ package io.github.mzmine.modules.dataprocessing.featdet_mobilogram_summing;
 import io.github.mzmine.datamodel.IMSRawDataFile;
 import io.github.mzmine.datamodel.data_access.BinningMobilogramDataAccess;
 import io.github.mzmine.datamodel.featuredata.IonMobilogramTimeSeries;
+import io.github.mzmine.datamodel.featuredata.impl.ReducedIonMobilogramTimeSeries;
 import io.github.mzmine.datamodel.featuredata.impl.SummedIntensityMobilitySeries;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.ModularFeature;
@@ -59,8 +60,7 @@ public class MobilogramBinningSetupDialog extends ParameterSetupDialogWithPrevie
   protected ColoredXYShapeRenderer shapeRenderer = new ColoredXYShapeRenderer();
   protected BinningMobilogramDataAccess summedMobilogramAccess;
 
-  public MobilogramBinningSetupDialog(boolean valueCheckRequired,
-      ParameterSet parameters) {
+  public MobilogramBinningSetupDialog(boolean valueCheckRequired, ParameterSet parameters) {
     super(valueCheckRequired, parameters);
 
     intensityFormat = MZmineCore.getConfiguration().getIntensityFormat();
@@ -70,24 +70,22 @@ public class MobilogramBinningSetupDialog extends ParameterSetupDialogWithPrevie
     previewChart.setRangeAxisLabel("Intensity");
     previewChart.setDomainAxisLabel("Mobility");
     previewChart.setRangeAxisNumberFormatOverride(intensityFormat);
-    previewChart
-        .setDomainAxisNumberFormatOverride(MZmineCore.getConfiguration().getMobilityFormat());
+    previewChart.setDomainAxisNumberFormatOverride(
+        MZmineCore.getConfiguration().getMobilityFormat());
     previewChart.setMinHeight(400);
     processedRenderer = new ColoredXYShapeRenderer();
 
     previewChart.setRangeAxisNumberFormatOverride(intensityFormat);
-    ObservableList<ModularFeatureList> flists = (ObservableList<ModularFeatureList>)
-        (ObservableList<? extends FeatureList>) MZmineCore.getProjectManager().getCurrentProject()
-            .getFeatureLists();
+    ObservableList<ModularFeatureList> flists = (ObservableList<ModularFeatureList>) (ObservableList<? extends FeatureList>) MZmineCore.getProjectManager()
+        .getCurrentProject().getFeatureLists();
 
     fBox = new ComboBox<>();
     flistBox = new ComboBox<>(flists);
     flistBox.getSelectionModel().selectedItemProperty()
         .addListener(((observable, oldValue, newValue) -> {
           if (newValue != null) {
-            fBox.setItems(
-                FXCollections.observableArrayList(newValue
-                    .getFeatures(newValue.getRawDataFile(0))));
+            fBox.setItems(FXCollections.observableArrayList(
+                newValue.getFeatures(newValue.getRawDataFile(0))));
           } else {
             fBox.setItems(FXCollections.emptyObservableList());
           }
@@ -130,24 +128,24 @@ public class MobilogramBinningSetupDialog extends ParameterSetupDialogWithPrevie
   private void onSelectedFeatureChanged(final ModularFeature f) {
     previewChart.removeAllDatasets();
 
-    if (f == null || !(f.getRawDataFile() instanceof IMSRawDataFile) || !(f
-        .getFeatureData() instanceof IonMobilogramTimeSeries series)) {
+    if (f == null || !(f.getRawDataFile() instanceof IMSRawDataFile)
+        || !(f.getFeatureData() instanceof IonMobilogramTimeSeries series)) {
       return;
     }
 
     previewChart.setDomainAxisLabel(f.getMobilityUnit().getAxisLabel());
-    previewChart.addDataset(
-        new ColoredXYDataset(new SummedMobilogramXYProvider(series.getSummedMobilogram(),
+    previewChart.addDataset(new ColoredXYDataset(
+        new SummedMobilogramXYProvider(series.getSummedMobilogram(),
             new SimpleObjectProperty<>(f.getRawDataFile().getColor()),
             FeatureUtils.featureToString(f))));
 
     final Integer binWidth = switch (((IMSRawDataFile) f.getRawDataFile()).getMobilityType()) {
-      case TIMS -> parameterSet
-          .getParameter(MobilogramBinningParameters.timsBinningWidth).getValue();
-      case TRAVELING_WAVE -> parameterSet
-          .getParameter(MobilogramBinningParameters.twimsBinningWidth).getValue();
-      case DRIFT_TUBE -> parameterSet
-          .getParameter(MobilogramBinningParameters.dtimsBinningWidth).getValue();
+      case TIMS -> parameterSet.getParameter(MobilogramBinningParameters.timsBinningWidth)
+          .getValue();
+      case TRAVELING_WAVE -> parameterSet.getParameter(
+          MobilogramBinningParameters.twimsBinningWidth).getValue();
+      case DRIFT_TUBE -> parameterSet.getParameter(MobilogramBinningParameters.dtimsBinningWidth)
+          .getValue();
       default -> throw new UnsupportedOperationException(
           "Summing of the mobility type in raw data file " + f.getRawDataFile().getName()
               + " is unsupported.");
@@ -168,22 +166,20 @@ public class MobilogramBinningSetupDialog extends ParameterSetupDialogWithPrevie
     }
 
     summedMobilogramAccess.setMobilogram(series.getSummedMobilogram());
-    SummedIntensityMobilitySeries fromSummed = summedMobilogramAccess
-        .toSummedMobilogram(null);
+    SummedIntensityMobilitySeries fromSummed = summedMobilogramAccess.toSummedMobilogram(null);
 
-    previewChart.addDataset(new ColoredXYDataset(
-        new SummedMobilogramXYProvider(fromSummed,
-            new SimpleObjectProperty<>(colorPalette.getPositiveColor()),
-            "From preprocessed")), processedRenderer);
+    previewChart.addDataset(new ColoredXYDataset(new SummedMobilogramXYProvider(fromSummed,
+            new SimpleObjectProperty<>(colorPalette.getPositiveColor()), "From preprocessed")),
+        processedRenderer);
 
-    summedMobilogramAccess.setMobilogram(series.getMobilograms());
-    SummedIntensityMobilitySeries fromMobilograms = summedMobilogramAccess
-        .toSummedMobilogram(null);
+    if (!(series instanceof ReducedIonMobilogramTimeSeries)) {
+      summedMobilogramAccess.setMobilogram(series.getMobilograms());
+      SummedIntensityMobilitySeries fromMobilograms = summedMobilogramAccess.toSummedMobilogram(
+          null);
+      previewChart.addDataset(new ColoredXYDataset(new SummedMobilogramXYProvider(fromMobilograms,
+          new SimpleObjectProperty<>(colorPalette.getPositiveColor()), "From raw")));
+    }
 
-    previewChart.addDataset(new ColoredXYDataset(
-        new SummedMobilogramXYProvider(fromMobilograms,
-            new SimpleObjectProperty<>(colorPalette.getPositiveColor()),
-            "From raw")));
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_tracereducer/IonMobilityTraceReducerModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_tracereducer/IonMobilityTraceReducerModule.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2006-2021 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
 package io.github.mzmine.modules.dataprocessing.filter_tracereducer;
 
 import io.github.mzmine.datamodel.MZmineProject;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_tracereducer/IonMobilityTraceReducerModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_tracereducer/IonMobilityTraceReducerModule.java
@@ -1,0 +1,56 @@
+package io.github.mzmine.modules.dataprocessing.filter_tracereducer;
+
+import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.features.ModularFeatureList;
+import io.github.mzmine.modules.MZmineModuleCategory;
+import io.github.mzmine.modules.MZmineProcessingModule;
+import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.taskcontrol.Task;
+import io.github.mzmine.util.ExitCode;
+import io.github.mzmine.util.MemoryMapStorage;
+import java.util.Collection;
+import java.util.Date;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class IonMobilityTraceReducerModule implements MZmineProcessingModule {
+
+  @Override
+  public @NotNull String getName() {
+    return "Ion mobility trace reducer";
+  }
+
+  @Override
+  public @Nullable Class<? extends ParameterSet> getParameterSetClass() {
+    return IonMobilityTraceReducerParameters.class;
+  }
+
+  @Override
+  public @NotNull String getDescription() {
+    return "Removes the individual mobilograms for each rt data point from an ion mobility trace.\nSummed mobilograms and EICs are retained.";
+  }
+
+  @Override
+  public @NotNull ExitCode runModule(@NotNull MZmineProject project,
+      @NotNull ParameterSet parameters, @NotNull Collection<Task> tasks,
+      @NotNull Date moduleCallDate) {
+
+    final ModularFeatureList[] matchingFeatureLists = parameters.getParameter(
+        IonMobilityTraceReducerParameters.flists).getValue().getMatchingFeatureLists();
+
+    final MemoryMapStorage memoryMapStorage = MemoryMapStorage.forFeatureList();
+
+    for (ModularFeatureList matchingFeatureList : matchingFeatureLists) {
+      tasks.add(
+          new IonMobilityTraceReducerTask(memoryMapStorage, moduleCallDate, matchingFeatureList,
+              parameters, project));
+    }
+
+    return ExitCode.OK;
+  }
+
+  @Override
+  public @NotNull MZmineModuleCategory getModuleCategory() {
+    return MZmineModuleCategory.FEATURELISTFILTERING;
+  }
+}

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_tracereducer/IonMobilityTraceReducerParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_tracereducer/IonMobilityTraceReducerParameters.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2006-2021 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
 package io.github.mzmine.modules.dataprocessing.filter_tracereducer;
 
 import io.github.mzmine.parameters.Parameter;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_tracereducer/IonMobilityTraceReducerParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_tracereducer/IonMobilityTraceReducerParameters.java
@@ -1,0 +1,29 @@
+package io.github.mzmine.modules.dataprocessing.filter_tracereducer;
+
+import io.github.mzmine.parameters.Parameter;
+import io.github.mzmine.parameters.impl.IonMobilitySupport;
+import io.github.mzmine.parameters.impl.SimpleParameterSet;
+import io.github.mzmine.parameters.parametertypes.BooleanParameter;
+import io.github.mzmine.parameters.parametertypes.StringParameter;
+import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
+import org.jetbrains.annotations.NotNull;
+
+public class IonMobilityTraceReducerParameters extends SimpleParameterSet {
+
+  public static final FeatureListsParameter flists = new FeatureListsParameter();
+
+  public static final BooleanParameter removeOriginal = new BooleanParameter("Remove original",
+      "If checked, the original feature list is removed after this module finishes.", false);
+
+  public static final StringParameter suffix = new StringParameter("Suffix",
+      "The suffix to give to the new feature list.", "reduced", true);
+
+  public IonMobilityTraceReducerParameters() {
+    super(new Parameter[] {flists, removeOriginal, suffix});
+  }
+
+  @Override
+  public @NotNull IonMobilitySupport getIonMobilitySupport() {
+    return IonMobilitySupport.ONLY;
+  }
+}

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_tracereducer/IonMobilityTraceReducerTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_tracereducer/IonMobilityTraceReducerTask.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2006-2021 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
 package io.github.mzmine.modules.dataprocessing.filter_tracereducer;
 
 import io.github.mzmine.datamodel.FeatureStatus;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_tracereducer/IonMobilityTraceReducerTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_tracereducer/IonMobilityTraceReducerTask.java
@@ -1,0 +1,95 @@
+package io.github.mzmine.modules.dataprocessing.filter_tracereducer;
+
+import io.github.mzmine.datamodel.FeatureStatus;
+import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.datamodel.featuredata.IonMobilogramTimeSeries;
+import io.github.mzmine.datamodel.featuredata.IonTimeSeries;
+import io.github.mzmine.datamodel.featuredata.impl.ReducedIonMobilogramTimeSeries;
+import io.github.mzmine.datamodel.featuredata.impl.SimpleIonMobilogramTimeSeries;
+import io.github.mzmine.datamodel.features.ModularFeature;
+import io.github.mzmine.datamodel.features.ModularFeatureList;
+import io.github.mzmine.datamodel.features.ModularFeatureListRow;
+import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
+import io.github.mzmine.datamodel.features.types.FeatureDataType;
+import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.taskcontrol.AbstractTask;
+import io.github.mzmine.taskcontrol.TaskStatus;
+import io.github.mzmine.util.MemoryMapStorage;
+import java.util.Date;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class IonMobilityTraceReducerTask extends AbstractTask {
+
+  private final ModularFeatureList flist;
+  private final int totalRows;
+  private final ParameterSet parameters;
+  private final MZmineProject project;
+  private final boolean removeOriginal;
+  private final String suffix;
+  private int processedRows;
+
+  public IonMobilityTraceReducerTask(@Nullable MemoryMapStorage storage,
+      @NotNull Date moduleCallDate, ModularFeatureList flist, ParameterSet parameters,
+      MZmineProject project) {
+    super(storage, moduleCallDate);
+    this.flist = flist;
+    this.totalRows = flist.getNumberOfRows();
+    this.parameters = parameters;
+    this.project = project;
+    this.processedRows = 0;
+    this.suffix = parameters.getParameter(IonMobilityTraceReducerParameters.suffix).getValue();
+    this.removeOriginal = parameters.getParameter(IonMobilityTraceReducerParameters.removeOriginal)
+        .getValue();
+  }
+
+  @Override
+  public String getTaskDescription() {
+    return "Reducign ion mobility traces in row " + processedRows + "/" + totalRows;
+  }
+
+  @Override
+  public double getFinishedPercentage() {
+    return (double) processedRows / totalRows;
+  }
+
+  @Override
+  public void run() {
+    setStatus(TaskStatus.PROCESSING);
+
+    ModularFeatureList reducedList = flist.createCopy(flist.getName() + " " + suffix,
+        getMemoryMapStorage(), false);
+
+    reducedList.modularStream().forEach(row -> {
+      if (isCanceled()) {
+        return;
+      }
+      processRow(row);
+      processedRows++;
+    });
+
+    if (removeOriginal) {
+      project.removeFeatureList(flist);
+    }
+
+    reducedList.getAppliedMethods().add(
+        new SimpleFeatureListAppliedMethod(IonMobilityTraceReducerModule.class, parameters,
+            getModuleCallDate()));
+    project.addFeatureList(reducedList);
+
+    setStatus(TaskStatus.FINISHED);
+  }
+
+  private static void processRow(ModularFeatureListRow row) {
+    for (ModularFeature feature : row.getFeatures()) {
+      if (feature != null && feature.getFeatureStatus() != FeatureStatus.UNKNOWN) {
+        IonTimeSeries<? extends Scan> featureData = feature.getFeatureData();
+        if (featureData instanceof SimpleIonMobilogramTimeSeries imts) {
+          IonMobilogramTimeSeries newSeries = new ReducedIonMobilogramTimeSeries(imts);
+          feature.set(FeatureDataType.class, newSeries);
+        }
+      }
+    }
+  }
+}

--- a/src/test/java/datamodel/FeatureDataTypeTest.java
+++ b/src/test/java/datamodel/FeatureDataTypeTest.java
@@ -30,6 +30,7 @@ import io.github.mzmine.datamodel.featuredata.IonMobilitySeries;
 import io.github.mzmine.datamodel.featuredata.IonMobilogramTimeSeries;
 import io.github.mzmine.datamodel.featuredata.IonTimeSeries;
 import io.github.mzmine.datamodel.featuredata.impl.IonMobilogramTimeSeriesFactory;
+import io.github.mzmine.datamodel.featuredata.impl.ReducedIonMobilogramTimeSeries;
 import io.github.mzmine.datamodel.featuredata.impl.SimpleIonMobilitySeries;
 import io.github.mzmine.datamodel.featuredata.impl.SimpleIonTimeSeries;
 import io.github.mzmine.datamodel.features.ModularFeature;
@@ -154,6 +155,18 @@ public class FeatureDataTypeTest {
     Assertions.assertNotEquals(series, series_3);
 
     DataTypeTestUtils.testSaveLoad(new FeatureDataType(), null, flist, row, feature, file);
+
+    // test save and load for reduced trace
+    ReducedIonMobilogramTimeSeries reduced = new ReducedIonMobilogramTimeSeries(series);
+    feature.set(new FeatureDataType(), reduced);
+    DataTypeTestUtils.testSaveLoad(new FeatureDataType(), series, flist, row, feature, file);
+
+    // test equals
+    IonMobilogramTimeSeries reduced_2 = new ReducedIonMobilogramTimeSeries(series_2);
+    Assertions.assertEquals(reduced, reduced_2);
+
+    IonMobilogramTimeSeries reduced_3 = new ReducedIonMobilogramTimeSeries(series_3);
+    Assertions.assertNotEquals(reduced, reduced_3);
   }
 
   @NotNull


### PR DESCRIPTION
Removes the list of individual mobilograms from an SimpleIonMobilityTrace and creates a ReducedIonMobilityTrace. Still contains the summed mobilogram, but will not consume as much memory due to less List<Scan>. However, no more processing such as resolving can be applied, therefore i added some error messages and exceptions.