### PR TITLE
Add temp directory argument

### DIFF
--- a/src/main/java/io/github/mzmine/main/MZmineArgumentParser.java
+++ b/src/main/java/io/github/mzmine/main/MZmineArgumentParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ * Copyright 2006-2020 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -8,12 +8,11 @@
  * License, or (at your option) any later version.
  *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License for more details.
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
- *
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 package io.github.mzmine.main;
@@ -21,7 +20,6 @@ package io.github.mzmine.main;
 import java.io.File;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.jetbrains.annotations.Nullable;
 import org.apache.commons.cli.BasicParser;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -29,6 +27,7 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Parses the command line arguments
@@ -41,6 +40,7 @@ public class MZmineArgumentParser {
 
   private File batchFile;
   private File preferencesFile;
+  private File tempDirectory;
   private boolean isKeepRunningAfterBatch = false;
   private KeepInRam isKeepInRam = KeepInRam.NONE;
 
@@ -55,6 +55,11 @@ public class MZmineArgumentParser {
     Option pref = new Option("p", "pref", true, "preferences file");
     pref.setRequired(false);
     options.addOption(pref);
+
+    Option tmpFolder = new Option("t", "temp", true,
+        "Temp directory overrides definition in preferences and JVM");
+    tmpFolder.setRequired(false);
+    options.addOption(tmpFolder);
 
     Option keepRunning = new Option("r", "running", false, "keep MZmine running in headless mode");
     keepRunning.setRequired(false);
@@ -83,6 +88,14 @@ public class MZmineArgumentParser {
         preferencesFile = new File(spref);
       }
 
+      String stemp = cmd.getOptionValue(tmpFolder.getLongOpt());
+      if (stemp != null) {
+        logger.info(
+            () -> "Temp directory set by command line, will override all other definitions: "
+                  + stemp);
+        tempDirectory = new File(stemp);
+      }
+
       isKeepRunningAfterBatch = cmd.hasOption(keepRunning.getLongOpt());
       if (isKeepRunningAfterBatch) {
 
@@ -94,7 +107,8 @@ public class MZmineArgumentParser {
       if (keepInData != null) {
         isKeepInRam = KeepInRam.parse(keepInData);
         logger.info(
-            () -> "the -m / --memory argument was set to "+isKeepInRam.toString()+" to keep objects in RAM (scan data, features, etc) which are otherwise stored in memory mapped ");
+            () -> "the -m / --memory argument was set to " + isKeepInRam.toString()
+                  + " to keep objects in RAM (scan data, features, etc) which are otherwise stored in memory mapped ");
       }
 
     } catch (ParseException e) {
@@ -104,6 +118,15 @@ public class MZmineArgumentParser {
     }
   }
 
+  /**
+   * The temp directory overrides all other definitions if set
+   *
+   * @return the temp directory override (null or a file)
+   */
+  @Nullable
+  public File getTempDirectory() {
+    return tempDirectory;
+  }
 
   @Nullable
   public File getPreferencesFile() {
@@ -123,8 +146,10 @@ public class MZmineArgumentParser {
   public boolean isKeepRunningAfterBatch() {
     return isKeepRunningAfterBatch;
   }
+
   /**
-   * Keep all {@link io.github.mzmine.util.MemoryMapStorage} items in RAM (e.g., scans, features, masslists)
+   * Keep all {@link io.github.mzmine.util.MemoryMapStorage} items in RAM (e.g., scans, features,
+   * masslists)
    *
    * @return true will keep objects in memory which are usually stored in memory mapped files
    */
@@ -137,7 +162,7 @@ public class MZmineArgumentParser {
 
     public static KeepInRam parse(String s) {
       s = s.toLowerCase();
-      return switch(s) {
+      return switch (s) {
         case "all" -> ALL;
         case "features" -> FEATURES;
         case "centroids" -> MASS_LISTS;

--- a/src/main/java/io/github/mzmine/main/MZmineCore.java
+++ b/src/main/java/io/github/mzmine/main/MZmineCore.java
@@ -172,7 +172,9 @@ public final class MZmineCore {
         configuration.getPreferences().setParameter(MZminePreferences.tempDirectory, tempDirectory);
         updateTempDir = true;
       } else {
-        logger.log(Level.WARNING, "Cannot ");
+        logger.log(Level.WARNING,
+            "Cannot create or access temp file directory that was set via program argument: "
+            + tempDirectory.getAbsolutePath());
       }
     }
 

--- a/src/main/java/io/github/mzmine/util/files/FileAndPathUtil.java
+++ b/src/main/java/io/github/mzmine/util/files/FileAndPathUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ * Copyright 2006-2020 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -8,18 +8,16 @@
  * License, or (at your option) any later version.
  *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License for more details.
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
- *
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 package io.github.mzmine.util.files;
 
 import java.io.File;
-import java.io.FilenameFilter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -37,9 +35,10 @@ public class FileAndPathUtil {
   /**
    * Returns the real file path as path/filename.fileformat
    *
-   * @param name
+   * @param path   the file path (directory of filename)
+   * @param name   filename
    * @param format a format starting with a dot for example: .pdf ; or without a dot: pdf
-   * @return
+   * @return path/name.format
    */
   public static File getRealFilePath(File path, String name, String format) {
     return new File(getFolderOfFile(path), getRealFileName(name, format));
@@ -48,9 +47,9 @@ public class FileAndPathUtil {
   /**
    * Returns the real file path as path/filename.fileformat
    *
-   * @param format a format starting with a dot for example: .pdf ; or without a dot: pdf
-   * @return
-   * @throws Exception if there is no filname (selected path = folder)
+   * @param filepath a filepath with file name
+   * @param format   a format starting with a dot for example: .pdf ; or without a dot: pdf
+   * @return filepath.format (the format will be exchanged by this format)
    */
   public static File getRealFilePath(File filepath, String format) {
     return new File(filepath.getParentFile(), getRealFileName(filepath.getName(), format));
@@ -65,9 +64,9 @@ public class FileAndPathUtil {
   /**
    * Returns the real file name as filename.fileformat
    *
-   * @param name
+   * @param name   filename
    * @param format a format starting with a dot for example .pdf
-   * @return
+   * @return name.format
    */
   public static String getRealFileName(String name, String format) {
     String result = FilenameUtils.removeExtension(name);
@@ -78,16 +77,16 @@ public class FileAndPathUtil {
   /**
    * Returns the real file name as filename.fileformat
    *
-   * @param name
+   * @param name   filename
    * @param format a format starting with a dot for example .pdf
-   * @return
+   * @return filename.format
    */
   public static String getRealFileName(File name, String format) {
     return getRealFileName(name.getAbsolutePath(), format);
   }
 
   /**
-   * @param f
+   * @param f target file
    * @return The file extension or null.
    */
   public static String getExtension(File f) {
@@ -102,7 +101,7 @@ public class FileAndPathUtil {
    * erases the format. "image.png" will be returned as "image" this method is used by
    * getRealFilePath and getRealFileName
    *
-   * @return
+   * @return remove format from file
    */
   public static File eraseFormat(File f) {
     int lastDot = f.getName().lastIndexOf(".");
@@ -117,9 +116,9 @@ public class FileAndPathUtil {
    * Adds the format. "image" will be returned as "image.format" Maybe use erase format first. this
    * method is used by getRealFilePath and getRealFileName
    *
-   * @param name
-   * @param format
-   * @return
+   * @param name   a file name without format (use {@link #eraseFormat(File)} before)
+   * @param format the new format
+   * @return name.format
    */
   public static String addFormat(String name, String format) {
     if (format.startsWith(".")) {
@@ -132,158 +131,166 @@ public class FileAndPathUtil {
   /**
    * Returns the file if it is already a folder. Or the parent folder if the file is a data file
    *
-   * @param file
-   * @return
+   * @param file file or folder
+   * @return the parameter file if it is a directory, otherwise its parent directory
    */
   public static File getFolderOfFile(File file) {
-    if (!isOnlyAFolder(file)) {
-      return file.getParentFile();
-    } else {
+    if (file.isDirectory()) {
       return file;
+    } else {
+      return file.getParentFile();
     }
   }
 
   /**
    * Returns the file name from a given file. If file is a folder an empty String is returned
    *
-   * @param file
-   * @return
+   * @param file a path
+   * @return the filename of a file
    */
   public static String getFileNameFromPath(File file) {
-    if (!isOnlyAFolder(file)) {
-      return file.getAbsolutePath().substring(file.getAbsolutePath().lastIndexOf("\\") + 1);
-    } else {
+    if (file.isDirectory()) {
       return "";
+    } else {
+      return file.getAbsolutePath().substring(file.getAbsolutePath().lastIndexOf("\\") + 1);
     }
   }
 
   /**
    * Returns the file name from a given file. If the file is a folder an empty String is returned
    *
-   * @param file
-   * @return
+   * @return the filename from a path
    */
   public static String getFileNameFromPath(String file) {
     return getFileNameFromPath(new File(file));
   }
 
   /**
-   * Checks if a given File is a folder or a data file
-   */
-  public static boolean isOnlyAFolder(File file) {
-    return file.isDirectory();
-  }
-
-  /**
    * Creates a new directory.
    *
-   * @param theDir
-   * @return false if directory was not created
+   * @param theDir target directory
+   * @return true if directory existed or was created
    */
   public static boolean createDirectory(File theDir) {
     // if the directory does not exist, create it
-    if (!theDir.exists()) {
-      boolean result = false;
+    if (theDir.exists()) {
+      return true;
+    } else {
       try {
-        theDir.mkdirs();
-        result = true;
+        return theDir.mkdirs();
       } catch (SecurityException se) {
         // handle it
       }
-      return result;
-    } else {
-      return true;
+      return false;
     }
   }
 
   /**
    * Sort an array of files These files have to start or end with a number
    *
-   * @param files
-   * @return
+   * @param files files to sort
+   * @return sorted array of files
    */
-  public static File[] sortFilesByNumber(File[] files) {
-    Arrays.sort(files, new Comparator<File>() {
+  public static File[] sortFilesByNumber(File[] files, boolean reverse) {
+    Comparator<File> fileNumberComparator = new Comparator<>() {
       private Boolean endsWithNumber = null;
 
       @Override
       public int compare(File o1, File o2) {
         try {
           if (endsWithNumber == null) {
-            checkEndsWithNumber(o1.getName());
+            endsWithNumber = checkEndsWithNumber(o1.getName());
           }
-          int n1 = extractNumber(o1.getName());
-          int n2 = extractNumber(o2.getName());
-          return n1 - n2;
+          int n1 = extractNumber(o1, endsWithNumber);
+          int n2 = extractNumber(o2, endsWithNumber);
+          return Integer.compare(n1, n2);
         } catch (Exception e) {
           return o1.compareTo(o2);
         }
       }
-
-      private int extractNumber(String name) throws Exception {
-        int i = 0;
-        try {
-          if (endsWithNumber) {
-            // ends with number?
-            int e = name.lastIndexOf('.');
-            e = e == -1 ? name.length() : e;
-            int f = e - 1;
-            for (; f > 0; f--) {
-              if (!isNumber(name.charAt(f))) {
-                f++;
-                break;
-              }
-            }
-            //
-            if (f < 0) {
-              f = 0;
-            }
-            String number = name.substring(f, e);
-            i = Integer.parseInt(number);
-          } else {
-            int f = 0;
-            for (; f < name.length(); f++) {
-              if (!isNumber(name.charAt(f))) {
-                break;
-              }
-            }
-            String number = name.substring(0, f);
-            i = Integer.parseInt(number);
-          }
-        } catch (Exception e) {
-          i = 0; // if filename does not match the format
-          throw e; // then default to 0
-        }
-        return i;
-      }
-
-      private void checkEndsWithNumber(String name) {
-        // ends with number?
-        int e = name.lastIndexOf('.');
-        e = e == -1 ? name.length() : e;
-        endsWithNumber = isNumber(name.charAt(e - 1));
-      }
-    });
+    };
+    if (reverse) {
+      fileNumberComparator = fileNumberComparator.reversed();
+    }
+    Arrays.sort(files, fileNumberComparator);
     return files;
   }
 
-  private static boolean isNumber(char c) {
+  public static boolean isNumber(char c) {
     return (c >= '0' && c <= '9');
+  }
+
+  /**
+   * @param file target file
+   * @return true if the name ends with a number (e.g., file1.mzML=true)
+   */
+  public static boolean checkEndsWithNumber(File file) {
+    return checkEndsWithNumber(file.getName());
+  }
+
+  /**
+   * @param name filename
+   * @return true if it ends with a number
+   */
+  public static boolean checkEndsWithNumber(String name) {
+    // ends with number?
+    int e = name.lastIndexOf('.');
+    e = e == -1 ? name.length() : e;
+    return isNumber(name.charAt(e - 1));
+  }
+
+  public static int extractNumber(File file, boolean endsWithNumber)
+      throws IllegalArgumentException {
+    return extractNumber(file.getName(), endsWithNumber);
+  }
+
+  public static int extractNumber(String name, boolean endsWithNumber)
+      throws IllegalArgumentException {
+    if (endsWithNumber) {
+      // ends with number?
+      int e = name.lastIndexOf('.');
+      e = e == -1 ? name.length() : e;
+      int f = e - 1;
+      for (; f > 0; f--) {
+        if (!isNumber(name.charAt(f))) {
+          f++;
+          break;
+        }
+      }
+      //
+      if (f < 0) {
+        f = 0;
+      }
+      if (f - e == 0) {
+        // there was no number
+        throw new IllegalArgumentException(name + " does not end with number");
+      }
+      String number = name.substring(f, e);
+      return Integer.parseInt(number);
+    } else {
+      int f = 0;
+      for (; f < name.length(); f++) {
+        if (!isNumber(name.charAt(f))) {
+          break;
+        }
+      }
+      if (f == 0) {
+        // there was no number
+        throw new IllegalArgumentException(name + " does not start with number");
+      }
+      String number = name.substring(0, f);
+      return Integer.parseInt(number);
+    }
   }
 
   /**
    * Lists all directories in directory f
    *
-   * @param f
-   * @return
+   * @param f directory
+   * @return all sub directories
    */
   public static File[] getSubDirectories(File f) {
-    return f.listFiles(new FilenameFilter() {
-      @Override
-      public boolean accept(File current, String name) {
-        return new File(current, name).isDirectory();
-      }
-    });
+    return f.listFiles((current, name) -> new File(current, name).isDirectory());
   }
 
   // ###############################################################################################
@@ -307,9 +314,9 @@ public class FileAndPathUtil {
   }
 
   /**
-   * @param dir
-   * @param fileFilter
-   * @return
+   * @param dir        parent directory
+   * @param fileFilter filter files
+   * @return list of all files in directory and sub directories
    */
   public static List<File[]> findFilesInDir(File dir, FileNameExtFilter fileFilter) {
     return findFilesInDir(dir, fileFilter, true, false);
@@ -324,11 +331,11 @@ public class FileAndPathUtil {
       boolean searchSubdir, boolean filesInSeparateFolders) {
     File[] subDir = FileAndPathUtil.getSubDirectories(dir);
     // result: each vector element stands for one img
-    ArrayList<File[]> list = new ArrayList<File[]>();
+    List<File[]> list = new ArrayList<>();
     // add all files as first image
     // sort all files and return them
     File[] files = dir.listFiles(fileFilter);
-    files = FileAndPathUtil.sortFilesByNumber(files);
+    files = FileAndPathUtil.sortFilesByNumber(files, false);
     if (files != null && files.length > 0) {
       list.add(files);
     }
@@ -338,7 +345,7 @@ public class FileAndPathUtil {
       return list;
     } else {
       // sort dirs
-      subDir = FileAndPathUtil.sortFilesByNumber(subDir);
+      subDir = FileAndPathUtil.sortFilesByNumber(subDir, false);
       // go in all sub and subsub... folders to find files
       if (filesInSeparateFolders) {
         findFilesInSubDirSeparatedFolders(dir, subDir, list, fileFilter);
@@ -356,39 +363,36 @@ public class FileAndPathUtil {
    *
    * @param dirs musst be sorted!
    * @param list
-   * @return
    */
   private static void findFilesInSubDirSeparatedFolders(File parent, File[] dirs,
-      ArrayList<File[]> list, FileNameExtFilter fileFilter) {
+      List<File[]> list, FileNameExtFilter fileFilter) {
     // go into folder and find files
-    ArrayList<File> img = null;
+    List<File> img = null;
     // each file in one folder
-    for (int i = 0; i < dirs.length; i++) {
+    for (File dir : dirs) {
       // find all suiting files
-      File[] subFiles = FileAndPathUtil.sortFilesByNumber(dirs[i].listFiles(fileFilter));
+      File[] subFiles = FileAndPathUtil.sortFilesByNumber(dir.listFiles(fileFilter), false);
       // if there are some suiting files in here directory has been found!
       // create image of these
       // dirs
       if (subFiles.length > 0) {
         if (img == null) {
-          img = new ArrayList<File>();
+          img = new ArrayList<>();
         }
         // put them into the list
-        for (int f = 0; f < subFiles.length; f++) {
-          img.add(subFiles[f]);
-        }
+        img.addAll(Arrays.asList(subFiles));
       } else {
         // search in subfolders for data
         // find all subfolders, sort them and do the same iterative
         File[] subDir =
-            FileAndPathUtil.sortFilesByNumber(FileAndPathUtil.getSubDirectories(dirs[i]));
+            FileAndPathUtil.sortFilesByNumber(FileAndPathUtil.getSubDirectories(dir), false);
         // call this method
-        findFilesInSubDirSeparatedFolders(dirs[i], subDir, list, fileFilter);
+        findFilesInSubDirSeparatedFolders(dir, subDir, list, fileFilter);
       }
     }
     // add to list
     if (img != null && img.size() > 0) {
-      list.add(img.toArray(new File[img.size()]));
+      list.add(img.toArray(File[]::new));
     }
   }
 
@@ -397,20 +401,20 @@ public class FileAndPathUtil {
    *
    * @param dirs musst be sorted!
    * @param list
-   * @return
    */
-  private static void findFilesInSubDir(File[] dirs, ArrayList<File[]> list,
+  private static void findFilesInSubDir(File[] dirs, List<File[]> list,
       FileNameExtFilter fileFilter) {
     // All files in one folder
-    for (int i = 0; i < dirs.length; i++) {
+    for (File dir : dirs) {
       // find all suiting files
-      File[] subFiles = FileAndPathUtil.sortFilesByNumber(dirs[i].listFiles(fileFilter));
+      File[] subFiles = FileAndPathUtil.sortFilesByNumber(dir.listFiles(fileFilter), false);
       // put them into the list
       if (subFiles != null && subFiles.length > 0) {
         list.add(subFiles);
       }
       // find all subfolders, sort them and do the same iterative
-      File[] subDir = FileAndPathUtil.sortFilesByNumber(FileAndPathUtil.getSubDirectories(dirs[i]));
+      File[] subDir = FileAndPathUtil
+          .sortFilesByNumber(FileAndPathUtil.getSubDirectories(dir), false);
       // call this method
       findFilesInSubDir(subDir, list, fileFilter);
     }
@@ -419,7 +423,7 @@ public class FileAndPathUtil {
   /**
    * The Path of the Jar.
    *
-   * @return
+   * @return jar path
    */
   public static File getPathOfJar() {
     /*


### PR DESCRIPTION
Currently, users would need to supply a modified config file to set the temp directory - that's very inconvenient.

Therefore, a new argument controls the temp folder and overrides the default and the one configured in the config.

--temp D:\tmpmzmine\