### PR TITLE
IMS expander allow raw data

### DIFF
--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/ADAPpeakpicking/ADAPResolver.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/ADAPpeakpicking/ADAPResolver.java
@@ -38,6 +38,7 @@ import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.modules.MZmineProcessingStep;
 import io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.AbstractResolver;
 import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.util.RangeUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -84,8 +85,8 @@ public class ADAPResolver extends AbstractResolver {
 
     final Range<Double> peakDuration = parameters.getParameter(PEAK_DURATION).getValue();
 
-    final MZmineProcessingStep<SNEstimatorChoice> signalNoiseEstimator = parameters
-        .getParameter(SN_ESTIMATORS).getValue();
+    final MZmineProcessingStep<SNEstimatorChoice> signalNoiseEstimator = parameters.getParameter(
+        SN_ESTIMATORS).getValue();
     String SNCode = signalNoiseEstimator.getModule().getSNCode();
 
     double signalNoiseWindowMult = -1.0;
@@ -119,8 +120,8 @@ public class ADAPResolver extends AbstractResolver {
     final double rtLow = rtRangeForCWTScales.lowerEndpoint();
     final double rtHigh = rtRangeForCWTScales.upperEndpoint();
     final int numScansRTLow = Math.max((int) Math.round(rtLow / avgRTInterval), 1);
-    final int numScansRTHigh = Math
-        .min((int) Math.round(rtHigh / avgRTInterval), retentionTimes.length);
+    final int numScansRTHigh = Math.min((int) Math.round(rtHigh / avgRTInterval),
+        retentionTimes.length);
 
     final List<PeakInfo> ADAPPeaks = DeconvoluteSignal(retentionTimes, intensities, 0d,
         parameters.getParameter(SN_THRESHOLD).getValue(),
@@ -141,7 +142,56 @@ public class ADAPResolver extends AbstractResolver {
     for (int i = 0; i < ADAPPeaks.size(); i++) {
       final PeakInfo curPeak = ADAPPeaks.get(i);
 
-      ranges.add(Range.closed(curPeak.retTimeStart, curPeak.retTimeEnd));
+      Range<Double> newRange = Range.closed(curPeak.retTimeStart, curPeak.retTimeEnd);
+
+      for (int j = 0; j < ranges.size(); j++) {
+        Range<Double> range = ranges.get(j);
+
+        // are they connected? if not, continue
+        if (!range.isConnected(newRange)) {
+          continue;
+        }
+
+        // are they the same? if yes, delete and break.
+        if (newRange.equals(range)) {
+          newRange = null;
+          break;
+        }
+
+        // if they only have one point in common, continue
+        if (RangeUtils.rangeLength(range.intersection(newRange)) < 0.001) {
+          continue;
+        }
+
+        // which range is the bigger one?
+        final Range<Double> biggerRange =
+            RangeUtils.rangeLength(newRange) >= RangeUtils.rangeLength(range) ? newRange : range;
+        final Range<Double> smallerRange =
+            RangeUtils.rangeLength(newRange) < RangeUtils.rangeLength(range) ? newRange : range;
+
+        // if the big range starts before the small range, use the original start point
+        // if the big range has the same or higher start point, start after the small range
+        final double newStart =
+            biggerRange.lowerEndpoint() < smallerRange.lowerEndpoint() ? biggerRange.lowerEndpoint()
+                : smallerRange.upperEndpoint();
+
+        // if the big range ends after the small range, use the original end
+        // if the big range ends with or before the small range, stop at the small range start point
+        final double newEnd =
+            biggerRange.upperEndpoint() > smallerRange.upperEndpoint() ? biggerRange.upperEndpoint()
+                : smallerRange.lowerEndpoint();
+
+        final Range<Double> newBiggerRange = Range.closed(newStart, newEnd);
+
+        if (biggerRange == newRange) {
+          newRange = newBiggerRange;
+        } else {
+          ranges.set(j, newBiggerRange);
+        }
+      }
+      if (newRange != null) {
+        ranges.add(newRange);
+      }
     }
     return ranges;
   }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/ADAPpeakpicking/ADAPResolver.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/ADAPpeakpicking/ADAPResolver.java
@@ -38,7 +38,6 @@ import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.modules.MZmineProcessingStep;
 import io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.AbstractResolver;
 import io.github.mzmine.parameters.ParameterSet;
-import io.github.mzmine.util.RangeUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -85,8 +84,8 @@ public class ADAPResolver extends AbstractResolver {
 
     final Range<Double> peakDuration = parameters.getParameter(PEAK_DURATION).getValue();
 
-    final MZmineProcessingStep<SNEstimatorChoice> signalNoiseEstimator = parameters.getParameter(
-        SN_ESTIMATORS).getValue();
+    final MZmineProcessingStep<SNEstimatorChoice> signalNoiseEstimator = parameters
+        .getParameter(SN_ESTIMATORS).getValue();
     String SNCode = signalNoiseEstimator.getModule().getSNCode();
 
     double signalNoiseWindowMult = -1.0;
@@ -120,8 +119,8 @@ public class ADAPResolver extends AbstractResolver {
     final double rtLow = rtRangeForCWTScales.lowerEndpoint();
     final double rtHigh = rtRangeForCWTScales.upperEndpoint();
     final int numScansRTLow = Math.max((int) Math.round(rtLow / avgRTInterval), 1);
-    final int numScansRTHigh = Math.min((int) Math.round(rtHigh / avgRTInterval),
-        retentionTimes.length);
+    final int numScansRTHigh = Math
+        .min((int) Math.round(rtHigh / avgRTInterval), retentionTimes.length);
 
     final List<PeakInfo> ADAPPeaks = DeconvoluteSignal(retentionTimes, intensities, 0d,
         parameters.getParameter(SN_THRESHOLD).getValue(),
@@ -142,56 +141,7 @@ public class ADAPResolver extends AbstractResolver {
     for (int i = 0; i < ADAPPeaks.size(); i++) {
       final PeakInfo curPeak = ADAPPeaks.get(i);
 
-      Range<Double> newRange = Range.closed(curPeak.retTimeStart, curPeak.retTimeEnd);
-
-      for (int j = 0; j < ranges.size(); j++) {
-        Range<Double> range = ranges.get(j);
-
-        // are they connected? if not, continue
-        if (!range.isConnected(newRange)) {
-          continue;
-        }
-
-        // are they the same? if yes, delete and break.
-        if (newRange.equals(range)) {
-          newRange = null;
-          break;
-        }
-
-        // if they only have one point in common, continue
-        if (RangeUtils.rangeLength(range.intersection(newRange)) < 0.001) {
-          continue;
-        }
-
-        // which range is the bigger one?
-        final Range<Double> biggerRange =
-            RangeUtils.rangeLength(newRange) >= RangeUtils.rangeLength(range) ? newRange : range;
-        final Range<Double> smallerRange =
-            RangeUtils.rangeLength(newRange) < RangeUtils.rangeLength(range) ? newRange : range;
-
-        // if the big range starts before the small range, use the original start point
-        // if the big range has the same or higher start point, start after the small range
-        final double newStart =
-            biggerRange.lowerEndpoint() < smallerRange.lowerEndpoint() ? biggerRange.lowerEndpoint()
-                : smallerRange.upperEndpoint();
-
-        // if the big range ends after the small range, use the original end
-        // if the big range ends with or before the small range, stop at the small range start point
-        final double newEnd =
-            biggerRange.upperEndpoint() > smallerRange.upperEndpoint() ? biggerRange.upperEndpoint()
-                : smallerRange.lowerEndpoint();
-
-        final Range<Double> newBiggerRange = Range.closed(newStart, newEnd);
-
-        if (biggerRange == newRange) {
-          newRange = newBiggerRange;
-        } else {
-          ranges.set(j, newBiggerRange);
-        }
-      }
-      if (newRange != null) {
-        ranges.add(newRange);
-      }
+      ranges.add(Range.closed(curPeak.retTimeStart, curPeak.retTimeEnd));
     }
     return ranges;
   }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_imsexpander/ImsExpanderParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_imsexpander/ImsExpanderParameters.java
@@ -18,12 +18,20 @@
 
 package io.github.mzmine.modules.dataprocessing.featdet_imsexpander;
 
+import io.github.mzmine.datamodel.IMSRawDataFile;
+import io.github.mzmine.datamodel.MassSpectrumType;
+import io.github.mzmine.datamodel.features.ModularFeatureList;
+import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.parameters.Parameter;
+import io.github.mzmine.parameters.impl.IonMobilitySupport;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
+import io.github.mzmine.parameters.parametertypes.DoubleParameter;
 import io.github.mzmine.parameters.parametertypes.IntegerParameter;
 import io.github.mzmine.parameters.parametertypes.OptionalParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZToleranceParameter;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 public class ImsExpanderParameters extends SimpleParameterSet {
 
@@ -35,13 +43,55 @@ public class ImsExpanderParameters extends SimpleParameterSet {
               + "tolerance will be applied to the feature m/z. If disabled, the m/z range of the "
               + "feature's data points will be used as a tolerance range."));
 
-  public static final IntegerParameter mobilogramBinWidth = new IntegerParameter(
-      "Mobility bin witdh (scans)",
-      "The mobility binning width in scans. (default = 1, high mobility resolutions "
-          + "in TIMS might require a higher bin width to achieve a constant ion current for a "
-          + "mobilogram.", 1, true);
+  public static final OptionalParameter<DoubleParameter> useRawData = new OptionalParameter<>(
+      new DoubleParameter("Raw data instead of thresholded",
+          "If checked, the raw data can be used to expand the chromatograms into mobility dimension.\n"
+              + "This can increase sensitivity but will also increase RAM demands and computation time.\n"
+              + "A new noise level can be given or every data point can be used (0E0)",
+          MZmineCore.getConfiguration().getIntensityFormat(), 1E1, 0d, Double.POSITIVE_INFINITY));
+
+  public static final OptionalParameter<IntegerParameter> mobilogramBinWidth = new OptionalParameter<>(
+      new IntegerParameter("Override default mobility bin witdh (scans)",
+          "If checked, the default recommended bin width for the raw data file will be overridden with the given value.\n"
+              + "The mobility binning width in scans. (high mobility resolutions "
+              + "in TIMS might require a higher bin width to achieve a constant ion current for a "
+              + "mobilogram.", 1, true));
 
   public ImsExpanderParameters() {
-    super(new Parameter[]{featureLists, mzTolerance, mobilogramBinWidth});
+    super(new Parameter[]{featureLists, mzTolerance, useRawData, mobilogramBinWidth});
+  }
+
+  @Override
+  public boolean checkParameterValues(Collection<String> errorMessages) {
+    final boolean superCheck = super.checkParameterValues(errorMessages);
+    if (!superCheck) {
+      return false;
+    }
+
+    ModularFeatureList[] matchingFeatureLists = getParameter(featureLists).getValue()
+        .getMatchingFeatureLists();
+
+    for (ModularFeatureList flist : matchingFeatureLists) {
+      if (flist.getNumberOfRawDataFiles() > 1) {
+        errorMessages.add("Feature list " + flist.getName()
+            + " is an aligned feature list. Please expand before alignment.");
+      }
+
+      if (((IMSRawDataFile) flist.getRawDataFile(0)).getFrame(0).getMobilityScan(0)
+          .getSpectrumType() != MassSpectrumType.CENTROIDED
+          && getParameter(useRawData).getValue() == true) {
+        errorMessages.add(
+            "Feature list " + flist.getName() + " contains raw data file " + flist.getRawDataFile(0)
+                + " which has profile raw data.\nCannot use profile raw data to expand in mobility dimension. Please disable the \""
+                + useRawData.getName() + "\" parameter.");
+      }
+    }
+
+    return errorMessages.isEmpty();
+  }
+
+  @Override
+  public @NotNull IonMobilitySupport getIonMobilitySupport() {
+    return IonMobilitySupport.ONLY;
   }
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_imsexpander/ImsExpanderSubTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_imsexpander/ImsExpanderSubTask.java
@@ -46,9 +46,9 @@ public class ImsExpanderSubTask extends AbstractTask {
   private final ModularFeatureList flist;
   private final List<ExpandingTrace> expandingTraces;
 
-  private String desc = "Mobility expanding.";
   private final AtomicInteger processedFrames = new AtomicInteger(0);
-  private final AtomicInteger processedRows = new AtomicInteger(0);
+  private final Boolean useRawData;
+  private final Double customNoiseLevel;
 
   private long totalFrames = 1;
 
@@ -61,11 +61,16 @@ public class ImsExpanderSubTask extends AbstractTask {
     this.frames = frames;
     this.flist = flist;
     this.expandingTraces = expandingTraces;
+    this.useRawData = parameters.getParameter(ImsExpanderParameters.useRawData).getValue();
+    this.customNoiseLevel = parameters.getParameter(ImsExpanderParameters.useRawData)
+        .getEmbeddedParameter().getValue();
   }
 
   @Override
   public String getTaskDescription() {
-    return desc;
+    return flist.getName() + ": expanding traces for frame " + processedFrames.get() + "/"
+        + totalFrames + " (m/z " + expandingTraces.get(0).getMzRange().lowerEndpoint() + " - "
+        + expandingTraces.get(expandingTraces.size() - 1).getMzRange().upperEndpoint();
   }
 
   @Override
@@ -79,7 +84,7 @@ public class ImsExpanderSubTask extends AbstractTask {
     final IMSRawDataFile imsFile = (IMSRawDataFile) frames.get(0).getDataFile();
     logger.finest("Initialising data access for file " + imsFile.getName());
     final MobilityScanDataAccess access = new MobilityScanDataAccess(imsFile,
-        MobilityScanDataType.CENTROID, frames);
+        useRawData ? MobilityScanDataType.RAW : MobilityScanDataType.CENTROID, frames);
 
     totalFrames = access.getNumberOfScans();
 
@@ -93,16 +98,19 @@ public class ImsExpanderSubTask extends AbstractTask {
 
         final Frame frame = access.nextFrame();
 
-        desc = flist.getName() + ": expanding traces for frame " + processedFrames.get() + "/"
-            + totalFrames + ".";
-
         while (access.hasNextMobilityScan()) {
           final MobilityScan mobilityScan = access.nextMobilityScan();
 
           int traceIndex = 0;
           for (int dpIndex = 0; dpIndex < access.getNumberOfDataPoints() && traceIndex < numTraces;
               dpIndex++) {
-            double mz = access.getMzValue(dpIndex);
+            final double mz = access.getMzValue(dpIndex);
+            final double intensity = access.getIntensityValue(dpIndex);
+
+            if(useRawData && intensity < customNoiseLevel) {
+              continue;
+            }
+
             // while the trace upper mz smaller than the current mz, we increment the trace index
             while (expandingTraces.get(traceIndex).getMzRange().upperEndpoint() < mz
                 && traceIndex < numTraces - 1) {
@@ -114,23 +122,12 @@ public class ImsExpanderSubTask extends AbstractTask {
             }
 
             // try to offer the current data point to the trace
-            while (expandingTraces.get(traceIndex).getMzRange().contains(mz) && !expandingTraces
-                .get(traceIndex).offerDataPoint(access, dpIndex) && traceIndex < numTraces - 1) {
+            while (expandingTraces.get(traceIndex).getMzRange().contains(mz)
+                && !expandingTraces.get(traceIndex).offerDataPoint(access, dpIndex)
+                && traceIndex < numTraces - 1) {
               traceIndex++;
             }
           }
-
-          /*int dpIndex = 0;
-          for(int traceIndex = 0; i < expandingTraces.size(); traceIndex++) {
-            final double mz = access.getMzValue(dpIndex);
-            final ExpandingTrace trace = expandingTraces.get(traceIndex);
-
-            if(trace.getMzRange().lowerEndpoint() > mz) {
-              continue;
-            } else if(trace.getMzRange().upperEndpoint() < mz) {
-              continue;
-            }
-          }*/
         }
         processedFrames.getAndIncrement();
       }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_imsexpander/ImsExpanderTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_imsexpander/ImsExpanderTask.java
@@ -83,7 +83,10 @@ public class ImsExpanderTask extends AbstractTask {
     useMzToleranceRange = parameters.getParameter(ImsExpanderParameters.mzTolerance).getValue();
     mzTolerance = parameters.getParameter(ImsExpanderParameters.mzTolerance).getEmbeddedParameter()
         .getValue();
-    binWidth = parameters.getParameter(ImsExpanderParameters.mobilogramBinWidth).getValue();
+    binWidth = parameters.getParameter(ImsExpanderParameters.mobilogramBinWidth).getValue()
+        ? parameters.getParameter(ImsExpanderParameters.mobilogramBinWidth).getEmbeddedParameter()
+        .getValue() : BinningMobilogramDataAccess.getRecommendedBinWidth(
+        (IMSRawDataFile) flist.getRawDataFile(0));
   }
 
   @Override


### PR DESCRIPTION
IMS expander can use raw data instead of thresholded for expansion to achieve higher intensity coverage (centroided files only)