### PR TITLE
MZmineCore nonstatic for tests

### DIFF
--- a/src/main/java/io/github/mzmine/gui/HeadLessDesktop.java
+++ b/src/main/java/io/github/mzmine/gui/HeadLessDesktop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ * Copyright 2006-2020 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -8,12 +8,11 @@
  * License, or (at your option) any later version.
  *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License for more details.
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
- *
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 package io.github.mzmine.gui;
@@ -43,8 +42,7 @@ import org.jetbrains.annotations.NotNull;
 public class HeadLessDesktop implements Desktop {
 
   private static final String MODULE_NAME = "Desktop";
-
-  private Logger logger = Logger.getLogger(this.getClass().getName());
+  private static final Logger logger = Logger.getLogger(HeadLessDesktop.class.getName());
 
   @Override
   public Stage getMainWindow() {
@@ -113,13 +111,12 @@ public class HeadLessDesktop implements Desktop {
   }
 
   @Override
-  public void openWebPage(URL url) {
+  public void openWebPage(@NotNull URL url) {
     throw new UnsupportedOperationException();
   }
 
   @Override
   public void addTab(MZmineTab tab) {
-    return;
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/main/MZmineCore.java
+++ b/src/main/java/io/github/mzmine/main/MZmineCore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ * Copyright 2006-2020 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -8,12 +8,11 @@
  * License, or (at your option) any later version.
  *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License for more details.
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
- *
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 package io.github.mzmine.main;
@@ -70,27 +69,30 @@ public final class MZmineCore {
 
   private static final Logger logger = Logger.getLogger(MZmineCore.class.getName());
 
-  private static TaskControllerImpl taskController;
-  private static MZmineConfiguration configuration;
-  private static Desktop desktop;
-  private static ProjectManagerImpl projectManager;
-  private static final List<MemoryMapStorage> storageList = Collections
-      .synchronizedList(new ArrayList<>());
+  private static final MZmineCore instance = new MZmineCore();
 
-  private static final Map<Class<?>, MZmineModule> initializedModules = new Hashtable<>();
-  private static boolean headLessMode = false;
+  // the default headless desktop is returned if no other desktop is set (e.g., during start up)
+  // it is also used in headless mode
+  private final Desktop defaultHeadlessDesktop = new HeadLessDesktop();
+  private final List<MemoryMapStorage> storageList = Collections
+      .synchronizedList(new ArrayList<>());
+  private final Map<Class<?>, MZmineModule> initializedModules = new Hashtable<>();
+  private TaskControllerImpl taskController;
+  private MZmineConfiguration configuration;
+  private Desktop desktop;
+  private ProjectManagerImpl projectManager;
+  private boolean headLessMode = false;
   // batch exit code is only set if run in headless mode with batch file
-  private static ExitCode batchExitCode = null;
+  private ExitCode batchExitCode = null;
+
+  private MZmineCore() {
+    init();
+  }
 
   /**
    * Main method
    */
   public static void main(final String[] args) {
-    // In the beginning, set the default locale to English, to avoid
-    // problems with conversion of numbers etc. (e.g. decimal separator may
-    // be . or , depending on the locale)
-    Locale.setDefault(new Locale("en", "US"));
-
     logger.info("Starting MZmine " + getMZmineVersion());
     /*
      * Dump the MZmine and JVM arguments for debugging purposes
@@ -114,20 +116,6 @@ public final class MZmineCore {
     Thread cleanupThread = new Thread(new TmpFileCleanup()); // check regular temp dir
     cleanupThread.setPriority(Thread.MIN_PRIORITY);
     cleanupThread.start();
-
-    logger.fine("Loading core classes..");
-
-    // Create instance of configuration
-    configuration = new MZmineConfigurationImpl();
-
-    // Create instances of core modules
-    projectManager = new ProjectManagerImpl();
-    taskController = new TaskControllerImpl();
-
-    logger.fine("Initializing core classes..");
-
-    projectManager.initModule();
-    taskController.initModule();
 
     MZmineArgumentParser argsParser = new MZmineArgumentParser();
     argsParser.parse(args);
@@ -156,7 +144,7 @@ public final class MZmineCore {
     // Load configuration
     if (prefFile.exists() && prefFile.canRead()) {
       try {
-        configuration.loadConfiguration(prefFile);
+        getInstance().configuration.loadConfiguration(prefFile);
         setTempDirToPreference();
       } catch (Exception e) {
         e.printStackTrace();
@@ -167,9 +155,9 @@ public final class MZmineCore {
     File batchFile = argsParser.getBatchFile();
     boolean keepRunningInHeadless = argsParser.isKeepRunningAfterBatch();
 
-    headLessMode = false;
+    getInstance().headLessMode = (batchFile != null || keepRunningInHeadless);
     // If we have no arguments, run in GUI mode, otherwise run in batch mode
-    if (batchFile == null && !keepRunningInHeadless) {
+    if (!getInstance().headLessMode) {
       try {
         logger.info("Starting MZmine GUI");
         Application.launch(MZmineGUI.class, args);
@@ -178,10 +166,8 @@ public final class MZmineCore {
         logger.log(Level.SEVERE, "Could not initialize GUI", e);
         System.exit(1);
       }
-
     } else {
-      headLessMode = true;
-      desktop = new HeadLessDesktop();
+      getInstance().desktop = getInstance().defaultHeadlessDesktop;
 
       // Tracker
       GoogleAnalyticsTracker GAT = new GoogleAnalyticsTracker("MZmine Loaded (Headless mode)",
@@ -198,7 +184,8 @@ public final class MZmineCore {
         }
 
         // run batch file
-        batchExitCode = BatchModeModule.runBatch(projectManager.getCurrentProject(), batchFile, new Date());
+        getInstance().batchExitCode = BatchModeModule
+            .runBatch(getInstance().projectManager.getCurrentProject(), batchFile, new Date());
       }
 
       // option to keep MZmine running after the batch is finished
@@ -209,46 +196,51 @@ public final class MZmineCore {
     }
   }
 
+  public static MZmineCore getInstance() {
+    return instance;
+  }
+
   /**
    * Exit MZmine (usually used in headless mode)
    */
   public static void exit() {
-    if (batchExitCode == ExitCode.OK || batchExitCode == null) {
+    if (instance.batchExitCode == ExitCode.OK || instance.batchExitCode == null) {
       System.exit(0);
     } else {
       System.exit(1);
     }
   }
 
-
   @NotNull
   public static TaskController getTaskController() {
-    return taskController;
+    return instance.taskController;
   }
 
   /**
-   * May return null during application startup when desktop is not ready yet.
+   * The current desktop or a default headless desktop (e.g., during app startup).
+   *
+   * @return the current desktop or the default headless desktop if still during app startup
    */
-  @Nullable
+  @NotNull
   public static Desktop getDesktop() {
-    return desktop;
+    return instance.desktop == null ? instance.defaultHeadlessDesktop : instance.desktop;
   }
 
   public static void setDesktop(Desktop desktop) {
     assert desktop != null;
-    MZmineCore.desktop = desktop;
+    getInstance().desktop = desktop;
   }
 
   @NotNull
   public static ProjectManager getProjectManager() {
-    assert projectManager != null;
-    return projectManager;
+    assert getInstance().projectManager != null;
+    return getInstance().projectManager;
   }
 
   @NotNull
   public static MZmineConfiguration getConfiguration() {
-    assert configuration != null;
-    return configuration;
+    assert getInstance().configuration != null;
+    return getInstance().configuration;
   }
 
   /**
@@ -258,7 +250,7 @@ public final class MZmineCore {
   public synchronized static <ModuleType extends MZmineModule> ModuleType getModuleInstance(
       Class<ModuleType> moduleClass) {
 
-    ModuleType module = (ModuleType) initializedModules.get(moduleClass);
+    ModuleType module = (ModuleType) getInstance().initializedModules.get(moduleClass);
 
     if (module == null) {
 
@@ -270,7 +262,7 @@ public final class MZmineCore {
         module = moduleClass.getDeclaredConstructor().newInstance();
 
         // Add to the module list
-        initializedModules.put(moduleClass, module);
+        getInstance().initializedModules.put(moduleClass, module);
 
       } catch (Throwable e) {
         logger.log(Level.SEVERE, "Could not start module " + moduleClass, e);
@@ -283,10 +275,11 @@ public final class MZmineCore {
   }
 
   public static Collection<MZmineModule> getAllModules() {
-    return initializedModules.values();
+    return getInstance().initializedModules.values();
   }
 
-  public static RawDataFile createNewFile(@NotNull final String name, @Nullable final String absPath,
+  public static RawDataFile createNewFile(@NotNull final String name,
+      @Nullable final String absPath,
       @Nullable final MemoryMapStorage storage) throws IOException {
     return new RawDataFileImpl(name, absPath, storage);
   }
@@ -316,8 +309,7 @@ public final class MZmineCore {
       if ((versionString == null) || (versionString.startsWith("$"))) {
         return Version.parse("3-SNAPSHOT");
       }
-      Version version = Version.parse(versionString);
-      return version;
+      return Version.parse(versionString);
     } catch (Exception e) {
       e.printStackTrace();
       return Version.parse("3-SNAPSHOT");
@@ -346,10 +338,10 @@ public final class MZmineCore {
 
     // Run the module
     final List<Task> newTasks = new ArrayList<>();
-    final MZmineProject currentProject = projectManager.getCurrentProject();
+    final MZmineProject currentProject = getInstance().projectManager.getCurrentProject();
     final Date date = new Date();
     module.runModule(currentProject, parameters, newTasks, date);
-    taskController.addTasks(newTasks.toArray(new Task[0]));
+    getInstance().taskController.addTasks(newTasks.toArray(new Task[0]));
 
     return newTasks;
     // Log module run in audit log
@@ -387,7 +379,7 @@ public final class MZmineCore {
    * @return headless mode or JavaFX GUI
    */
   public static boolean isHeadLessMode() {
-    return headLessMode;
+    return getInstance().headLessMode;
   }
 
   /**
@@ -402,10 +394,32 @@ public final class MZmineCore {
   }
 
   public static void registerStorage(MemoryMapStorage storage) {
-    storageList.add(storage);
+    getInstance().storageList.add(storage);
   }
 
   public static List<MemoryMapStorage> getStorageList() {
-    return storageList;
+    return getInstance().storageList;
+  }
+
+  protected void init() {
+    // In the beginning, set the default locale to English, to avoid
+    // problems with conversion of numbers etc. (e.g. decimal separator may
+    // be . or , depending on the locale)
+    Locale.setDefault(new Locale("en", "US"));
+    // initialize by default with all in memory
+    MemoryMapStorage.setStoreAllInRam(true);
+
+    logger.fine("Loading core classes..");
+    // Create instance of configuration
+    configuration = new MZmineConfigurationImpl();
+
+    // Create instances of core modules
+    projectManager = new ProjectManagerImpl();
+    taskController = new TaskControllerImpl();
+
+    logger.fine("Initializing core classes..");
+
+    projectManager.initModule();
+    taskController.initModule();
   }
 }

--- a/src/main/java/io/github/mzmine/main/MZmineCore.java
+++ b/src/main/java/io/github/mzmine/main/MZmineCore.java
@@ -81,7 +81,7 @@ public final class MZmineCore {
   private MZmineConfiguration configuration;
   private Desktop desktop;
   private ProjectManagerImpl projectManager;
-  private boolean headLessMode = false;
+  private boolean headLessMode = true;
   // batch exit code is only set if run in headless mode with batch file
   private ExitCode batchExitCode = null;
 

--- a/src/main/java/io/github/mzmine/modules/io/projectload/version_2_5/RawDataFileOpenHandler_2_5.java
+++ b/src/main/java/io/github/mzmine/modules/io/projectload/version_2_5/RawDataFileOpenHandler_2_5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ * Copyright 2006-2020 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -8,12 +8,11 @@
  * License, or (at your option) any later version.
  *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License for more details.
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
- *
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 package io.github.mzmine.modules.io.projectload.version_2_5;
@@ -96,7 +95,7 @@ public class RawDataFileOpenHandler_2_5 extends DefaultHandler  {
     charBuffer = new StringBuffer();
     massLists = new ArrayList<>();
 
-    newRawDataFile = (RawDataFileImpl) MZmineCore.createNewFile(null, null, null);
+    newRawDataFile = (RawDataFileImpl) MZmineCore.createNewFile("DUMMYNAME", null, null);
     // newRawDataFile.openDataPointsFile(scansFile);
 
     // dataPointsOffsets = newRawDataFile.getDataPointsOffsets();

--- a/src/test/java/ProjectTest.java
+++ b/src/test/java/ProjectTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2006-2020 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.features.ModularFeatureList;
+import io.github.mzmine.main.MZmineCore;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Test ion identity networking
+ *
+ * @author Robin Schmid (https://github.com/robinschmid)
+ */
+@ExtendWith(MockitoExtension.class)
+public class ProjectTest {
+
+  @Mock
+  RawDataFile raw;
+
+  @Test
+  void projectTest() {
+    // state for testing should be headless
+    assertEquals(true, MZmineCore.isHeadLessMode());
+
+    final MZmineProject project = MZmineCore.getProjectManager().getCurrentProject();
+    assertNotNull(project);
+
+    ModularFeatureList flist = new ModularFeatureList("A", null, raw);
+    project.addFeatureList(flist);
+
+    assertEquals(1, project.getFeatureLists().size());
+
+    project.addFile(raw);
+    assertEquals(1, project.getRawDataFiles().size());
+  }
+
+}


### PR DESCRIPTION
We had a bunch of static objects in the stateful MZmineCore class. All of MZmine relies on this class and it was not initialized by default for the tests... Therefore, I migrated it to a static singleton instance with some default init function. 

This will make it easier to Mock the singleton instance and its core components. 