### PR TITLE
remove mz center parameter from resolver dialog 

### DIFF
--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/ADAPpeakpicking/ADAPResolverParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/ADAPpeakpicking/ADAPResolverParameters.java
@@ -78,8 +78,8 @@ public class ADAPResolverParameters extends GeneralResolverParameters {
           + "set in the chromatogram building.", NumberFormat.getNumberInstance(), 10.0, 0.0, null);
 
   public ADAPResolverParameters() {
-    super(new Parameter[]{PEAK_LISTS, SUFFIX, MZ_CENTER_FUNCTION, AUTO_REMOVE, groupMS2Parameters,
-        dimension, SN_THRESHOLD, SN_ESTIMATORS, MIN_FEAT_HEIGHT, COEF_AREA_THRESHOLD, PEAK_DURATION,
+    super(new Parameter[]{PEAK_LISTS, SUFFIX, AUTO_REMOVE, groupMS2Parameters, dimension,
+        SN_THRESHOLD, SN_ESTIMATORS, MIN_FEAT_HEIGHT, COEF_AREA_THRESHOLD, PEAK_DURATION,
         RT_FOR_CWT_SCALES_DURATION});
   }
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/FeatureResolverModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/FeatureResolverModule.java
@@ -19,18 +19,14 @@
 package io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution;
 
 import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.featuredata.FeatureDataUtils;
 import io.github.mzmine.datamodel.features.FeatureList;
-import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
-import io.github.mzmine.util.maths.CenterFunction;
-import io.github.mzmine.util.maths.CenterMeasure;
-import io.github.mzmine.util.maths.Weighting;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import org.jetbrains.annotations.NotNull;
@@ -38,8 +34,7 @@ import org.jetbrains.annotations.NotNull;
 public abstract class FeatureResolverModule implements MZmineProcessingModule {
 
   private static final String MODULE_NAME = "Chromatogram deconvolution";
-  private static final String MODULE_DESCRIPTION =
-      "This module separates each detected chromatogram into individual peaks.";
+  private static final String MODULE_DESCRIPTION = "This module separates each detected chromatogram into individual peaks.";
 
   @Override
   public @NotNull MZmineModuleCategory getModuleCategory() {
@@ -53,37 +48,11 @@ public abstract class FeatureResolverModule implements MZmineProcessingModule {
     // one memory map storage per module call to reduce number of files and connect related feature lists
     MemoryMapStorage storage = MemoryMapStorage.forFeatureList();
 
-    FeatureList[] peakLists = parameters.getParameter(GeneralResolverParameters.PEAK_LISTS).getValue()
-        .getMatchingFeatureLists();
-
-    // function to calculate center mz
-    CenterFunction mzCenterFunction =
-        parameters.getParameter(GeneralResolverParameters.MZ_CENTER_FUNCTION).getValue();
-
-    // use a logger weighted, noise corrected, maximum weight capped function
-    if (mzCenterFunction.getMeasure().equals(CenterMeasure.AUTO)) {
-      // data point with lowest intensity
-      // weight = logger(value) - logger(noise) (maxed to maxWeight)
-      double noise =
-          Arrays.stream(peakLists).flatMap(pkl -> pkl.getRows().stream()).map(r -> r.getFeatures().get(0))
-              .mapToDouble(peak -> peak.getRawDataPointsIntensityRange().lowerEndpoint())
-              .filter(v -> v != 0).min().orElse(0);
-
-      // maxWeight 4 corresponds to a linear range of 4 orders of
-      // magnitude
-      // everything higher than this will be capped to this weight
-      // do not overestimate influence of very high data points on mass
-      // accuracy
-      double maxWeight = 4;
-
-      // use a logger weighted, noise corrected, maximum weight capped
-      // function
-      mzCenterFunction =
-          new CenterFunction(CenterMeasure.AVG, Weighting.logger10, noise, maxWeight);
-    }
-
+    FeatureList[] peakLists = parameters.getParameter(GeneralResolverParameters.PEAK_LISTS)
+        .getValue().getMatchingFeatureLists();
     for (final FeatureList peakList : peakLists) {
-      tasks.add(new FeatureResolverTask(project, storage, peakList, parameters, mzCenterFunction, moduleCallDate));
+      tasks.add(new FeatureResolverTask(project, storage, peakList, parameters,
+          FeatureDataUtils.DEFAULT_CENTER_FUNCTION, moduleCallDate));
     }
 
     return ExitCode.OK;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/GeneralResolverParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/GeneralResolverParameters.java
@@ -24,13 +24,11 @@ import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
 import io.github.mzmine.parameters.parametertypes.BooleanParameter;
-import io.github.mzmine.parameters.parametertypes.CenterMeasureParameter;
 import io.github.mzmine.parameters.parametertypes.ComboParameter;
 import io.github.mzmine.parameters.parametertypes.StringParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
 import io.github.mzmine.parameters.parametertypes.submodules.OptionalModuleParameter;
 import io.github.mzmine.util.R.REngineType;
-import io.github.mzmine.util.maths.CenterMeasure;
 import javafx.collections.FXCollections;
 import org.jetbrains.annotations.Nullable;
 
@@ -40,10 +38,6 @@ public abstract class GeneralResolverParameters extends SimpleParameterSet {
 
   public static final StringParameter SUFFIX = new StringParameter("Suffix",
       "This string is added to feature list name as suffix", "resolved");
-
-  public static final CenterMeasureParameter MZ_CENTER_FUNCTION = new CenterMeasureParameter(
-      "m/z center calculation", "Median, average or an automatic log10-weighted approach",
-      CenterMeasure.values(), null, CenterMeasure.MEDIAN, null);
 
   public static final BooleanParameter AUTO_REMOVE = new BooleanParameter(
       "Remove original feature list",

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/baseline/BaselineFeatureResolverParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/baseline/BaselineFeatureResolverParameters.java
@@ -30,27 +30,27 @@ import io.github.mzmine.util.ExitCode;
 
 public class BaselineFeatureResolverParameters extends GeneralResolverParameters {
 
-  public static final DoubleParameter MIN_PEAK_HEIGHT =
-      new DoubleParameter("Min peak height", "Minimum acceptable peak height (absolute intensity)",
-          MZmineCore.getConfiguration().getIntensityFormat());
+  public static final DoubleParameter MIN_PEAK_HEIGHT = new DoubleParameter("Min peak height",
+      "Minimum acceptable peak height (absolute intensity)",
+      MZmineCore.getConfiguration().getIntensityFormat());
 
-  public static final DoubleRangeParameter PEAK_DURATION =
-      new DoubleRangeParameter("Peak duration range (min)", "Range of acceptable peak lengths",
-          MZmineCore.getConfiguration().getRTFormat(), Range.closed(0.0, 10.0));
+  public static final DoubleRangeParameter PEAK_DURATION = new DoubleRangeParameter(
+      "Peak duration range (min)", "Range of acceptable peak lengths",
+      MZmineCore.getConfiguration().getRTFormat(), Range.closed(0.0, 10.0));
 
   public static final DoubleParameter BASELINE_LEVEL = new DoubleParameter("Baseline level",
       "Level below which all data points of the chromatogram are removed (absolute intensity)",
       MZmineCore.getConfiguration().getIntensityFormat());
 
   public BaselineFeatureResolverParameters() {
-    super(new Parameter[]{PEAK_LISTS, SUFFIX, MZ_CENTER_FUNCTION, AUTO_REMOVE, groupMS2Parameters,
-        MIN_PEAK_HEIGHT, PEAK_DURATION, BASELINE_LEVEL});
+    super(new Parameter[]{PEAK_LISTS, SUFFIX, AUTO_REMOVE, groupMS2Parameters, MIN_PEAK_HEIGHT,
+        PEAK_DURATION, BASELINE_LEVEL});
   }
 
   @Override
   public ExitCode showSetupDialog(boolean valueCheckRequired) {
-    final FeatureResolverSetupDialog dialog =
-        new FeatureResolverSetupDialog(valueCheckRequired, this, null);
+    final FeatureResolverSetupDialog dialog = new FeatureResolverSetupDialog(valueCheckRequired,
+        this, null);
     dialog.showAndWait();
     return dialog.getExitCode();
   }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/centwave/CentWaveResolverParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/centwave/CentWaveResolverParameters.java
@@ -93,7 +93,7 @@ public class CentWaveResolverParameters extends GeneralResolverParameters {
 
   public CentWaveResolverParameters() {
 
-    super(new Parameter[]{PEAK_LISTS, SUFFIX, MZ_CENTER_FUNCTION, AUTO_REMOVE, groupMS2Parameters, SN_THRESHOLD,
+    super(new Parameter[]{PEAK_LISTS, SUFFIX, AUTO_REMOVE, groupMS2Parameters, SN_THRESHOLD,
         PEAK_SCALES, PEAK_DURATION, INTEGRATION_METHOD, RENGINE_TYPE});
   }
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/minimumsearch/MinimumSearchFeatureResolverParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/minimumsearch/MinimumSearchFeatureResolverParameters.java
@@ -71,9 +71,9 @@ public class MinimumSearchFeatureResolverParameters extends GeneralResolverParam
 
 
   public MinimumSearchFeatureResolverParameters() {
-    super(new Parameter[]{PEAK_LISTS, SUFFIX, MZ_CENTER_FUNCTION, AUTO_REMOVE, groupMS2Parameters,
-        dimension, CHROMATOGRAPHIC_THRESHOLD_LEVEL, SEARCH_RT_RANGE, MIN_RELATIVE_HEIGHT,
-        MIN_ABSOLUTE_HEIGHT, MIN_RATIO, PEAK_DURATION, MIN_NUMBER_OF_DATAPOINTS});
+    super(new Parameter[]{PEAK_LISTS, SUFFIX, AUTO_REMOVE, groupMS2Parameters, dimension,
+        CHROMATOGRAPHIC_THRESHOLD_LEVEL, SEARCH_RT_RANGE, MIN_RELATIVE_HEIGHT, MIN_ABSOLUTE_HEIGHT,
+        MIN_RATIO, PEAK_DURATION, MIN_NUMBER_OF_DATAPOINTS});
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/noiseamplitude/NoiseAmplitudeFeatureResolverParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/noiseamplitude/NoiseAmplitudeFeatureResolverParameters.java
@@ -43,7 +43,7 @@ public class NoiseAmplitudeFeatureResolverParameters extends GeneralResolverPara
       MZmineCore.getConfiguration().getIntensityFormat());
 
   public NoiseAmplitudeFeatureResolverParameters() {
-    super(new Parameter[]{PEAK_LISTS, SUFFIX, MZ_CENTER_FUNCTION, AUTO_REMOVE, groupMS2Parameters, MIN_PEAK_HEIGHT,
+    super(new Parameter[]{PEAK_LISTS, SUFFIX, AUTO_REMOVE, groupMS2Parameters, MIN_PEAK_HEIGHT,
         PEAK_DURATION, NOISE_AMPLITUDE});
   }
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/savitzkygolay/SavitzkyGolayFeatureResolverParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/savitzkygolay/SavitzkyGolayFeatureResolverParameters.java
@@ -31,27 +31,27 @@ import io.github.mzmine.util.ExitCode;
 
 public class SavitzkyGolayFeatureResolverParameters extends GeneralResolverParameters {
 
-  public static final DoubleParameter MIN_PEAK_HEIGHT =
-      new DoubleParameter("Min peak height", "Minimum acceptable peak height (absolute intensity)",
-          MZmineCore.getConfiguration().getIntensityFormat());
+  public static final DoubleParameter MIN_PEAK_HEIGHT = new DoubleParameter("Min peak height",
+      "Minimum acceptable peak height (absolute intensity)",
+      MZmineCore.getConfiguration().getIntensityFormat());
 
-  public static final DoubleRangeParameter PEAK_DURATION =
-      new DoubleRangeParameter("Peak duration range (min)", "Range of acceptable peak lengths",
-          MZmineCore.getConfiguration().getRTFormat(), Range.closed(0.0, 10.0));
+  public static final DoubleRangeParameter PEAK_DURATION = new DoubleRangeParameter(
+      "Peak duration range (min)", "Range of acceptable peak lengths",
+      MZmineCore.getConfiguration().getRTFormat(), Range.closed(0.0, 10.0));
 
-  public static final PercentParameter DERIVATIVE_THRESHOLD_LEVEL =
-      new PercentParameter("Derivative threshold level",
-          "Minimum acceptable intensity in the 2nd derivative for peak recognition");
+  public static final PercentParameter DERIVATIVE_THRESHOLD_LEVEL = new PercentParameter(
+      "Derivative threshold level",
+      "Minimum acceptable intensity in the 2nd derivative for peak recognition");
 
   public SavitzkyGolayFeatureResolverParameters() {
-    super(new Parameter[]{PEAK_LISTS, SUFFIX, MZ_CENTER_FUNCTION, AUTO_REMOVE, groupMS2Parameters,
-        MIN_PEAK_HEIGHT, PEAK_DURATION, DERIVATIVE_THRESHOLD_LEVEL, RENGINE_TYPE});
+    super(new Parameter[]{PEAK_LISTS, SUFFIX, AUTO_REMOVE, groupMS2Parameters, MIN_PEAK_HEIGHT,
+        PEAK_DURATION, DERIVATIVE_THRESHOLD_LEVEL, RENGINE_TYPE});
   }
 
   @Override
   public ExitCode showSetupDialog(boolean valueCheckRequired) {
-    final FeatureResolverSetupDialog dialog =
-        new FeatureResolverSetupDialog(valueCheckRequired, this, null);
+    final FeatureResolverSetupDialog dialog = new FeatureResolverSetupDialog(valueCheckRequired,
+        this, null);
     dialog.showAndWait();
     return dialog.getExitCode();
   }

--- a/src/main/java/io/github/mzmine/modules/tools/batchwizard/BatchWizardController.java
+++ b/src/main/java/io/github/mzmine/modules/tools/batchwizard/BatchWizardController.java
@@ -78,8 +78,6 @@ import io.github.mzmine.parameters.parametertypes.tolerances.RTTolerance;
 import io.github.mzmine.parameters.parametertypes.tolerances.RTTolerance.Unit;
 import io.github.mzmine.parameters.parametertypes.tolerances.mobilitytolerance.MobilityTolerance;
 import io.github.mzmine.util.ExitCode;
-import io.github.mzmine.util.maths.CenterFunction;
-import io.github.mzmine.util.maths.CenterMeasure;
 import io.github.mzmine.util.maths.similarity.SimilarityMeasure;
 import java.util.ArrayList;
 import java.util.List;
@@ -371,8 +369,6 @@ public class BatchWizardController {
     param.setParameter(MinimumSearchFeatureResolverParameters.PEAK_LISTS,
         new FeatureListsSelection(FeatureListsSelectionType.BATCH_LAST_FEATURELISTS));
     param.setParameter(MinimumSearchFeatureResolverParameters.SUFFIX, "r");
-    param.setParameter(MinimumSearchFeatureResolverParameters.MZ_CENTER_FUNCTION,
-        new CenterFunction(CenterMeasure.AVG, CenterFunction.DEFAULT_MZ_WEIGHTING));
     param.setParameter(MinimumSearchFeatureResolverParameters.AUTO_REMOVE, true);
 
     param.setParameter(MinimumSearchFeatureResolverParameters.groupMS2Parameters, true);
@@ -424,8 +420,6 @@ public class BatchWizardController {
     param.setParameter(MinimumSearchFeatureResolverParameters.PEAK_LISTS,
         new FeatureListsSelection(FeatureListsSelectionType.BATCH_LAST_FEATURELISTS));
     param.setParameter(MinimumSearchFeatureResolverParameters.SUFFIX, "r");
-    param.setParameter(MinimumSearchFeatureResolverParameters.MZ_CENTER_FUNCTION,
-        new CenterFunction(CenterMeasure.AVG, CenterFunction.DEFAULT_MZ_WEIGHTING));
     param.setParameter(MinimumSearchFeatureResolverParameters.AUTO_REMOVE, true);
 
     param.setParameter(MinimumSearchFeatureResolverParameters.groupMS2Parameters, true);

--- a/src/main/java/io/github/mzmine/util/FeatureConvertors.java
+++ b/src/main/java/io/github/mzmine/util/FeatureConvertors.java
@@ -102,12 +102,12 @@ public class FeatureConvertors {
     ModularFeature modularFeature = new ModularFeature(
         (ModularFeatureList) chromatogram.getFeatureList());
 
-    modularFeature
-        .set(FragmentScanNumbersType.class, List.of(chromatogram.getAllMS2FragmentScanNumbers()));
+    modularFeature.set(FragmentScanNumbersType.class,
+        List.of(chromatogram.getAllMS2FragmentScanNumbers()));
 //    modularFeature.set(ScanNumbersType.class, List.of(chromatogram.getScanNumbers()));
 
-    modularFeature
-        .set(BestFragmentScanNumberType.class, chromatogram.getMostIntenseFragmentScanNumber());
+    modularFeature.set(BestFragmentScanNumberType.class,
+        chromatogram.getMostIntenseFragmentScanNumber());
     modularFeature.set(BestScanNumberType.class, chromatogram.getRepresentativeScanNumber());
     if (chromatogram.getIsotopePattern() != null) {
       modularFeature.set(IsotopePatternType.class, chromatogram.getIsotopePattern());
@@ -133,9 +133,9 @@ public class FeatureConvertors {
     // recalculate data dependent types
     FeatureDataUtils.recalculateIonSeriesDependingTypes(modularFeature);
 
-    ObservableList<Scan> allMS2 = Arrays.stream(ScanUtils
-        .findAllMS2FragmentScans(chromatogram.getDataFile(),
-            modularFeature.getRawDataPointsRTRange(), modularFeature.getRawDataPointsMZRange()))
+    ObservableList<Scan> allMS2 = Arrays.stream(
+            ScanUtils.findAllMS2FragmentScans(chromatogram.getDataFile(),
+                modularFeature.getRawDataPointsRTRange(), modularFeature.getRawDataPointsMZRange()))
         .collect(Collectors.toCollection(FXCollections::observableArrayList));
     modularFeature.setAllMS2FragmentScans(allMS2);
 
@@ -163,8 +163,7 @@ public class FeatureConvertors {
     modularFeature.set(DetectionType.class, FeatureStatus.DETECTED);
     modularFeature.setMobilityUnit(((IMSRawDataFile) rawDataFile).getMobilityType());
 
-    final MemoryMapStorage storage = ((ModularFeatureList) ionTrace.getFeatureList())
-        .getMemoryMapStorage();
+    final MemoryMapStorage storage = ((ModularFeatureList) ionTrace.getFeatureList()).getMemoryMapStorage();
     final List<IonMobilitySeries> mobilograms = new ArrayList<>();
 
     var sortedDp = FeatureConvertorIonMobility.groupDataPointsByFrameId(ionTrace.getDataPoints());
@@ -175,14 +174,13 @@ public class FeatureConvertors {
       mobilograms.add(mobilogram);
     }
 
-    final IonMobilogramTimeSeries imTimeSeries = IonMobilogramTimeSeriesFactory
-        .of(storage, mobilograms, mobilogramBinner);
+    final IonMobilogramTimeSeries imTimeSeries = IonMobilogramTimeSeriesFactory.of(storage,
+        mobilograms, mobilogramBinner);
     modularFeature.set(FeatureDataType.class, imTimeSeries);
 
     // no need to calc quality parameters after feature detection.
-    FeatureDataUtils
-        .recalculateIonSeriesDependingTypes(modularFeature, FeatureDataUtils.DEFAULT_CENTER_MEASURE,
-            false);
+    FeatureDataUtils.recalculateIonSeriesDependingTypes(modularFeature,
+        FeatureDataUtils.DEFAULT_CENTER_FUNCTION, false);
 
     return modularFeature;
   }
@@ -200,11 +198,12 @@ public class FeatureConvertors {
     modularFeature.set(FeatureShapeIonMobilityRetentionTimeHeatMapType.class, false);
 
     MemoryMapStorage storage = flist.getMemoryMapStorage();
-    IonMobilogramTimeSeries imTimeSeries = IonMobilogramTimeSeriesFactory
-        .of(storage, ionTrace.getMobilograms(), mobilogramBinner);
+    IonMobilogramTimeSeries imTimeSeries = IonMobilogramTimeSeriesFactory.of(storage,
+        ionTrace.getMobilograms(), mobilogramBinner);
     modularFeature.set(FeatureDataType.class, imTimeSeries);
     // no need to calc quality parameters after feature detection.
-    FeatureDataUtils.recalculateIonSeriesDependingTypes(modularFeature, FeatureDataUtils.DEFAULT_CENTER_MEASURE, false);
+    FeatureDataUtils.recalculateIonSeriesDependingTypes(modularFeature,
+        FeatureDataUtils.DEFAULT_CENTER_FUNCTION, false);
 
     return modularFeature;
   }
@@ -247,11 +246,11 @@ public class FeatureConvertors {
 
     // Ranges
     Range<Float> rtRange = Range.closed(0.f, 0.f);
-    Range<Double> mzRange = Range
-        .closed(image.getMzRange().lowerEndpoint(), image.getMzRange().upperEndpoint());
-    Range<Float> intensityRange = Range
-        .closed(image.getIntensityRange().lowerEndpoint().floatValue(),
-            image.getIntensityRange().upperEndpoint().floatValue());
+    Range<Double> mzRange = Range.closed(image.getMzRange().lowerEndpoint(),
+        image.getMzRange().upperEndpoint());
+    Range<Float> intensityRange = Range.closed(
+        image.getIntensityRange().lowerEndpoint().floatValue(),
+        image.getIntensityRange().upperEndpoint().floatValue());
     modularFeature.set(MZRangeType.class, mzRange);
     modularFeature.set(RTRangeType.class, rtRange);
     modularFeature.set(IntensityRangeType.class, intensityRange);
@@ -309,8 +308,8 @@ public class FeatureConvertors {
     modularFeature.setRepresentativeScan(manualFeature.getRepresentativeScanNumber());
     // Add values to feature
 
-    modularFeature
-        .set(FragmentScanNumbersType.class, List.of(manualFeature.getAllMS2FragmentScanNumbers()));
+    modularFeature.set(FragmentScanNumbersType.class,
+        List.of(manualFeature.getAllMS2FragmentScanNumbers()));
 //    modularFeature.set(ScanNumbersType.class, List.of(manualFeature.getScanNumbers()));
 
     modularFeature.set(RawFileType.class, manualFeature.getRawDataFile());
@@ -334,9 +333,9 @@ public class FeatureConvertors {
         manualFeature.getRawDataPointsRTRange().upperEndpoint());
     Range<Double> mzRange = Range.closed(manualFeature.getRawDataPointsMZRange().lowerEndpoint(),
         manualFeature.getRawDataPointsMZRange().upperEndpoint());
-    Range<Float> intensityRange = Range
-        .closed(manualFeature.getRawDataPointsIntensityRange().lowerEndpoint(),
-            manualFeature.getRawDataPointsIntensityRange().upperEndpoint());
+    Range<Float> intensityRange = Range.closed(
+        manualFeature.getRawDataPointsIntensityRange().lowerEndpoint(),
+        manualFeature.getRawDataPointsIntensityRange().upperEndpoint());
     modularFeature.set(MZRangeType.class, mzRange);
     modularFeature.set(RTRangeType.class, rtRange);
     modularFeature.set(IntensityRangeType.class, intensityRange);
@@ -383,12 +382,12 @@ public class FeatureConvertors {
 
     ModularFeature modularFeature = new ModularFeature(featureList);
 
-    modularFeature
-        .set(FragmentScanNumbersType.class, List.of(sameRangePeak.getAllMS2FragmentScanNumbers()));
+    modularFeature.set(FragmentScanNumbersType.class,
+        List.of(sameRangePeak.getAllMS2FragmentScanNumbers()));
 //    modularFeature.set(ScanNumbersType.class, List.of(sameRangePeak.getScanNumbers()));
 
-    modularFeature
-        .set(BestFragmentScanNumberType.class, sameRangePeak.getMostIntenseFragmentScanNumber());
+    modularFeature.set(BestFragmentScanNumberType.class,
+        sameRangePeak.getMostIntenseFragmentScanNumber());
     modularFeature.set(BestScanNumberType.class, sameRangePeak.getRepresentativeScanNumber());
     modularFeature.set(IsotopePatternType.class, sameRangePeak.getIsotopePattern());
     modularFeature.set(FeatureInformationType.class, sameRangePeak.getPeakInformation());
@@ -415,9 +414,9 @@ public class FeatureConvertors {
         sameRangePeak.getRawDataPointsRTRange().upperEndpoint());
     Range<Double> mzRange = Range.closed(sameRangePeak.getRawDataPointsMZRange().lowerEndpoint(),
         sameRangePeak.getRawDataPointsMZRange().upperEndpoint());
-    Range<Float> intensityRange = Range
-        .closed(sameRangePeak.getRawDataPointsIntensityRange().lowerEndpoint().floatValue(),
-            sameRangePeak.getRawDataPointsIntensityRange().upperEndpoint().floatValue());
+    Range<Float> intensityRange = Range.closed(
+        sameRangePeak.getRawDataPointsIntensityRange().lowerEndpoint().floatValue(),
+        sameRangePeak.getRawDataPointsIntensityRange().upperEndpoint().floatValue());
     modularFeature.set(MZRangeType.class, mzRange);
     modularFeature.set(RTRangeType.class, rtRange);
     modularFeature.set(IntensityRangeType.class, intensityRange);
@@ -458,12 +457,12 @@ public class FeatureConvertors {
 
     ModularFeature modularFeature = new ModularFeature(featureList);
 
-    modularFeature
-        .set(FragmentScanNumbersType.class, List.of(sameRangePeak.getAllMS2FragmentScanNumbers()));
+    modularFeature.set(FragmentScanNumbersType.class,
+        List.of(sameRangePeak.getAllMS2FragmentScanNumbers()));
 //    modularFeature.set(ScanNumbersType.class, List.of(sameRangePeak.getScanNumbers()));
 
-    modularFeature
-        .set(BestFragmentScanNumberType.class, sameRangePeak.getMostIntenseFragmentScanNumber());
+    modularFeature.set(BestFragmentScanNumberType.class,
+        sameRangePeak.getMostIntenseFragmentScanNumber());
     modularFeature.set(BestScanNumberType.class, sameRangePeak.getRepresentativeScanNumber());
     modularFeature.set(IsotopePatternType.class, sameRangePeak.getIsotopePattern());
     modularFeature.set(FeatureInformationType.class, sameRangePeak.getPeakInformation());
@@ -490,9 +489,9 @@ public class FeatureConvertors {
         sameRangePeak.getRawDataPointsRTRange().upperEndpoint());
     Range<Double> mzRange = Range.closed(sameRangePeak.getRawDataPointsMZRange().lowerEndpoint(),
         sameRangePeak.getRawDataPointsMZRange().upperEndpoint());
-    Range<Float> intensityRange = Range
-        .closed(sameRangePeak.getRawDataPointsIntensityRange().lowerEndpoint().floatValue(),
-            sameRangePeak.getRawDataPointsIntensityRange().upperEndpoint().floatValue());
+    Range<Float> intensityRange = Range.closed(
+        sameRangePeak.getRawDataPointsIntensityRange().lowerEndpoint().floatValue(),
+        sameRangePeak.getRawDataPointsIntensityRange().upperEndpoint().floatValue());
     modularFeature.set(MZRangeType.class, mzRange);
     modularFeature.set(RTRangeType.class, rtRange);
     modularFeature.set(IntensityRangeType.class, intensityRange);
@@ -534,12 +533,12 @@ public class FeatureConvertors {
     ModularFeature modularFeature = new ModularFeature(featureList);
 
     // Add values to feature
-    modularFeature
-        .set(FragmentScanNumbersType.class, List.of(resolvedPeak.getAllMS2FragmentScanNumbers()));
+    modularFeature.set(FragmentScanNumbersType.class,
+        List.of(resolvedPeak.getAllMS2FragmentScanNumbers()));
 //    modularFeature.set(ScanNumbersType.class, List.of(resolvedPeak.getScanNumbers()));
 
-    modularFeature
-        .set(BestFragmentScanNumberType.class, resolvedPeak.getMostIntenseFragmentScanNumber());
+    modularFeature.set(BestFragmentScanNumberType.class,
+        resolvedPeak.getMostIntenseFragmentScanNumber());
     modularFeature.set(BestScanNumberType.class, resolvedPeak.getRepresentativeScanNumber());
     modularFeature.set(IsotopePatternType.class, resolvedPeak.getIsotopePattern());
     modularFeature.set(FeatureInformationType.class, resolvedPeak.getPeakInformation());
@@ -561,14 +560,13 @@ public class FeatureConvertors {
 //        Arrays.asList(resolvedPeak.getScanNumbers()));
     IonTimeSeries<? extends Scan> resolvedData = null;
     if (originalData instanceof SimpleIonTimeSeries) {
-      resolvedData = ((SimpleIonTimeSeries) originalData)
-          .subSeries(featureList.getMemoryMapStorage(),
-              Arrays.asList(resolvedPeak.getScanNumbers()));
+      resolvedData = ((SimpleIonTimeSeries) originalData).subSeries(
+          featureList.getMemoryMapStorage(), Arrays.asList(resolvedPeak.getScanNumbers()));
     } else if (originalData instanceof IonMobilogramTimeSeries) {
       List<? extends Scan> scans = Arrays.asList(resolvedPeak.getScanNumbers());
       List<Frame> frames = (List<Frame>) scans;
-      resolvedData = ((SimpleIonMobilogramTimeSeries) originalData)
-          .subSeries(featureList.getMemoryMapStorage(), frames);
+      resolvedData = ((SimpleIonMobilogramTimeSeries) originalData).subSeries(
+          featureList.getMemoryMapStorage(), frames);
     } else {
       throw new IllegalArgumentException(
           "Smoothing is not yet supported for this kind of data. " + originalData.getClass()
@@ -581,9 +579,9 @@ public class FeatureConvertors {
         resolvedPeak.getRawDataPointsRTRange().upperEndpoint());
     Range<Double> mzRange = Range.closed(resolvedPeak.getRawDataPointsMZRange().lowerEndpoint(),
         resolvedPeak.getRawDataPointsMZRange().upperEndpoint());
-    Range<Float> intensityRange = Range
-        .closed(resolvedPeak.getRawDataPointsIntensityRange().lowerEndpoint().floatValue(),
-            resolvedPeak.getRawDataPointsIntensityRange().upperEndpoint().floatValue());
+    Range<Float> intensityRange = Range.closed(
+        resolvedPeak.getRawDataPointsIntensityRange().lowerEndpoint().floatValue(),
+        resolvedPeak.getRawDataPointsIntensityRange().upperEndpoint().floatValue());
     modularFeature.set(MZRangeType.class, mzRange);
     modularFeature.set(RTRangeType.class, rtRange);
     modularFeature.set(IntensityRangeType.class, intensityRange);

--- a/src/test/java/FeatureFindingTest.java
+++ b/src/test/java/FeatureFindingTest.java
@@ -58,7 +58,6 @@ import io.github.mzmine.parameters.parametertypes.selectors.ScanSelection;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.parameters.parametertypes.tolerances.RTTolerance;
 import io.github.mzmine.parameters.parametertypes.tolerances.RTTolerance.Unit;
-import io.github.mzmine.util.maths.CenterMeasure;
 import java.io.File;
 import java.util.Comparator;
 import java.util.Objects;
@@ -394,8 +393,6 @@ public class FeatureFindingTest {
     generalParam.setParameter(MinimumSearchFeatureResolverParameters.MIN_NUMBER_OF_DATAPOINTS, 4);
     generalParam.setParameter(MinimumSearchFeatureResolverParameters.MIN_RATIO, 1.8);
     generalParam.setParameter(MinimumSearchFeatureResolverParameters.MIN_RELATIVE_HEIGHT, 0d);
-    generalParam.getParameter(MinimumSearchFeatureResolverParameters.MZ_CENTER_FUNCTION)
-        .setValue(CenterMeasure.MEDIAN);
     generalParam.setParameter(MinimumSearchFeatureResolverParameters.PEAK_DURATION,
         Range.closed(0.02, 1d));
     generalParam.setParameter(MinimumSearchFeatureResolverParameters.SEARCH_RT_RANGE, 0.15);


### PR DESCRIPTION
Since we moved to the new feature model, the mz center was calculated in the FeatureDataUtils and always used the default center measure with a linear weighted mz center function. Here, i removed the old code that still had reference to that parameter.