### PR TITLE
MemoryMapping option in program arguments also in configuration

### DIFF
--- a/src/main/java/io/github/mzmine/gui/preferences/MZminePreferences.java
+++ b/src/main/java/io/github/mzmine/gui/preferences/MZminePreferences.java
@@ -124,7 +124,7 @@ public class MZminePreferences extends SimpleParameterSet {
       "Temporary file directory", "Directory where temporary files"
                                   + " will be stored. Directory should be located on a drive with fast read and write "
                                   + "(e.g., an SSD). Requires a restart of MZmine to take effect (the program argument --temp "
-                                  + "override this parameter: --temp D:\\your_tmp_dir\\)",
+                                  + "overrides this parameter, if set: --temp D:\\your_tmp_dir\\)",
       System.getProperty("java.io.tmpdir"));
 
   public static final ComboParameter<KeepInMemory> memoryOption =

--- a/src/main/java/io/github/mzmine/main/KeepInMemory.java
+++ b/src/main/java/io/github/mzmine/main/KeepInMemory.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2006-2020 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+package io.github.mzmine.main;
+
+import io.github.mzmine.util.MemoryMapStorage;
+
+/**
+ * @author Robin Schmid (https://github.com/robinschmid)
+ */
+public enum KeepInMemory {
+
+  NONE, ALL, FEATURES, MASS_LISTS, RAW_SCANS, MASSES_AND_FEATURES;
+
+  public static KeepInMemory parse(String s) {
+    s = s.toLowerCase();
+    return switch (s) {
+      case "all" -> ALL;
+      case "features" -> FEATURES;
+      case "centroids" -> MASS_LISTS;
+      case "raw" -> RAW_SCANS;
+      case "masses_features" -> MASSES_AND_FEATURES;
+      default -> throw new IllegalStateException("Unexpected value: " + s);
+    };
+  }
+
+  /**
+   * Apply this option for memory mapping
+   */
+  public void enforceToMemoryMapping() {
+    // reset
+    MemoryMapStorage.setStoreAllInRam(false);
+    // keep all in memory? (features, scans, ... in RAM instead of MemoryMapStorage
+    switch (this) {
+      case NONE -> {
+        // nothing in RAM
+      }
+      case ALL -> MemoryMapStorage.setStoreAllInRam(true);
+      case FEATURES -> MemoryMapStorage.setStoreFeaturesInRam(true);
+      case MASS_LISTS -> MemoryMapStorage.setStoreMassListsInRam(true);
+      case RAW_SCANS -> MemoryMapStorage.setStoreRawFilesInRam(true);
+      case MASSES_AND_FEATURES -> {
+        MemoryMapStorage.setStoreMassListsInRam(true);
+        MemoryMapStorage.setStoreFeaturesInRam(true);
+      }
+    }
+  }
+}

--- a/src/main/java/io/github/mzmine/main/MZmineArgumentParser.java
+++ b/src/main/java/io/github/mzmine/main/MZmineArgumentParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ * Copyright 2006-2020 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -8,12 +8,11 @@
  * License, or (at your option) any later version.
  *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License for more details.
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
- *
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 package io.github.mzmine.main;
@@ -21,7 +20,6 @@ package io.github.mzmine.main;
 import java.io.File;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.jetbrains.annotations.Nullable;
 import org.apache.commons.cli.BasicParser;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -29,6 +27,7 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Parses the command line arguments
@@ -37,12 +36,12 @@ import org.apache.commons.cli.ParseException;
  */
 public class MZmineArgumentParser {
 
-  private static Logger logger = Logger.getLogger(MZmineArgumentParser.class.getName());
+  private static final Logger logger = Logger.getLogger(MZmineArgumentParser.class.getName());
 
   private File batchFile;
   private File preferencesFile;
   private boolean isKeepRunningAfterBatch = false;
-  private KeepInRam isKeepInRam = KeepInRam.NONE;
+  private KeepInMemory isKeepInMemory = null;
 
   public void parse(String[] args) {
     Options options = new Options();
@@ -92,9 +91,10 @@ public class MZmineArgumentParser {
 
       String keepInData = cmd.getOptionValue(keepInMemory.getLongOpt());
       if (keepInData != null) {
-        isKeepInRam = KeepInRam.parse(keepInData);
+        isKeepInMemory = KeepInMemory.parse(keepInData);
         logger.info(
-            () -> "the -m / --memory argument was set to "+isKeepInRam.toString()+" to keep objects in RAM (scan data, features, etc) which are otherwise stored in memory mapped ");
+            () -> "the -m / --memory argument was set to " + isKeepInMemory.toString()
+                  + " to keep objects in RAM (scan data, features, etc) which are otherwise stored in memory mapped ");
       }
 
     } catch (ParseException e) {
@@ -123,29 +123,16 @@ public class MZmineArgumentParser {
   public boolean isKeepRunningAfterBatch() {
     return isKeepRunningAfterBatch;
   }
+
   /**
-   * Keep all {@link io.github.mzmine.util.MemoryMapStorage} items in RAM (e.g., scans, features, masslists)
+   * Keep all {@link io.github.mzmine.util.MemoryMapStorage} items in RAM (e.g., scans, features,
+   * masslists)
    *
    * @return true will keep objects in memory which are usually stored in memory mapped files
    */
-  public KeepInRam isKeepInRam() {
-    return isKeepInRam;
+  public KeepInMemory isKeepInMemory() {
+    return isKeepInMemory;
   }
 
-  public enum KeepInRam {
-    NONE, ALL, FEATURES, MASS_LISTS, RAW_SCANS, MASSES_AND_FEATURES;
-
-    public static KeepInRam parse(String s) {
-      s = s.toLowerCase();
-      return switch(s) {
-        case "all" -> ALL;
-        case "features" -> FEATURES;
-        case "centroids" -> MASS_LISTS;
-        case "raw" -> RAW_SCANS;
-        case "masses_features" -> MASSES_AND_FEATURES;
-        default -> throw new IllegalStateException("Unexpected value: " + s);
-      };
-    }
-  }
 }
 

--- a/src/main/java/io/github/mzmine/main/MZmineCore.java
+++ b/src/main/java/io/github/mzmine/main/MZmineCore.java
@@ -139,9 +139,11 @@ public final class MZmineCore {
     KeepInMemory keepInMemory = argsParser.isKeepInMemory();
     if (keepInMemory != null) {
       // set to preferences
-      configuration.getPreferences().setParameter(MZminePreferences.memoryOption, keepInMemory);
+      getInstance().configuration.getPreferences()
+          .setParameter(MZminePreferences.memoryOption, keepInMemory);
     } else {
-      keepInMemory = configuration.getPreferences().getParameter(MZminePreferences.memoryOption)
+      keepInMemory = getInstance().configuration.getPreferences()
+          .getParameter(MZminePreferences.memoryOption)
           .getValue();
     }
 


### PR DESCRIPTION
This brings the memory mapping options into the preferences.
If the --memory program argument is set it will override the configuration. Otherwise, the user can change the behavior at any time during the processing. All new data (spectra/features) will be handled accordingly.