### PR TITLE
fix peaks with overlapping ranges in adap resolver

### DIFF
--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/ADAPpeakpicking/ADAPResolver.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/ADAPpeakpicking/ADAPResolver.java
@@ -38,6 +38,7 @@ import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.modules.MZmineProcessingStep;
 import io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.AbstractResolver;
 import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.util.RangeUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -141,7 +142,56 @@ public class ADAPResolver extends AbstractResolver {
     for (int i = 0; i < ADAPPeaks.size(); i++) {
       final PeakInfo curPeak = ADAPPeaks.get(i);
 
-      ranges.add(Range.closed(curPeak.retTimeStart, curPeak.retTimeEnd));
+      Range<Double> newRange = Range.closed(curPeak.retTimeStart, curPeak.retTimeEnd);
+
+      for (int j = 0; j < ranges.size(); j++) {
+        Range<Double> range = ranges.get(j);
+
+        // are they connected? if not, continue
+        if (!range.isConnected(newRange)) {
+          continue;
+        }
+
+        // are they the same? if yes, delete and break.
+        if (newRange.equals(range)) {
+          newRange = null;
+          break;
+        }
+
+        // if they only have one point in common, continue
+        if (RangeUtils.rangeLength(range.intersection(newRange)) < 0.001) {
+          continue;
+        }
+
+        // which range is the bigger one?
+        final Range<Double> biggerRange =
+            RangeUtils.rangeLength(newRange) >= RangeUtils.rangeLength(range) ? newRange : range;
+        final Range<Double> smallerRange =
+            RangeUtils.rangeLength(newRange) < RangeUtils.rangeLength(range) ? newRange : range;
+
+        // if the big range starts before the small range, use the original start point
+        // if the big range has the same or higher start point, start after the small range
+        final double newStart =
+            biggerRange.lowerEndpoint() < smallerRange.lowerEndpoint() ? biggerRange.lowerEndpoint()
+                : smallerRange.upperEndpoint();
+
+        // if the big range ends after the small range, use the original end
+        // if the big range ends with or before the small range, stop at the small range start point
+        final double newEnd =
+            biggerRange.upperEndpoint() > smallerRange.upperEndpoint() ? biggerRange.upperEndpoint()
+                : smallerRange.lowerEndpoint();
+
+        final Range<Double> newBiggerRange = Range.closed(newStart, newEnd);
+
+        if (biggerRange == newRange) {
+          newRange = newBiggerRange;
+        } else {
+          ranges.set(j, newBiggerRange);
+        }
+      }
+      if (newRange != null) {
+        ranges.add(newRange);
+      }
     }
     return ranges;
   }


### PR DESCRIPTION
I noticed that resolved features in the ADAP resolver will sometimes overlap with specific wavelet settings.

Example see the blue and red features here, the blue also covers the range of the red feature.
![grafik](https://user-images.githubusercontent.com/37407705/139668895-a42de7cf-5777-44c1-9da0-28972e92e004.png)

With this fix, the ranges of the peak are not overlapping anymore.
![grafik](https://user-images.githubusercontent.com/37407705/139669047-37487fde-87cd-45ca-88d4-209d7edb8064.png)

@asmirn1 Can you have a look please? Should this rather be commited to the ADAP source?
