### PR TITLE
move from java.util.Date to java.time.instant for microsecond accuracy

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/features/FeatureList.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/FeatureList.java
@@ -31,8 +31,8 @@ import io.github.mzmine.datamodel.features.types.numbers.RTType;
 import io.github.mzmine.modules.MZmineModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.util.DataTypeUtils;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -465,7 +465,7 @@ public interface FeatureList {
 
     public MZmineModule getModule();
 
-    public Date getModuleCallDate();
+    public Instant getModuleCallDate();
 
     public void saveValueToXML(Element element);
   }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/tasks/FeatureGraphicalNodeTask.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/tasks/FeatureGraphicalNodeTask.java
@@ -23,7 +23,7 @@ import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.application.Platform;
@@ -47,7 +47,7 @@ public class FeatureGraphicalNodeTask extends AbstractTask {
   public FeatureGraphicalNodeTask(Class<? extends Node> nodeClass, StackPane pane,
       ModularFeature feature,
       String collHeader) {
-    super(null, new Date()); // no new data stored -> null, date irrelevant
+    super(null, Instant.now()); // no new data stored -> null, date irrelevant
     this.nodeClass = nodeClass;
     this.pane = pane;
     this.feature = feature;

--- a/src/main/java/io/github/mzmine/datamodel/features/types/tasks/FeaturesGraphicalNodeTask.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/tasks/FeaturesGraphicalNodeTask.java
@@ -23,7 +23,7 @@ import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.application.Platform;
@@ -46,7 +46,7 @@ public class FeaturesGraphicalNodeTask extends AbstractTask {
 
   public FeaturesGraphicalNodeTask(Class<? extends Node> nodeClass, StackPane pane,
       ModularFeatureListRow row, String collHeader) {
-    super(null, new Date()); // no new data stored -> null
+    super(null, Instant.now()); // no new data stored -> null
     this.nodeClass = nodeClass;
     this.pane = pane;
     this.row = row;

--- a/src/main/java/io/github/mzmine/gui/MZmineGUI.java
+++ b/src/main/java/io/github/mzmine/gui/MZmineGUI.java
@@ -48,6 +48,7 @@ import io.github.mzmine.util.javafx.FxIconUtil;
 import io.github.mzmine.util.javafx.groupablelistview.GroupableListView;
 import java.io.File;
 import java.net.URL;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -286,7 +287,7 @@ public class MZmineGUI extends Application implements Desktop {
         if (module != null) {
           List<Task> tasks = new ArrayList<>();
           module.runModule(MZmineCore.getProjectManager().getCurrentProject(), param, tasks,
-              new Date());
+              Instant.now());
           MZmineCore.getTaskController().addTasks(tasks.toArray(Task[]::new));
         }
       }

--- a/src/main/java/io/github/mzmine/gui/chartbasics/graphicsexport/GraphicsExportModule.java
+++ b/src/main/java/io/github/mzmine/gui/chartbasics/graphicsexport/GraphicsExportModule.java
@@ -18,16 +18,16 @@
 
 package io.github.mzmine.gui.chartbasics.graphicsexport;
 
-import java.util.Collection;
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
-import org.jfree.chart.JFreeChart;
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.MZmineRunnableModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
+import org.jfree.chart.JFreeChart;
 
 public class GraphicsExportModule implements MZmineRunnableModule {
 
@@ -60,7 +60,7 @@ public class GraphicsExportModule implements MZmineRunnableModule {
 
   @Override
   public ExitCode runModule(MZmineProject project, ParameterSet parameters, Collection<Task> tasks,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     return null;
   }
 

--- a/src/main/java/io/github/mzmine/gui/mainwindow/MainMenuController.java
+++ b/src/main/java/io/github/mzmine/gui/mainwindow/MainMenuController.java
@@ -35,6 +35,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.util.Date;
 import java.util.logging.Logger;
 import javafx.event.ActionEvent;
@@ -198,7 +199,7 @@ public class MainMenuController {
         File f = new File(c.getText());
         if (f.exists()) {
           // load file
-          ProjectOpeningTask newTask = new ProjectOpeningTask(f, new Date());
+          ProjectOpeningTask newTask = new ProjectOpeningTask(f, Instant.now());
           MZmineCore.getTaskController().addTask(newTask);
         }
       });

--- a/src/main/java/io/github/mzmine/main/MZmineCore.java
+++ b/src/main/java/io/github/mzmine/main/MZmineCore.java
@@ -46,6 +46,7 @@ import java.io.InputStream;
 import java.lang.Runtime.Version;
 import java.lang.management.ManagementFactory;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -185,7 +186,7 @@ public final class MZmineCore {
 
         // run batch file
         getInstance().batchExitCode = BatchModeModule
-            .runBatch(getInstance().projectManager.getCurrentProject(), batchFile, new Date());
+            .runBatch(getInstance().projectManager.getCurrentProject(), batchFile, Instant.now());
       }
 
       // option to keep MZmine running after the batch is finished
@@ -339,7 +340,8 @@ public final class MZmineCore {
     // Run the module
     final List<Task> newTasks = new ArrayList<>();
     final MZmineProject currentProject = getInstance().projectManager.getCurrentProject();
-    final Date date = new Date();
+    final Instant date = Instant.now();
+    logger.finest(() -> "Module " + module.getName() + " called at " + date.toString());
     module.runModule(currentProject, parameters, newTasks, date);
     getInstance().taskController.addTasks(newTasks.toArray(new Task[0]));
 

--- a/src/main/java/io/github/mzmine/modules/MZmineRunnableModule.java
+++ b/src/main/java/io/github/mzmine/modules/MZmineRunnableModule.java
@@ -18,9 +18,9 @@
 
 package io.github.mzmine.modules;
 
+import java.time.Instant;
 import java.util.Collection;
 
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -64,7 +64,7 @@ public interface MZmineRunnableModule extends MZmineModule {
    */
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate);
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate);
 
   /**
    * Returns the category of the module (e.g. raw data processing, peak picking etc.). A menu item

--- a/src/main/java/io/github/mzmine/modules/batchmode/BatchModeModule.java
+++ b/src/main/java/io/github/mzmine/modules/batchmode/BatchModeModule.java
@@ -18,16 +18,6 @@
 
 package io.github.mzmine.modules.batchmode;
 
-import java.io.File;
-import java.util.Collection;
-import java.util.Date;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import org.jetbrains.annotations.NotNull;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import org.w3c.dom.Document;
-
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.MZmineProcessingModule;
@@ -35,6 +25,15 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.ExitCode;
+import java.io.File;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.jetbrains.annotations.NotNull;
+import org.w3c.dom.Document;
 
 /**
  * Batch mode module
@@ -60,7 +59,7 @@ public class BatchModeModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     BatchTask newTask = new BatchTask(project, parameters, moduleCallDate);
 
     /*
@@ -79,7 +78,7 @@ public class BatchModeModule implements MZmineProcessingModule {
     return MZmineModuleCategory.PROJECT;
   }
 
-  public static ExitCode runBatch(@NotNull MZmineProject project, File batchFile, @NotNull Date moduleCallDate) {
+  public static ExitCode runBatch(@NotNull MZmineProject project, File batchFile, @NotNull Instant moduleCallDate) {
 
     logger.info("Running batch from file " + batchFile);
 

--- a/src/main/java/io/github/mzmine/modules/batchmode/BatchTask.java
+++ b/src/main/java/io/github/mzmine/modules/batchmode/BatchTask.java
@@ -38,9 +38,9 @@ import io.github.mzmine.taskcontrol.TaskPriority;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.taskcontrol.impl.WrappedTask;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -60,7 +60,7 @@ public class BatchTask extends AbstractTask {
   private List<RawDataFile> createdDataFiles, previousCreatedDataFiles, startDataFiles;
   private List<FeatureList> createdFeatureLists, previousCreatedFeatureLists, startFeatureLists;
 
-  BatchTask(MZmineProject project, ParameterSet parameters, @NotNull Date moduleCallDate) {
+  BatchTask(MZmineProject project, ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // we don't create any new data here, date is irrelevant, too.
     this.project = project;
     this.queue = parameters.getParameter(BatchModeParameters.batchQueue).getValue();
@@ -150,7 +150,8 @@ public class BatchTask extends AbstractTask {
     }
 
     List<Task> currentStepTasks = new ArrayList<Task>();
-    Date moduleCallDate = new Date();
+    Instant moduleCallDate = Instant.now();
+    logger.finest(() -> "Module " + method.getName() + " called at " + moduleCallDate.toString());
     ExitCode exitCode = method
         .runModule(project, batchStepParameters, currentStepTasks, moduleCallDate);
 

--- a/src/main/java/io/github/mzmine/modules/dataanalysis/anova/AnovaModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataanalysis/anova/AnovaModule.java
@@ -16,17 +16,17 @@
 
 package io.github.mzmine.modules.dataanalysis.anova;
 
+import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
-import java.util.Collection;
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
-import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 public class AnovaModule implements MZmineProcessingModule {
 
@@ -47,7 +47,7 @@ public class AnovaModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     FeatureList[] featureLists =
         parameters.getParameter(AnovaParameters.featureLists).getValue().getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/dataanalysis/anova/AnovaTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataanalysis/anova/AnovaTask.java
@@ -27,9 +27,9 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.UserParameter;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,10 +39,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.apache.commons.math3.distribution.FDistribution;
 import org.apache.commons.math3.exception.MathIllegalArgumentException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class AnovaTask extends AbstractTask {
 
@@ -56,7 +56,7 @@ public class AnovaTask extends AbstractTask {
   private final FeatureListRow[] featureListRows;
   private final UserParameter userParameter;
 
-  public AnovaTask(FeatureListRow[] featureListRows, ParameterSet parameters, @NotNull Date moduleCallDate) {
+  public AnovaTask(FeatureListRow[] featureListRows, ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate);
     this.featureListRows = featureListRows;
     this.userParameter = parameters.getParameter(AnovaParameters.selectionData).getValue();

--- a/src/main/java/io/github/mzmine/modules/dataanalysis/bubbleplots/cvplot/CVPlotModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataanalysis/bubbleplots/cvplot/CVPlotModule.java
@@ -18,14 +18,8 @@
 
 package io.github.mzmine.modules.dataanalysis.bubbleplots.cvplot;
 
-import io.github.mzmine.datamodel.features.FeatureList;
-import java.awt.Color;
-import java.util.Collection;
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
-
-import org.jfree.data.xy.AbstractXYZDataset;
 import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.MZmineRunnableModule;
 import io.github.mzmine.modules.dataanalysis.bubbleplots.RTMZAnalyzerWindow;
@@ -33,6 +27,11 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.interpolatinglookuppaintscale.InterpolatingLookupPaintScale;
+import java.awt.Color;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
+import org.jfree.data.xy.AbstractXYZDataset;
 
 public class CVPlotModule implements MZmineRunnableModule {
 
@@ -52,7 +51,7 @@ public class CVPlotModule implements MZmineRunnableModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     FeatureList featureLists[] =
         parameters.getParameter(CVParameters.featureLists).getValue().getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/dataanalysis/bubbleplots/logratioplot/LogratioPlotModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataanalysis/bubbleplots/logratioplot/LogratioPlotModule.java
@@ -20,8 +20,8 @@ package io.github.mzmine.modules.dataanalysis.bubbleplots.logratioplot;
 
 import io.github.mzmine.datamodel.features.FeatureList;
 import java.awt.Color;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 import org.jfree.data.xy.AbstractXYZDataset;
 import io.github.mzmine.datamodel.MZmineProject;
@@ -52,7 +52,7 @@ public class LogratioPlotModule implements MZmineRunnableModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     FeatureList featureLists[] =
         parameters.getParameter(CVParameters.featureLists).getValue().getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/dataanalysis/clustering/ClusteringModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataanalysis/clustering/ClusteringModule.java
@@ -18,11 +18,6 @@
 
 package io.github.mzmine.modules.dataanalysis.clustering;
 
-import java.util.Collection;
-
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
-
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.MZmineRunnableModule;
@@ -30,6 +25,9 @@ import io.github.mzmine.modules.dataanalysis.projectionplots.ProjectionPlotDatas
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 public class ClusteringModule implements MZmineRunnableModule {
 
@@ -50,7 +48,7 @@ public class ClusteringModule implements MZmineRunnableModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     ProjectionPlotDataset dataset = new ClusteringTask(parameters);
     tasks.add(dataset);
     return ExitCode.OK;

--- a/src/main/java/io/github/mzmine/modules/dataanalysis/heatmaps/HeatMapModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataanalysis/heatmaps/HeatMapModule.java
@@ -18,18 +18,16 @@
 
 package io.github.mzmine.modules.dataanalysis.heatmaps;
 
-import io.github.mzmine.datamodel.features.FeatureList;
-import java.util.Collection;
-
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
-
 import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.MZmineRunnableModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 public class HeatMapModule implements MZmineRunnableModule {
 
@@ -49,7 +47,7 @@ public class HeatMapModule implements MZmineRunnableModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     FeatureList selectedDataset =
         parameters.getParameter(HeatMapParameters.featureLists).getValue().getMatchingFeatureLists()[0];

--- a/src/main/java/io/github/mzmine/modules/dataanalysis/heatmaps/HeatMapTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataanalysis/heatmaps/HeatMapTask.java
@@ -18,22 +18,11 @@
 
 package io.github.mzmine.modules.dataanalysis.heatmaps;
 
+import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Vector;
-import java.util.logging.Logger;
-
-import org.apache.commons.math.MathException;
-import org.apache.commons.math.stat.descriptive.DescriptiveStatistics;
-import org.apache.commons.math.stat.inference.TTestImpl;
-
-import io.github.mzmine.datamodel.MZmineProject;
-import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.UserParameter;
 import io.github.mzmine.taskcontrol.AbstractTask;
@@ -42,6 +31,15 @@ import io.github.mzmine.util.R.REngineType;
 import io.github.mzmine.util.R.RSessionWrapper;
 import io.github.mzmine.util.R.RSessionWrapperException;
 import io.github.mzmine.util.R.Rsession.Rsession;
+import java.io.File;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Vector;
+import java.util.logging.Logger;
+import org.apache.commons.math.MathException;
+import org.apache.commons.math.stat.descriptive.DescriptiveStatistics;
+import org.apache.commons.math.stat.inference.TTestImpl;
 import org.jetbrains.annotations.NotNull;
 
 public class HeatMapTask extends AbstractTask {
@@ -65,7 +63,7 @@ public class HeatMapTask extends AbstractTask {
   private final Object referenceGroup;
   private final FeatureList featureList;
 
-  public HeatMapTask(MZmineProject project, FeatureList featureList, ParameterSet parameters, @NotNull Date moduleCallDate) {
+  public HeatMapTask(MZmineProject project, FeatureList featureList, ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
 
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataanalysis/projectionplots/CDAPlotModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataanalysis/projectionplots/CDAPlotModule.java
@@ -18,17 +18,15 @@
 
 package io.github.mzmine.modules.dataanalysis.projectionplots;
 
-import java.util.Collection;
-
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
-
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.MZmineRunnableModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 public class CDAPlotModule implements MZmineRunnableModule {
 
@@ -48,7 +46,7 @@ public class CDAPlotModule implements MZmineRunnableModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     ProjectionPlotDataset dataset = new CDADataset(project, parameters);
     tasks.add(dataset);
     return ExitCode.OK;

--- a/src/main/java/io/github/mzmine/modules/dataanalysis/projectionplots/PCAPlotModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataanalysis/projectionplots/PCAPlotModule.java
@@ -18,9 +18,9 @@
 
 package io.github.mzmine.modules.dataanalysis.projectionplots;
 
+import java.time.Instant;
 import java.util.Collection;
 
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -48,7 +48,7 @@ public class PCAPlotModule implements MZmineRunnableModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     ProjectionPlotDataset dataset = new PCADataset(project, parameters);
     tasks.add(dataset);
     return ExitCode.OK;

--- a/src/main/java/io/github/mzmine/modules/dataanalysis/projectionplots/SammonsPlotModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataanalysis/projectionplots/SammonsPlotModule.java
@@ -18,9 +18,9 @@
 
 package io.github.mzmine.modules.dataanalysis.projectionplots;
 
+import java.time.Instant;
 import java.util.Collection;
 
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -48,7 +48,7 @@ public class SammonsPlotModule implements MZmineRunnableModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     ProjectionPlotDataset dataset = new SammonsDataset(project, parameters);
     tasks.add(dataset);
     return ExitCode.OK;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/adap_hierarchicalclustering/ADAP3DecompositionV1_5Task.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/adap_hierarchicalclustering/ADAP3DecompositionV1_5Task.java
@@ -41,10 +41,10 @@ import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.MemoryMapStorage;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -73,7 +73,7 @@ public class ADAP3DecompositionV1_5Task extends AbstractTask {
   private final ParameterSet parameters;
 
   ADAP3DecompositionV1_5Task(final MZmineProject project, final FeatureList list,
-      final ParameterSet parameterSet, @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      final ParameterSet parameterSet, @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
     // Initialize.
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/adap_hierarchicalclustering/ADAPHierarchicalClusteringModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/adap_hierarchicalclustering/ADAPHierarchicalClusteringModule.java
@@ -23,8 +23,8 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -59,7 +59,7 @@ public class ADAPHierarchicalClusteringModule implements MZmineProcessingModule 
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     FeatureList[] peakLists = parameters.getParameter(ADAP3DecompositionV1_5Parameters.PEAK_LISTS)
         .getValue().getMatchingFeatureLists();
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/adap_mcr/ADAP3DecompositionV2Task.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/adap_mcr/ADAP3DecompositionV2Task.java
@@ -39,9 +39,9 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -68,7 +68,7 @@ public class ADAP3DecompositionV2Task extends AbstractTask {
   private final ParameterSet parameters;
 
   ADAP3DecompositionV2Task(final MZmineProject project, final ChromatogramPeakPair lists,
-      final ParameterSet parameterSet, @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      final ParameterSet parameterSet, @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
     // Initialize.
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/adap_mcr/ADAPMultivariateCurveResolutionModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/adap_mcr/ADAPMultivariateCurveResolutionModule.java
@@ -15,12 +15,6 @@
  */
 package io.github.mzmine.modules.dataprocessing.adap_mcr;
 
-import io.github.mzmine.util.MemoryMapStorage;
-import java.util.Collection;
-import java.util.Date;
-import java.util.Map;
-import org.jetbrains.annotations.NotNull;
-
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.modules.MZmineModuleCategory;
@@ -28,6 +22,11 @@ import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
 
 /**
  *
@@ -62,7 +61,7 @@ public class ADAPMultivariateCurveResolutionModule implements MZmineProcessingMo
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     Map<RawDataFile, ChromatogramPeakPair> lists =
         ChromatogramPeakPair.fromParameterSet(parameters);
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_adap3/ADAP3AlignerModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_adap3/ADAP3AlignerModule.java
@@ -17,9 +17,6 @@
  */
 package io.github.mzmine.modules.dataprocessing.align_adap3;
 
-import java.util.Collection;
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.MZmineProcessingModule;
@@ -27,6 +24,9 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * @author aleksandrsmirnov
@@ -62,7 +62,7 @@ public class ADAP3AlignerModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     Task newTask = new ADAP3AlignerTask(project, parameters, MemoryMapStorage.forFeatureList(),
         moduleCallDate);
     tasks.add(newTask);

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_adap3/ADAP3AlignerTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_adap3/ADAP3AlignerTask.java
@@ -43,9 +43,9 @@ import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.adap.ADAPInterface;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.NavigableMap;
 import java.util.TreeMap;
@@ -71,7 +71,7 @@ public class ADAP3AlignerTask extends AbstractTask {
   private final Project alignment;
 
   public ADAP3AlignerTask(MZmineProject project, ParameterSet parameters, @Nullable
-      MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
     this.project = project;
     this.parameters = parameters;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_append_rows/MergeAlignerModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_append_rows/MergeAlignerModule.java
@@ -25,8 +25,8 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public class MergeAlignerModule implements MZmineProcessingModule {
@@ -50,7 +50,7 @@ public class MergeAlignerModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     Task newTask = new MergeAlignerTask(project, parameters, MemoryMapStorage.forFeatureList(), moduleCallDate);
     tasks.add(newTask);
     return ExitCode.OK;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_append_rows/MergeAlignerTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_append_rows/MergeAlignerTask.java
@@ -30,6 +30,7 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.logging.Logger;
@@ -53,7 +54,7 @@ public class MergeAlignerTask extends AbstractTask {
   private ParameterSet parameters;
 
   public MergeAlignerTask(MZmineProject project, ParameterSet parameters,
-      @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_hierarchical/HierarAlignerGCTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_hierarchical/HierarAlignerGCTask.java
@@ -19,6 +19,8 @@
 package io.github.mzmine.modules.dataprocessing.align_hierarchical;
 
 import io.github.mzmine.datamodel.FeatureIdentity;
+import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
@@ -26,16 +28,23 @@ import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
+import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
+import io.github.mzmine.parameters.parametertypes.tolerances.RTTolerance;
+import io.github.mzmine.taskcontrol.AbstractTask;
+import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.FeatureUtils;
 import io.github.mzmine.util.MemoryMapStorage;
+import io.github.mzmine.util.SortingDirection;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.text.Format;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
@@ -43,21 +52,12 @@ import java.util.List;
 import java.util.Set;
 import java.util.Vector;
 import java.util.logging.Logger;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.gnf.clustering.DataSource;
 import org.gnf.clustering.DistanceMatrix;
 import org.gnf.clustering.FloatSource1D;
 import org.gnf.clustering.LinkageMode;
-import io.github.mzmine.datamodel.MZmineProject;
-import io.github.mzmine.datamodel.RawDataFile;
-import io.github.mzmine.main.MZmineCore;
-import io.github.mzmine.parameters.ParameterSet;
-import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
-import io.github.mzmine.parameters.parametertypes.tolerances.RTTolerance;
-import io.github.mzmine.taskcontrol.AbstractTask;
-import io.github.mzmine.taskcontrol.TaskStatus;
-import io.github.mzmine.util.SortingDirection;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class HierarAlignerGCTask extends AbstractTask {
 
@@ -129,7 +129,7 @@ public class HierarAlignerGCTask extends AbstractTask {
   //// public static final double MIN_SCORE_ABSOLUTE = Double.MIN_VALUE;
   public static final double MIN_SCORE_ABSOLUTE = 0.0;
 
-  HierarAlignerGCTask(MZmineProject project, ParameterSet parameters, @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+  HierarAlignerGCTask(MZmineProject project, ParameterSet parameters, @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_hierarchical/HierarAlignerGcModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_hierarchical/HierarAlignerGcModule.java
@@ -18,18 +18,16 @@
 
 package io.github.mzmine.modules.dataprocessing.align_hierarchical;
 
-import io.github.mzmine.util.MemoryMapStorage;
-import java.util.Collection;
-
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
-
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 public class HierarAlignerGcModule implements MZmineProcessingModule {
 
@@ -52,7 +50,7 @@ public class HierarAlignerGcModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     Task newTask = new HierarAlignerGCTask(project, parameters, MemoryMapStorage.forFeatureList(), moduleCallDate);
     tasks.add(newTask);
     return ExitCode.OK;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_join/JoinAlignerModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_join/JoinAlignerModule.java
@@ -25,8 +25,8 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public class JoinAlignerModule implements MZmineProcessingModule {
@@ -49,7 +49,7 @@ public class JoinAlignerModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     Task newTask = new JoinAlignerTask(project, parameters, MemoryMapStorage.forFeatureList(), moduleCallDate);
     tasks.add(newTask);
     return ExitCode.OK;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_join/JoinAlignerTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_join/JoinAlignerTask.java
@@ -48,6 +48,7 @@ import io.github.mzmine.util.SortingDirection;
 import io.github.mzmine.util.SortingProperty;
 import io.github.mzmine.util.scans.similarity.SpectralSimilarity;
 import io.github.mzmine.util.scans.similarity.SpectralSimilarityFunction;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -97,7 +98,7 @@ public class JoinAlignerTask extends AbstractTask {
   private int msLevel;
 
   public JoinAlignerTask(MZmineProject project, ParameterSet parameters,
-      @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_path/PathAlignerModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_path/PathAlignerModule.java
@@ -19,9 +19,9 @@
 package io.github.mzmine.modules.dataprocessing.align_path;
 
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
 
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -49,7 +49,7 @@ public class PathAlignerModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     Task newTask = new PathAlignerTask(project, parameters, MemoryMapStorage.forFeatureList(), moduleCallDate);
     tasks.add(newTask);
     return ExitCode.OK;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_path/PathAlignerTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_path/PathAlignerTask.java
@@ -26,6 +26,7 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Date;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -45,7 +46,7 @@ class PathAlignerTask extends AbstractTask {
   private ParameterSet parameters;
   private Aligner aligner;
 
-  PathAlignerTask(MZmineProject project, ParameterSet parameters, @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+  PathAlignerTask(MZmineProject project, ParameterSet parameters, @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_ransac/RansacAlignerModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_ransac/RansacAlignerModule.java
@@ -26,8 +26,8 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public class RansacAlignerModule implements MZmineProcessingModule {
@@ -49,7 +49,7 @@ public class RansacAlignerModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     FeatureList[] featureLists = parameters.getParameter(RansacAlignerParameters.peakLists).getValue()
         .getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_ransac/RansacAlignerTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_ransac/RansacAlignerTask.java
@@ -37,6 +37,7 @@ import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.FeatureUtils;
 import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.RangeUtils;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -73,7 +74,7 @@ class RansacAlignerTask extends AbstractTask {
   private int newRowID = 1;
 
   public RansacAlignerTask(MZmineProject project, FeatureList[] featureLists, ParameterSet parameters, @Nullable
-      MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adap3d/ADAP3DModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adap3d/ADAP3DModule.java
@@ -27,8 +27,8 @@ import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesParamete
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public class ADAP3DModule implements MZmineProcessingModule {
@@ -49,7 +49,7 @@ public class ADAP3DModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     RawDataFile[] dataFiles = parameters.getParameter(new RawDataFilesParameter()).getValue()
         .getMatchingRawDataFiles();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adap3d/ADAP3DTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adap3d/ADAP3DTask.java
@@ -18,19 +18,6 @@
 
 package io.github.mzmine.modules.dataprocessing.featdet_adap3d;
 
-import io.github.mzmine.datamodel.features.FeatureListRow;
-import io.github.mzmine.datamodel.features.ModularFeature;
-import io.github.mzmine.datamodel.features.ModularFeatureList;
-import io.github.mzmine.datamodel.features.ModularFeatureListRow;
-import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
-import io.github.mzmine.util.FeatureConvertors;
-import io.github.mzmine.util.MemoryMapStorage;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.function.Predicate;
-import java.util.logging.Logger;
 import io.github.msdk.datamodel.Feature;
 import io.github.msdk.datamodel.MsScan;
 import io.github.msdk.featuredetection.adap3d.ADAP3DFeatureDetectionMethod;
@@ -39,12 +26,25 @@ import io.github.mzmine.datamodel.FeatureStatus;
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.datamodel.features.FeatureListRow;
+import io.github.mzmine.datamodel.features.ModularFeature;
+import io.github.mzmine.datamodel.features.ModularFeatureList;
+import io.github.mzmine.datamodel.features.ModularFeatureListRow;
+import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
 import io.github.mzmine.datamodel.impl.MZmineToMSDKMsScan;
 import io.github.mzmine.datamodel.impl.MZmineToMSDKRawDataFile;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.parametertypes.selectors.ScanSelection;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import io.github.mzmine.util.FeatureConvertors;
+import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -64,7 +64,7 @@ public class ADAP3DTask extends AbstractTask {
    * @param parameters
    */
   public ADAP3DTask(MZmineProject project, RawDataFile dataFile, ParameterSet parameters, @Nullable
-      MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ModularADAPChromatogramBuilderModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ModularADAPChromatogramBuilderModule.java
@@ -26,8 +26,8 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public class ModularADAPChromatogramBuilderModule implements MZmineProcessingModule {
@@ -51,7 +51,7 @@ public class ModularADAPChromatogramBuilderModule implements MZmineProcessingMod
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     // one memory map storage per module call to reduce number of files and connect related feature lists
     MemoryMapStorage storage = MemoryMapStorage.forFeatureList();
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ModularADAPChromatogramBuilderTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ModularADAPChromatogramBuilderTask.java
@@ -46,6 +46,7 @@ import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.SortingDirection;
 import io.github.mzmine.util.SortingProperty;
 import io.github.mzmine.util.exceptions.MissingMassListException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -92,7 +93,7 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
    * @param parameters
    */
   public ModularADAPChromatogramBuilderTask(MZmineProject project, RawDataFile dataFile,
-      ParameterSet parameters, @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      ParameterSet parameters, @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
     this.project = project;
     this.dataFile = dataFile;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogrambuilder/ChromatogramBuilderModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogrambuilder/ChromatogramBuilderModule.java
@@ -26,8 +26,8 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 @Deprecated
@@ -49,7 +49,7 @@ public class ChromatogramBuilderModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     RawDataFile[] dataFiles = parameters.getParameter(ChromatogramBuilderParameters.dataFiles)
         .getValue().getMatchingRawDataFiles();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogrambuilder/ChromatogramBuilderTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogrambuilder/ChromatogramBuilderTask.java
@@ -38,8 +38,8 @@ import io.github.mzmine.util.FeatureSorter;
 import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.SortingDirection;
 import io.github.mzmine.util.SortingProperty;
+import java.time.Instant;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -70,7 +70,7 @@ public class ChromatogramBuilderTask extends AbstractTask {
    * @param parameters
    */
   public ChromatogramBuilderTask(MZmineProject project, RawDataFile dataFile,
-      ParameterSet parameters, @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      ParameterSet parameters, @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/FeatureResolverModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/FeatureResolverModule.java
@@ -27,8 +27,8 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public abstract class FeatureResolverModule implements MZmineProcessingModule {
@@ -44,7 +44,7 @@ public abstract class FeatureResolverModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull final ParameterSet parameters,
-      @NotNull final Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull final Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     // one memory map storage per module call to reduce number of files and connect related feature lists
     MemoryMapStorage storage = MemoryMapStorage.forFeatureList();
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/FeatureResolverTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/FeatureResolverTask.java
@@ -46,7 +46,7 @@ import io.github.mzmine.util.R.REngineType;
 import io.github.mzmine.util.R.RSessionWrapper;
 import io.github.mzmine.util.R.RSessionWrapperException;
 import io.github.mzmine.util.maths.CenterFunction;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -83,7 +83,7 @@ public class FeatureResolverTask extends AbstractTask {
    */
   public FeatureResolverTask(final MZmineProject project, MemoryMapStorage storage,
       final FeatureList list, final ParameterSet parameterSet, CenterFunction mzCenterFunction,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     // Initialize.

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_gridmass/GridMassModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_gridmass/GridMassModule.java
@@ -27,8 +27,8 @@ import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesParamete
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public class GridMassModule implements MZmineProcessingModule {
@@ -50,7 +50,7 @@ public class GridMassModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     RawDataFile[] dataFiles =
         parameters.getParameter(new RawDataFilesParameter()).getValue().getMatchingRawDataFiles();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_gridmass/GridMassTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_gridmass/GridMassTask.java
@@ -37,9 +37,9 @@ import io.github.mzmine.util.FeatureConvertors;
 import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.scans.ScanUtils;
 import java.text.Format;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.logging.Logger;
@@ -89,7 +89,7 @@ public class GridMassTask extends AbstractTask {
    * @param parameters
    */
   public GridMassTask(MZmineProject project, RawDataFile dataFile, ParameterSet parameters,
-      @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_imagebuilder/ImageBuilderModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_imagebuilder/ImageBuilderModule.java
@@ -27,8 +27,8 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 /*
@@ -53,7 +53,7 @@ public class ImageBuilderModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     RawDataFile[] files = parameters.getParameter(ImageBuilderParameters.rawDataFiles).getValue()
         .getMatchingRawDataFiles();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_imagebuilder/ImageBuilderTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_imagebuilder/ImageBuilderTask.java
@@ -41,6 +41,7 @@ import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.FeatureConvertors;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -81,7 +82,7 @@ public class ImageBuilderTask extends AbstractTask {
   private final ModularFeatureList featureList;
 
   public ImageBuilderTask(MZmineProject project, RawDataFile rawDataFile, ParameterSet parameters,
-      @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_imsexpander/ImsExpanderModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_imsexpander/ImsExpanderModule.java
@@ -28,8 +28,8 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -53,7 +53,7 @@ public class ImsExpanderModule implements MZmineProcessingModule {
   @Override
   public @NotNull ExitCode runModule(@NotNull MZmineProject project,
       @NotNull ParameterSet parameters, @NotNull Collection<Task> tasks,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
 
     final Integer numThreads = MZmineCore.getConfiguration().getPreferences()
         .getParameter(MZminePreferences.numOfThreads).getValue();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_imsexpander/ImsExpanderSubTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_imsexpander/ImsExpanderSubTask.java
@@ -32,6 +32,7 @@ import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.RangeUtils;
 import io.github.mzmine.util.exceptions.MissingMassListException;
+import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -60,7 +61,7 @@ public class ImsExpanderSubTask extends AbstractTask {
       @NotNull final ParameterSet parameters, @NotNull final List<Frame> frames,
       @NotNull final ModularFeatureList flist,
       @NotNull final List<ExpandingTrace> expandingTraces) {
-    super(storage, new Date()); // just a subtask, date irrelevant
+    super(storage, Instant.now()); // just a subtask, date irrelevant
     this.parameters = parameters;
     this.frames = frames;
     this.flist = flist;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_imsexpander/ImsExpanderTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_imsexpander/ImsExpanderTask.java
@@ -43,6 +43,7 @@ import io.github.mzmine.taskcontrol.TaskPriority;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.DataTypeUtils;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
@@ -74,7 +75,7 @@ public class ImsExpanderTask extends AbstractTask {
 
   public ImsExpanderTask(@Nullable final MemoryMapStorage storage,
       @NotNull final ParameterSet parameters, @NotNull final ModularFeatureList flist,
-      MZmineProject project, final int allowedThreads, @NotNull Date moduleCallDate) {
+      MZmineProject project, final int allowedThreads, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
     this.parameters = parameters;
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_ionmobilitytracebuilder/IonMobilityTraceBuilderModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_ionmobilitytracebuilder/IonMobilityTraceBuilderModule.java
@@ -27,8 +27,8 @@ import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -44,7 +44,7 @@ public class IonMobilityTraceBuilderModule implements MZmineProcessingModule {
   @NotNull
   @Override
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     RawDataFile[] files = parameters.getParameter(IonMobilityTraceBuilderParameters.rawDataFiles)
         .getValue().getMatchingRawDataFiles();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_ionmobilitytracebuilder/IonMobilityTraceBuilderTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_ionmobilitytracebuilder/IonMobilityTraceBuilderTask.java
@@ -44,6 +44,7 @@ import io.github.mzmine.util.DataTypeUtils;
 import io.github.mzmine.util.FeatureConvertorIonMobility;
 import io.github.mzmine.util.FeatureConvertors;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Date;
@@ -93,7 +94,7 @@ public class IonMobilityTraceBuilderTask extends AbstractTask {
 
   @SuppressWarnings("unchecked")
   public IonMobilityTraceBuilderTask(MZmineProject project, RawDataFile rawDataFile,
-      List<Frame> frames, ParameterSet parameters, @NotNull Date moduleCallDate) {
+      List<Frame> frames, ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(MemoryMapStorage.forFeatureList(), moduleCallDate); // Ims files are usually big, so we create our own
     this.project = project;
     this.rawDataFile = rawDataFile;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_manual/ManualPickerTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_manual/ManualPickerTask.java
@@ -36,6 +36,7 @@ import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.FeatureConvertors;
 import io.github.mzmine.util.RangeUtils;
 import io.github.mzmine.util.scans.ScanUtils;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -59,7 +60,7 @@ class ManualPickerTask extends AbstractTask {
 
   ManualPickerTask(MZmineProject project, FeatureListRow featureListRow, RawDataFile dataFiles[],
       ManualPickerParameters parameters, FeatureList featureList, FeatureTableFX table) {
-    super(null, new Date()); // we get passed a flist, so it should contain a storage
+    super(null, Instant.now()); // we get passed a flist, so it should contain a storage
 
     this.project = project;
     this.featureListRow = featureListRow;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_manual/XICManualPickerDialog.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_manual/XICManualPickerDialog.java
@@ -42,6 +42,7 @@ import java.awt.Stroke;
 import java.awt.Toolkit;
 import java.awt.geom.Rectangle2D;
 import java.text.NumberFormat;
+import java.time.Instant;
 import java.util.Date;
 import java.util.logging.Logger;
 import javafx.application.Platform;
@@ -296,7 +297,7 @@ public class XICManualPickerDialog extends ParameterSetupDialog {
       return;
     }
 
-    Task integration = new AbstractTask(null, new Date()) {
+    Task integration = new AbstractTask(null, Instant.now()) {
 
       @Override
       public void run() {

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_masscalibration/MassCalibrationModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_masscalibration/MassCalibrationModule.java
@@ -26,8 +26,8 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public class MassCalibrationModule implements MZmineProcessingModule {
@@ -50,7 +50,7 @@ public class MassCalibrationModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     // create a single storage map for all mass lists that were created with the same parameters
     final MemoryMapStorage storageMemoryMap = MemoryMapStorage.forMassList();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_masscalibration/MassCalibrationSetupDialog.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_masscalibration/MassCalibrationSetupDialog.java
@@ -27,6 +27,7 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.dialogs.ParameterSetupDialog;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
 import java.util.Date;
 import javafx.animation.PauseTransition;
 import javafx.application.Platform;
@@ -208,7 +209,7 @@ public class MassCalibrationSetupDialog extends ParameterSetupDialog {
         previewTask.cancel();
       }
 
-      previewTask = new MassCalibrationTask(previewDataFile, parameterSet, null, true, new Date());
+      previewTask = new MassCalibrationTask(previewDataFile, parameterSet, null, true, Instant.now());
 
       previewTask.setAfterHook(() -> Platform.runLater(() -> updatePreviewAfterTaskRun(rerun)));
       MZmineCore.getTaskController().addTask(previewTask);

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_masscalibration/MassCalibrationTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_masscalibration/MassCalibrationTask.java
@@ -47,6 +47,7 @@ import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.MemoryMapStorage;
 import java.io.InputStream;
 import java.net.URL;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -106,7 +107,7 @@ public class MassCalibrationTask extends AbstractTask {
    * @param previewRun
    */
   public MassCalibrationTask(RawDataFile dataFile, ParameterSet parameters,
-      @Nullable MemoryMapStorage storageMemoryMap, boolean previewRun, @NotNull Date moduleCallDate) {
+      @Nullable MemoryMapStorage storageMemoryMap, boolean previewRun, @NotNull Instant moduleCallDate) {
     super(storageMemoryMap, moduleCallDate);
     this.dataFile = dataFile;
     this.parameters = parameters;
@@ -116,7 +117,7 @@ public class MassCalibrationTask extends AbstractTask {
   }
 
   public MassCalibrationTask(RawDataFile dataFile, ParameterSet parameters,
-      MemoryMapStorage storageMemoryMap, @NotNull Date moduleCallDate) {
+      MemoryMapStorage storageMemoryMap, @NotNull Instant moduleCallDate) {
     this(dataFile, parameters, storageMemoryMap, false, moduleCallDate);
   }
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_massdetection/MassDetectionModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_massdetection/MassDetectionModule.java
@@ -26,8 +26,8 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public class MassDetectionModule implements MZmineProcessingModule {
@@ -49,7 +49,7 @@ public class MassDetectionModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     RawDataFile[] dataFiles = parameters.getParameter(MassDetectionParameters.dataFiles).getValue()
         .getMatchingRawDataFiles();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_massdetection/MassDetectionTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_massdetection/MassDetectionTask.java
@@ -31,6 +31,7 @@ import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.MemoryMapStorage;
 import java.io.File;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -65,7 +66,7 @@ public class MassDetectionTask extends AbstractTask {
    * @param storageMemoryMap
    */
   public MassDetectionTask(RawDataFile dataFile, ParameterSet parameters,
-      MemoryMapStorage storageMemoryMap, @NotNull Date moduleCallDate) {
+      MemoryMapStorage storageMemoryMap, @NotNull Instant moduleCallDate) {
     super(storageMemoryMap, moduleCallDate);
 
     this.dataFile = dataFile;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_mobilityscanmerger/MobilityScanMergerModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_mobilityscanmerger/MobilityScanMergerModule.java
@@ -26,8 +26,8 @@ import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -56,7 +56,7 @@ public class MobilityScanMergerModule implements MZmineProcessingModule {
   @NotNull
   @Override
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     for (RawDataFile file : parameters.getParameter(MobilityScanMergerParameters.rawDataFiles)
         .getValue().getMatchingRawDataFiles()) {

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_mobilityscanmerger/MoblityScanMergerTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_mobilityscanmerger/MoblityScanMergerTask.java
@@ -33,6 +33,7 @@ import io.github.mzmine.util.maths.CenterFunction;
 import io.github.mzmine.util.maths.Weighting;
 import io.github.mzmine.util.scans.SpectraMerging;
 import io.github.mzmine.util.scans.SpectraMerging.MergingType;
+import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.logging.Level;
@@ -52,7 +53,7 @@ public class MoblityScanMergerTask extends AbstractTask {
   private int totalFrames;
   private int processedFrames;
 
-  public MoblityScanMergerTask(final IMSRawDataFile file, ParameterSet parameters, @NotNull Date moduleCallDate) {
+  public MoblityScanMergerTask(final IMSRawDataFile file, ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // for now, the merged data points are added to the frame on the raw data
     // level. In the future, we will generate a mass list.
     processedFrames = 0;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_mobilogram_summing/MobilogramBinningModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_mobilogram_summing/MobilogramBinningModule.java
@@ -26,8 +26,8 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -57,7 +57,7 @@ public class MobilogramBinningModule implements MZmineProcessingModule {
   @NotNull
   @Override
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     final ModularFeatureList[] flists = parameters
         .getParameter(MobilogramBinningParameters.featureLists).getValue()

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_mobilogram_summing/MobilogramBinningTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_mobilogram_summing/MobilogramBinningTask.java
@@ -33,6 +33,7 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
@@ -60,7 +61,7 @@ public class MobilogramBinningTask extends AbstractTask {
       @NotNull final ModularFeatureList originalFeatureList,
       @NotNull final ParameterSet parameters,
       @NotNull final MZmineProject project,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
     this.parameters = parameters;
     this.originalFeatureList = originalFeatureList;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_msn/MsnFeatureDetectionModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_msn/MsnFeatureDetectionModule.java
@@ -26,8 +26,8 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public class MsnFeatureDetectionModule implements MZmineProcessingModule {
@@ -49,7 +49,7 @@ public class MsnFeatureDetectionModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     RawDataFile[] dataFiles = parameters.getParameter(MsnPeakPickerParameters.dataFiles).getValue()
         .getMatchingRawDataFiles();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_msn/MsnPeakPickingTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_msn/MsnPeakPickingTask.java
@@ -34,6 +34,7 @@ import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.FeatureUtils;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Date;
 import java.util.logging.Logger;
 import org.apache.commons.lang3.ArrayUtils;
@@ -56,7 +57,7 @@ public class MsnPeakPickingTask extends AbstractTask {
   private int processedScans, totalScans;
 
   public MsnPeakPickingTask(MZmineProject project, RawDataFile dataFile, ParameterSet parameters,
-      @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_recursiveimsbuilder/RecursiveIMSBuilderModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_recursiveimsbuilder/RecursiveIMSBuilderModule.java
@@ -27,8 +27,8 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -55,7 +55,7 @@ public class RecursiveIMSBuilderModule implements MZmineProcessingModule {
   @NotNull
   @Override
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     final MemoryMapStorage storage = MemoryMapStorage.forFeatureList();
     for (RawDataFile rawDataFile : parameters

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_recursiveimsbuilder/RecursiveIMSBuilderTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_recursiveimsbuilder/RecursiveIMSBuilderTask.java
@@ -49,6 +49,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -90,7 +91,7 @@ public class RecursiveIMSBuilderTask extends AbstractTask {
 
   public RecursiveIMSBuilderTask(@Nullable MemoryMapStorage storage,
       @NotNull final IMSRawDataFile file,
-      @NotNull final ParameterSet parameters, MZmineProject project, @NotNull Date moduleCallDate) {
+      @NotNull final ParameterSet parameters, MZmineProject project, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     this.file = file;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_shoulderpeaksfilter/ShoulderPeaksFilterModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_shoulderpeaksfilter/ShoulderPeaksFilterModule.java
@@ -26,8 +26,8 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public class ShoulderPeaksFilterModule implements MZmineProcessingModule {
@@ -49,7 +49,7 @@ public class ShoulderPeaksFilterModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     // storage for masslists
     MemoryMapStorage storage = MemoryMapStorage.forMassList();
     RawDataFile[] dataFiles = parameters.getParameter(ShoulderPeaksFilterParameters.dataFiles)

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_shoulderpeaksfilter/ShoulderPeaksFilterTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_shoulderpeaksfilter/ShoulderPeaksFilterTask.java
@@ -28,6 +28,7 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Date;
 import java.util.logging.Logger;
 import javafx.collections.ObservableList;
@@ -54,7 +55,7 @@ public class ShoulderPeaksFilterTask extends AbstractTask {
    * @param storage
    */
   public ShoulderPeaksFilterTask(RawDataFile dataFile, ParameterSet parameters,
-      MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
     this.dataFile = dataFile;
     this.parameters = parameters;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_smoothing/SmoothingModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_smoothing/SmoothingModule.java
@@ -26,8 +26,8 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -56,7 +56,7 @@ public class SmoothingModule implements MZmineProcessingModule {
   @NotNull
   @Override
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     final ModularFeatureList[] flists = parameters.getParameter(SmoothingParameters.featureLists)
         .getValue().getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_smoothing/SmoothingTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_smoothing/SmoothingTask.java
@@ -45,6 +45,7 @@ import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.DataPointUtils;
 import io.github.mzmine.util.DataTypeUtils;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -73,7 +74,7 @@ public class SmoothingTask extends AbstractTask {
   private final boolean removeOriginal;
 
   public SmoothingTask(@NotNull MZmineProject project, @NotNull ModularFeatureList flist,
-      @Nullable MemoryMapStorage storage, @NotNull ParameterSet parameters, @NotNull Date moduleCallDate) {
+      @Nullable MemoryMapStorage storage, @NotNull ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     this.flist = flist;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_targeted/TargetedFeatureDetectionModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_targeted/TargetedFeatureDetectionModule.java
@@ -26,8 +26,8 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public class TargetedFeatureDetectionModule implements MZmineProcessingModule {
@@ -48,7 +48,7 @@ public class TargetedFeatureDetectionModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     RawDataFile[] dataFiles = parameters.getParameter(TargetedPeakDetectionParameters.rawDataFile)
         .getValue().getMatchingRawDataFiles();
     final MemoryMapStorage storage = MemoryMapStorage.forFeatureList();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_targeted/TargetedPeakDetectionModuleTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_targeted/TargetedPeakDetectionModuleTask.java
@@ -37,6 +37,7 @@ import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.MemoryMapStorage;
 import java.io.File;
 import java.io.FileReader;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -67,7 +68,7 @@ class TargetedPeakDetectionModuleTask extends AbstractTask {
   private double noiseLevel;
 
   TargetedPeakDetectionModuleTask(MZmineProject project, ParameterSet parameters,
-      RawDataFile dataFile, @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      RawDataFile dataFile, @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_alignscans/AlignScansModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_alignscans/AlignScansModule.java
@@ -27,8 +27,8 @@ import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesParamete
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public class AlignScansModule implements MZmineProcessingModule {
@@ -54,7 +54,7 @@ public class AlignScansModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     RawDataFile[] dataFiles =
         parameters.getParameter(new RawDataFilesParameter()).getValue().getMatchingRawDataFiles();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_alignscans/AlignScansTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_alignscans/AlignScansTask.java
@@ -34,7 +34,7 @@ import io.github.mzmine.util.DataPointUtils;
 import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.scans.ScanUtils;
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -64,7 +64,7 @@ public class AlignScansTask extends AbstractTask {
    * @param storage
    */
   public AlignScansTask(MZmineProject project, RawDataFile dataFile, ParameterSet parameters,
-      @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_baselinecorrection/BaselineCorrectionModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_baselinecorrection/BaselineCorrectionModule.java
@@ -24,12 +24,6 @@
 
 package io.github.mzmine.modules.dataprocessing.filter_baselinecorrection;
 
-import io.github.mzmine.util.MemoryMapStorage;
-import java.util.Collection;
-
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
-
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.modules.MZmineModuleCategory;
@@ -37,6 +31,10 @@ import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Baseline correction module.
@@ -60,7 +58,7 @@ public class BaselineCorrectionModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     RawDataFile dataFiles[] = parameters.getParameter(BaselineCorrectionParameters.dataFiles)
         .getValue().getMatchingRawDataFiles();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_baselinecorrection/BaselineCorrectionTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_baselinecorrection/BaselineCorrectionTask.java
@@ -37,7 +37,7 @@ import io.github.mzmine.util.R.REngineType;
 import io.github.mzmine.util.R.RSessionWrapper;
 import io.github.mzmine.util.R.RSessionWrapperException;
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -82,7 +82,7 @@ public class BaselineCorrectionTask extends AbstractTask {
    * @param storage
    */
   public BaselineCorrectionTask(MZmineProject project, final RawDataFile dataFile,
-      final ParameterSet parameters, @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      final ParameterSet parameters, @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     // Initialize.

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_baselinecorrection/BaselineCorrectorSetupDialog.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_baselinecorrection/BaselineCorrectorSetupDialog.java
@@ -18,21 +18,6 @@
 
 package io.github.mzmine.modules.dataprocessing.filter_baselinecorrection;
 
-import java.awt.Component;
-import java.awt.Container;
-import java.awt.event.KeyEvent;
-import java.awt.event.KeyListener;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import org.jetbrains.annotations.NotNull;
-import org.jfree.data.xy.XYDataset;
-import org.jfree.data.xy.XYSeries;
-import org.jfree.data.xy.XYSeriesCollection;
 import com.google.common.collect.Range;
 import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.RawDataFile;
@@ -48,8 +33,23 @@ import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.R.RSessionWrapper;
 import io.github.mzmine.util.R.RSessionWrapperException;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javafx.application.Platform;
 import javafx.scene.control.ProgressBar;
+import org.jetbrains.annotations.NotNull;
+import org.jfree.data.xy.XYDataset;
+import org.jfree.data.xy.XYSeries;
+import org.jfree.data.xy.XYSeriesCollection;
 
 /**
  * @description This class extends ParameterSetupDialogWithChromatogramPreview class. This is used
@@ -158,7 +158,7 @@ public class BaselineCorrectorSetupDialog extends ParameterSetupDialogWithChroma
     private boolean userCanceled;
 
     public PreviewTask(BaselineCorrectorSetupDialog dialog, TICPlot ticPlot, RawDataFile dataFile,
-        Range<Float> rtRange, Range<Double> mzRange, @NotNull Date moduleCallDate) {
+        Range<Float> rtRange, Range<Double> mzRange, @NotNull Instant moduleCallDate) {
       super(null, moduleCallDate); // no new data stored -> null
 
       this.dialog = dialog;
@@ -419,7 +419,7 @@ public class BaselineCorrectorSetupDialog extends ParameterSetupDialogWithChroma
     if (ready && (previewTask == null || previewTask.getStatus() != TaskStatus.PROCESSING)) {
 
       baselineCorrector.initProgress(dataFile);
-      previewTask = new PreviewTask(this, ticPlot, dataFile, rtRange, mzRange, new Date()); // date does not matter for preview
+      previewTask = new PreviewTask(this, ticPlot, dataFile, rtRange, mzRange, Instant.now()); // date does not matter for preview
       previewThread = new Thread(previewTask);
       logger.info("Launch preview task.");
       previewThread.start();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_blanksubtraction/FeatureListBlankSubtractionModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_blanksubtraction/FeatureListBlankSubtractionModule.java
@@ -25,8 +25,8 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -53,7 +53,7 @@ public class FeatureListBlankSubtractionModule implements MZmineProcessingModule
 
   @Override
   public ExitCode runModule(MZmineProject project, ParameterSet parameters, Collection<Task> tasks,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
 
     Task task = new FeatureListBlankSubtractionTask(project,
         (FeatureListBlankSubtractionParameters) parameters, MemoryMapStorage.forFeatureList(), moduleCallDate);

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_blanksubtraction/FeatureListBlankSubtractionTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_blanksubtraction/FeatureListBlankSubtractionTask.java
@@ -30,9 +30,9 @@ import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesSelectio
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -64,7 +64,7 @@ public class FeatureListBlankSubtractionTask extends AbstractTask {
   private ModularFeatureList alignedFeatureList;
 
   public FeatureListBlankSubtractionTask(MZmineProject project,
-      FeatureListBlankSubtractionParameters parameters, @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      FeatureListBlankSubtractionParameters parameters, @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_clearannotations/FeatureListClearAnnotationsModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_clearannotations/FeatureListClearAnnotationsModule.java
@@ -18,18 +18,16 @@
 
 package io.github.mzmine.modules.dataprocessing.filter_clearannotations;
 
-import io.github.mzmine.datamodel.features.FeatureList;
-import java.util.Collection;
-
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
-
 import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Implements a filter for comparison of peaks in a given row after alignment results. The filter
@@ -55,7 +53,7 @@ public class FeatureListClearAnnotationsModule implements MZmineProcessingModule
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     final FeatureList[] peakLists =
         parameters.getParameter(FeatureListClearAnnotationsParameters.PEAK_LISTS).getValue()

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_clearannotations/FeatureListClearAnnotationsTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_clearannotations/FeatureListClearAnnotationsTask.java
@@ -26,7 +26,7 @@ import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
-import java.util.Date;
+import java.time.Instant;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -55,7 +55,7 @@ public class FeatureListClearAnnotationsTask extends AbstractTask {
    * @param parameterSet task parameters.
    */
   public FeatureListClearAnnotationsTask(final MZmineProject project, final FeatureList list,
-      final ParameterSet parameterSet, @NotNull Date moduleCallDate) {
+      final ParameterSet parameterSet, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     // Initialize.
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_cropfilter/CropFilterModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_cropfilter/CropFilterModule.java
@@ -18,12 +18,6 @@
 
 package io.github.mzmine.modules.dataprocessing.filter_cropfilter;
 
-import io.github.mzmine.util.MemoryMapStorage;
-import java.util.Collection;
-
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
-
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.modules.MZmineModuleCategory;
@@ -31,6 +25,10 @@ import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 public class CropFilterModule implements MZmineProcessingModule {
 
@@ -51,7 +49,7 @@ public class CropFilterModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     // one storage for all files in the same module call
     final MemoryMapStorage storage = MemoryMapStorage.forRawDataFile();
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_cropfilter/CropFilterTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_cropfilter/CropFilterTask.java
@@ -31,10 +31,10 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.parametertypes.selectors.ScanSelection;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
-import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.DataPointUtils;
+import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.scans.ScanUtils;
-import java.util.Date;
+import java.time.Instant;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -57,7 +57,7 @@ public class CropFilterTask extends AbstractTask {
   private final MemoryMapStorage storage;
 
   CropFilterTask(MZmineProject project, RawDataFile dataFile, ParameterSet parameters,
-      @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_duplicatefilter/DuplicateFilterModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_duplicatefilter/DuplicateFilterModule.java
@@ -18,19 +18,17 @@
 
 package io.github.mzmine.modules.dataprocessing.filter_duplicatefilter;
 
-import io.github.mzmine.datamodel.features.FeatureList;
-import io.github.mzmine.util.MemoryMapStorage;
-import java.util.Collection;
-
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
-
 import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Duplicate peak filter
@@ -62,7 +60,7 @@ public class DuplicateFilterModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     FeatureList[] peakLists = parameters.getParameter(DuplicateFilterParameters.peakLists).getValue()
         .getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_duplicatefilter/DuplicateFilterTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_duplicatefilter/DuplicateFilterTask.java
@@ -18,6 +18,9 @@
 
 package io.github.mzmine.modules.dataprocessing.filter_duplicatefilter;
 
+import io.github.mzmine.datamodel.FeatureStatus;
+import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureList.FeatureListAppliedMethod;
@@ -26,24 +29,21 @@ import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
-import io.github.mzmine.util.FeatureListRowSorter;
-import io.github.mzmine.util.FeatureUtils;
-import io.github.mzmine.util.MemoryMapStorage;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import io.github.mzmine.datamodel.FeatureStatus;
-import io.github.mzmine.datamodel.MZmineProject;
-import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.modules.dataprocessing.filter_duplicatefilter.DuplicateFilterParameters.FilterMode;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.parameters.parametertypes.tolerances.RTTolerance;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import io.github.mzmine.util.FeatureListRowSorter;
+import io.github.mzmine.util.FeatureUtils;
+import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.SortingDirection;
 import io.github.mzmine.util.SortingProperty;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -68,7 +68,7 @@ public class DuplicateFilterTask extends AbstractTask {
   private final ParameterSet parameters;
 
   public DuplicateFilterTask(final MZmineProject project, final FeatureList list,
-      final ParameterSet params, @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      final ParameterSet params, @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     // Initialize.

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_extractscans/ExtractScansModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_extractscans/ExtractScansModule.java
@@ -24,8 +24,8 @@ import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -50,7 +50,7 @@ public class ExtractScansModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     ExtractScansTask task = new ExtractScansTask(parameters, moduleCallDate);
     tasks.add(task);
     return ExitCode.OK;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_extractscans/ExtractScansTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_extractscans/ExtractScansTask.java
@@ -18,16 +18,6 @@
 
 package io.github.mzmine.modules.dataprocessing.filter_extractscans;
 
-import io.github.mzmine.util.exceptions.MissingMassListException;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.text.DecimalFormat;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import org.apache.commons.io.FilenameUtils;
 import com.google.common.collect.Range;
 import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.MassList;
@@ -36,7 +26,17 @@ import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import io.github.mzmine.util.exceptions.MissingMassListException;
 import io.github.mzmine.util.files.FileAndPathUtil;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.text.DecimalFormat;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.io.FilenameUtils;
 import org.jetbrains.annotations.NotNull;
 
 class ExtractScansTask extends AbstractTask {
@@ -52,7 +52,7 @@ class ExtractScansTask extends AbstractTask {
   private double minTime, maxTime;
   private boolean useCenterTime;
 
-  ExtractScansTask(ParameterSet parameters, @NotNull Date moduleCallDate) {
+  ExtractScansTask(ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
 
     dataFiles = Arrays.asList(parameters.getParameter(ExtractScansParameters.dataFiles).getValue()

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_featurefilter/FeatureFilterModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_featurefilter/FeatureFilterModule.java
@@ -18,19 +18,17 @@
 
 package io.github.mzmine.modules.dataprocessing.filter_featurefilter;
 
-import io.github.mzmine.datamodel.features.FeatureList;
-import io.github.mzmine.util.MemoryMapStorage;
-import java.util.Collection;
-
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
-
 import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Implements a filter for alignment results. The filter removes rows that have fewer than a defined
@@ -55,7 +53,7 @@ public class FeatureFilterModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     final FeatureList[] peakLists = parameters.getParameter(FeatureFilterParameters.PEAK_LISTS)
         .getValue().getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_featurefilter/FeatureFilterTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_featurefilter/FeatureFilterTask.java
@@ -35,7 +35,7 @@ import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.RangeUtils;
-import java.util.Date;
+import java.time.Instant;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -68,7 +68,7 @@ public class FeatureFilterTask extends AbstractTask {
    * @param parameterSet task parameters.
    */
   public FeatureFilterTask(final MZmineProject project, final FeatureList list,
-      final ParameterSet parameterSet, @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      final ParameterSet parameterSet, @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     // Initialize

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_groupms2/GroupMS2Module.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_groupms2/GroupMS2Module.java
@@ -18,17 +18,16 @@
 
 package io.github.mzmine.modules.dataprocessing.filter_groupms2;
 
-import io.github.mzmine.datamodel.features.FeatureList;
-import java.util.Collection;
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
-
 import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Group all MS2 scans to their features
@@ -52,7 +51,7 @@ public class GroupMS2Module implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     final FeatureList[] peakLists =
         parameters.getParameter(GroupMS2Parameters.PEAK_LISTS).getValue().getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_groupms2/GroupMS2Task.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_groupms2/GroupMS2Task.java
@@ -43,9 +43,9 @@ import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.scans.ScanUtils;
 import io.github.mzmine.util.scans.SpectraMerging;
 import io.github.mzmine.util.scans.SpectraMerging.MergingType;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -82,7 +82,7 @@ public class GroupMS2Task extends AbstractTask {
    * @param parameterSet task parameters.
    */
   public GroupMS2Task(final MZmineProject project, final FeatureList list,
-      final ParameterSet parameterSet, @NotNull Date moduleCallDate) {
+      final ParameterSet parameterSet, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
 
     // Initialize.

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_interestingfeaturefinder/AnnotateIsomersModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_interestingfeaturefinder/AnnotateIsomersModule.java
@@ -25,8 +25,8 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -51,7 +51,7 @@ public class AnnotateIsomersModule implements MZmineProcessingModule {
   @Override
   public @NotNull ExitCode runModule(@NotNull MZmineProject project,
       @NotNull ParameterSet parameters, @NotNull Collection<Task> tasks,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     final MemoryMapStorage storage = MemoryMapStorage.forFeatureList();
 
     for (var flist : parameters.getParameter(AnnotateIsomersParameters.featureLists).getValue()

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_interestingfeaturefinder/AnnotateIsomersTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_interestingfeaturefinder/AnnotateIsomersTask.java
@@ -36,9 +36,9 @@ import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.FeatureListUtils;
 import io.github.mzmine.util.IonMobilityUtils;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
@@ -67,7 +67,7 @@ public class AnnotateIsomersTask extends AbstractTask {
 
 
   public AnnotateIsomersTask(MemoryMapStorage storage, @NotNull MZmineProject project,
-      @NotNull ParameterSet parameters, ModularFeatureList flist, @NotNull Date moduleCallDate) {
+      @NotNull ParameterSet parameters, ModularFeatureList flist, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_isotopegrouper/IsotopeGrouperModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_isotopegrouper/IsotopeGrouperModule.java
@@ -20,9 +20,9 @@ package io.github.mzmine.modules.dataprocessing.filter_isotopegrouper;
 
 import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
 
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -56,7 +56,7 @@ public class IsotopeGrouperModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     ModularFeatureList[] featureLists= parameters.getParameter(IsotopeGrouperParameters.peakLists).getValue()
         .getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_isotopegrouper/IsotopeGrouperTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_isotopegrouper/IsotopeGrouperTask.java
@@ -39,6 +39,7 @@ import io.github.mzmine.util.FeatureListRowSorter;
 import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.SortingDirection;
 import io.github.mzmine.util.SortingProperty;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -82,7 +83,7 @@ class IsotopeGrouperTask extends AbstractTask {
    *
    */
   IsotopeGrouperTask(MZmineProject project, ModularFeatureList featureList, ParameterSet parameters,
-      @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_merge/RawFileMergeModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_merge/RawFileMergeModule.java
@@ -19,9 +19,9 @@
 package io.github.mzmine.modules.dataprocessing.filter_merge;
 
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import io.github.msdk.MSDKRuntimeException;
@@ -57,7 +57,7 @@ public class RawFileMergeModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     // one storage for all files in the same module call
     final MemoryMapStorage storage = MemoryMapStorage.forRawDataFile();
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_merge/RawFileMergeTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_merge/RawFileMergeTask.java
@@ -31,6 +31,7 @@ import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.MemoryMapStorage;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
@@ -60,7 +61,7 @@ class RawFileMergeTask extends AbstractTask {
   private MZmineProject project;
 
   RawFileMergeTask(MZmineProject project, ParameterSet parameters, RawDataFile[] raw,
-      @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
     this.project = project;
     this.parameters = parameters;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_mobilitymzregionextraction/MobilityMzRegionExtractionModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_mobilitymzregionextraction/MobilityMzRegionExtractionModule.java
@@ -32,6 +32,7 @@ import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
 import java.awt.geom.Point2D;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -70,7 +71,7 @@ public class MobilityMzRegionExtractionModule implements MZmineProcessingModule 
 
     final MemoryMapStorage storage = MemoryMapStorage.forFeatureList();
     Task task = new MobilityMzRegionExtractionTask(parameterSet, featureList,
-        MZmineCore.getProjectManager().getCurrentProject(), storage, new Date());
+        MZmineCore.getProjectManager().getCurrentProject(), storage, Instant.now());
     MZmineCore.getTaskController().addTask(task);
   }
 
@@ -95,7 +96,7 @@ public class MobilityMzRegionExtractionModule implements MZmineProcessingModule 
   @NotNull
   @Override
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     ModularFeatureList[] featureLists = parameters
         .getParameter(MobilityMzRegionExtractionParameters.featureLists).getValue()
         .getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_mobilitymzregionextraction/MobilityMzRegionExtractionTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_mobilitymzregionextraction/MobilityMzRegionExtractionTask.java
@@ -31,6 +31,7 @@ import io.github.mzmine.util.IonMobilityUtils;
 import io.github.mzmine.util.MemoryMapStorage;
 import java.awt.geom.Path2D;
 import java.awt.geom.Point2D;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -52,7 +53,7 @@ public class MobilityMzRegionExtractionTask extends AbstractTask {
 
   public MobilityMzRegionExtractionTask(ParameterSet parameterSet,
       ModularFeatureList originalFeatureList, MZmineProject project,
-      @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
     this.originalFeatureList = originalFeatureList;
     this.parameterSet = parameterSet;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_neutralloss/NeutralLossFilterModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_neutralloss/NeutralLossFilterModule.java
@@ -26,8 +26,8 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public class NeutralLossFilterModule implements MZmineProcessingModule {
@@ -57,7 +57,7 @@ public class NeutralLossFilterModule implements MZmineProcessingModule {
   @Override
   public @NotNull ExitCode runModule(@NotNull MZmineProject project,
       @NotNull ParameterSet parameters, @NotNull Collection<Task> tasks,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     FeatureList peakLists[] = parameters.getParameter(NeutralLossFilterParameters.PEAK_LISTS)
         .getValue().getMatchingFeatureLists();
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_neutralloss/NeutralLossFilterTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_neutralloss/NeutralLossFilterTask.java
@@ -41,6 +41,7 @@ import io.github.mzmine.util.SortingDirection;
 import io.github.mzmine.util.SortingProperty;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -75,7 +76,7 @@ public class NeutralLossFilterTask extends AbstractTask {
   private IMolecularFormula formula;
 
   NeutralLossFilterTask(MZmineProject project, FeatureList peakList, ParameterSet parameters,
-      @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     this.parameters = parameters;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_peakcomparisonrowfilter/PeakComparisonRowFilterModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_peakcomparisonrowfilter/PeakComparisonRowFilterModule.java
@@ -20,9 +20,9 @@ package io.github.mzmine.modules.dataprocessing.filter_peakcomparisonrowfilter;
 
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
 
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -56,7 +56,7 @@ public class PeakComparisonRowFilterModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     final FeatureList[] peakLists =
         parameters.getParameter(PeakComparisonRowFilterParameters.PEAK_LISTS).getValue()

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_peakcomparisonrowfilter/PeakComparisonRowFilterTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_peakcomparisonrowfilter/PeakComparisonRowFilterTask.java
@@ -31,6 +31,7 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -61,7 +62,7 @@ public class PeakComparisonRowFilterTask extends AbstractTask {
    * @param parameterSet task parameters.
    */
   public PeakComparisonRowFilterTask(final MZmineProject project, final FeatureList list,
-      final ParameterSet parameterSet, @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      final ParameterSet parameterSet, @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     // Initialize.

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_rowsfilter/RowsFilterModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_rowsfilter/RowsFilterModule.java
@@ -20,9 +20,9 @@ package io.github.mzmine.modules.dataprocessing.filter_rowsfilter;
 
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
 
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -55,7 +55,7 @@ public class RowsFilterModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     final FeatureList[] featureLists =
         parameters.getParameter(RowsFilterParameters.FEATURE_LISTS).getValue().getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_rowsfilter/RowsFilterTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_rowsfilter/RowsFilterTask.java
@@ -41,6 +41,7 @@ import io.github.mzmine.util.FormulaUtils;
 import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.RangeUtils;
 import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
+import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -75,7 +76,7 @@ public class RowsFilterTask extends AbstractTask {
    */
   public RowsFilterTask(final MZmineProject project, final FeatureList list,
       final ParameterSet parameterSet, @Nullable MemoryMapStorage storage,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     // Initialize.

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_scanfilters/ScanFilteringTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_scanfilters/ScanFilteringTask.java
@@ -32,6 +32,7 @@ import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.MemoryMapStorage;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Date;
 import java.util.logging.Logger;
 import javafx.collections.ObservableList;
@@ -65,7 +66,7 @@ class ScanFilteringTask extends AbstractTask {
    * @param storage
    */
   ScanFilteringTask(MZmineProject project, RawDataFile dataFile, ParameterSet parameters,
-      @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_scanfilters/ScanFiltersModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_scanfilters/ScanFiltersModule.java
@@ -19,9 +19,9 @@
 package io.github.mzmine.modules.dataprocessing.filter_scanfilters;
 
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
 
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -51,7 +51,7 @@ public class ScanFiltersModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     // one storage for all files in the same module call
     final MemoryMapStorage storage = MemoryMapStorage.forRawDataFile();
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_scansmoothing/ScanSmoothingModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_scansmoothing/ScanSmoothingModule.java
@@ -27,8 +27,8 @@ import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesParamete
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public class ScanSmoothingModule implements MZmineProcessingModule {
@@ -52,7 +52,7 @@ public class ScanSmoothingModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     // one storage for all files in the same module call
     MemoryMapStorage storage = MemoryMapStorage.forRawDataFile();
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_scansmoothing/ScanSmoothingTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_scansmoothing/ScanSmoothingTask.java
@@ -34,6 +34,7 @@ import io.github.mzmine.util.DataPointUtils;
 import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.scans.ScanUtils;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.logging.Logger;
@@ -68,7 +69,7 @@ public class ScanSmoothingTask extends AbstractTask {
    * @param storage
    */
   public ScanSmoothingTask(MZmineProject project, RawDataFile dataFile, ParameterSet parameters,
-      @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/PeakFinderModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/PeakFinderModule.java
@@ -20,9 +20,9 @@ package io.github.mzmine.modules.dataprocessing.gapfill_peakfinder;
 
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
 
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -51,7 +51,7 @@ public class PeakFinderModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     MemoryMapStorage storage = MemoryMapStorage.forFeatureList();
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/PeakFinderTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/PeakFinderTask.java
@@ -33,6 +33,7 @@ import io.github.mzmine.parameters.parametertypes.tolerances.RTTolerance;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -60,7 +61,7 @@ class PeakFinderTask extends AbstractTask {
   private int masterSample = 0;
   private boolean useParallelStream = false;
 
-  PeakFinderTask(MZmineProject project, FeatureList peakList, ParameterSet parameters, MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+  PeakFinderTask(MZmineProject project, FeatureList peakList, ParameterSet parameters, MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/multithreaded/MultiThreadPeakFinderMainTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/multithreaded/MultiThreadPeakFinderMainTask.java
@@ -32,6 +32,7 @@ import io.github.mzmine.taskcontrol.AllTasksFinishedListener;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -63,7 +64,7 @@ class MultiThreadPeakFinderMainTask extends AbstractTask {
    * @param batchTasks all sub tasks are registered to the batchtasks list
    */
   public MultiThreadPeakFinderMainTask(MZmineProject project, FeatureList peakList,
-      ParameterSet parameters, Collection<Task> batchTasks, @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      ParameterSet parameters, Collection<Task> batchTasks, @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
     this.project = project;
     this.peakList = (ModularFeatureList) peakList;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/multithreaded/MultiThreadPeakFinderModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/multithreaded/MultiThreadPeakFinderModule.java
@@ -20,8 +20,8 @@ package io.github.mzmine.modules.dataprocessing.gapfill_peakfinder.multithreaded
 
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -50,7 +50,7 @@ public class MultiThreadPeakFinderModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     FeatureList[] peakLists = parameters.getParameter(MultiThreadPeakFinderParameters.peakLists)
         .getValue().getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/multithreaded/MultiThreadPeakFinderTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/multithreaded/MultiThreadPeakFinderTask.java
@@ -40,6 +40,7 @@ import io.github.mzmine.parameters.parametertypes.tolerances.RTTolerance;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.IonMobilityUtils;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -65,7 +66,7 @@ class MultiThreadPeakFinderTask extends AbstractTask {
   private int taskIndex;
 
   MultiThreadPeakFinderTask(ModularFeatureList peakList, ModularFeatureList processedPeakList,
-      ParameterSet parameters, int start, int endexcl, int taskIndex, @NotNull Date moduleCallDate) {
+      ParameterSet parameters, int start, int endexcl, int taskIndex, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate);
 
     this.taskIndex = taskIndex;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_samerange/SameRangeGapFillerModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_samerange/SameRangeGapFillerModule.java
@@ -20,9 +20,9 @@ package io.github.mzmine.modules.dataprocessing.gapfill_samerange;
 
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
 
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -51,7 +51,7 @@ public class SameRangeGapFillerModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     FeatureList[] peakLists = parameters.getParameter(SameRangeGapFillerParameters.peakLists)
         .getValue().getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_samerange/SameRangeTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_samerange/SameRangeTask.java
@@ -39,6 +39,7 @@ import io.github.mzmine.util.FeatureConvertors;
 import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.RangeUtils;
 import io.github.mzmine.util.scans.ScanUtils;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -65,7 +66,7 @@ class SameRangeTask extends AbstractTask {
   private ParameterSet parameters;
 
   SameRangeTask(MZmineProject project, FeatureList peakList, ParameterSet parameters,
-      @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/group_metacorrelate/corrgrouping/CorrelateGroupingModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/group_metacorrelate/corrgrouping/CorrelateGroupingModule.java
@@ -26,8 +26,8 @@ import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public class CorrelateGroupingModule implements MZmineProcessingModule {
@@ -65,7 +65,7 @@ public class CorrelateGroupingModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull final ParameterSet parameters,
-      @NotNull final Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull final Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     ModularFeatureList[] featureLists = parameters
         .getParameter(CorrelateGroupingParameters.PEAK_LISTS).getValue().getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/group_metacorrelate/corrgrouping/CorrelateGroupingTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/group_metacorrelate/corrgrouping/CorrelateGroupingTask.java
@@ -48,7 +48,7 @@ import io.github.mzmine.util.SortingDirection;
 import io.github.mzmine.util.SortingProperty;
 import io.github.mzmine.util.maths.similarity.SimilarityMeasure;
 import java.text.MessageFormat;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -104,7 +104,7 @@ public class CorrelateGroupingTask extends AbstractTask {
    * @param featureList  feature list.
    */
   public CorrelateGroupingTask(final MZmineProject project, final ParameterSet parameterSet,
-      final ModularFeatureList featureList, @NotNull Date moduleCallDate) {
+      final ModularFeatureList featureList, @NotNull Instant moduleCallDate) {
     super(featureList.getMemoryMapStorage(), moduleCallDate);
     this.project = project;
     this.featureList = featureList;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/group_metacorrelate/export/ExportCorrAnnotationModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/group_metacorrelate/export/ExportCorrAnnotationModule.java
@@ -24,10 +24,9 @@ import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
-
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
+import java.time.Instant;
 import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 public class ExportCorrAnnotationModule implements MZmineProcessingModule {
 
@@ -61,7 +60,7 @@ public class ExportCorrAnnotationModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull final ParameterSet parameters,
-      @NotNull final Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull final Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     tasks.add(new ExportCorrAnnotationTask(parameters,
         parameters.getParameter(ExportCorrAnnotationParameters.featureLists).getValue()
             .getMatchingFeatureLists(), moduleCallDate));

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/group_metacorrelate/export/ExportCorrAnnotationTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/group_metacorrelate/export/ExportCorrAnnotationTask.java
@@ -44,10 +44,10 @@ import io.github.mzmine.util.io.TxtWriter;
 import java.io.File;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -85,7 +85,7 @@ public class ExportCorrAnnotationTask extends AbstractTask {
    * @param parameterSet the parameters.
    */
   public ExportCorrAnnotationTask(final ParameterSet parameterSet,
-      final ModularFeatureList[] featureLists, @NotNull Date moduleCallDate) {
+      final ModularFeatureList[] featureLists, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate);
     this.featureLists = featureLists;
 
@@ -107,7 +107,7 @@ public class ExportCorrAnnotationTask extends AbstractTask {
    */
   public ExportCorrAnnotationTask(FeatureList[] featureLists, File filename, double minR,
       FeatureListRowsFilter filter, boolean exportAnnotationEdges, boolean exportIinRelationships,
-      boolean mergeLists, boolean allInOneFile, @NotNull Date moduleCallDate) {
+      boolean mergeLists, boolean allInOneFile, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate);
     this.featureLists = featureLists;
     this.filename = filename;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/group_metacorrelate/msms/similarity/MS2SimilarityModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/group_metacorrelate/msms/similarity/MS2SimilarityModule.java
@@ -24,8 +24,8 @@ import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public class MS2SimilarityModule implements MZmineProcessingModule {
@@ -62,7 +62,7 @@ public class MS2SimilarityModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull final ParameterSet parameters,
-      @NotNull final Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull final Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     ModularFeatureList[] featureLists = parameters
         .getParameter(MS2SimilarityParameters.FEATURE_LISTS)

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/group_metacorrelate/msms/similarity/MS2SimilarityTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/group_metacorrelate/msms/similarity/MS2SimilarityTask.java
@@ -43,6 +43,7 @@ import io.github.mzmine.util.maths.similarity.Similarity;
 import io.github.mzmine.util.scans.ScanAlignment;
 import io.github.mzmine.util.scans.ScanMZDiffConverter;
 import java.text.MessageFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -84,7 +85,7 @@ public class MS2SimilarityTask extends AbstractTask {
 
 
   public MS2SimilarityTask(final ParameterSet parameterSet,
-      @Nullable ModularFeatureList featureList, @NotNull Date moduleCallDate) {
+      @Nullable ModularFeatureList featureList, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate);
     this.featureList = featureList;
     mzTolerance = parameterSet.getParameter(MS2SimilarityParameters.MZ_TOLERANCE).getValue();
@@ -116,7 +117,7 @@ public class MS2SimilarityTask extends AbstractTask {
    * Create the task on set of rows
    */
   public MS2SimilarityTask(final ParameterSet parameters, @Nullable ModularFeatureList featureList,
-      List<FeatureListRow> rows, @NotNull Date moduleCallDate) {
+      List<FeatureListRow> rows, @NotNull Instant moduleCallDate) {
     this(parameters, featureList, moduleCallDate);
     this.rows = rows;
   }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_adductsearch/AdductSearchModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_adductsearch/AdductSearchModule.java
@@ -18,18 +18,16 @@
 
 package io.github.mzmine.modules.dataprocessing.id_adductsearch;
 
-import io.github.mzmine.datamodel.features.FeatureList;
-import java.util.Collection;
-
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
-
 import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 public class AdductSearchModule implements MZmineProcessingModule {
 
@@ -65,7 +63,7 @@ public class AdductSearchModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull final ParameterSet parameters,
-      @NotNull final Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull final Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     for (final FeatureList peakList : parameters.getParameter(AdductSearchParameters.PEAK_LISTS)
         .getValue().getMatchingFeatureLists()) {

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_adductsearch/AdductSearchTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_adductsearch/AdductSearchTask.java
@@ -26,19 +26,19 @@ import static io.github.mzmine.modules.dataprocessing.id_adductsearch.AdductSear
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
-import io.github.mzmine.util.FeatureListRowSorter;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.parameters.parametertypes.tolerances.RTTolerance;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import io.github.mzmine.util.FeatureListRowSorter;
 import io.github.mzmine.util.SortingDirection;
 import io.github.mzmine.util.SortingProperty;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 
 public class AdductSearchTask extends AbstractTask {
@@ -63,7 +63,7 @@ public class AdductSearchTask extends AbstractTask {
    * @param parameterSet the parameters.
    * @param list feature list.
    */
-  public AdductSearchTask(final ParameterSet parameterSet, final FeatureList list, @NotNull Date moduleCallDate) {
+  public AdductSearchTask(final ParameterSet parameterSet, final FeatureList list, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
 
     peakList = list;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_camera/CameraSearchModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_camera/CameraSearchModule.java
@@ -24,19 +24,17 @@
 
 package io.github.mzmine.modules.dataprocessing.id_camera;
 
-import io.github.mzmine.datamodel.features.FeatureList;
-import io.github.mzmine.util.MemoryMapStorage;
-import java.util.Collection;
-
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
-
 import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Uses CAMERA to form pseudo-spectra.
@@ -62,7 +60,7 @@ public class CameraSearchModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     FeatureList peakLists[] = parameters.getParameter(CameraSearchParameters.PEAK_LISTS).getValue()
         .getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_camera/CameraSearchTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_camera/CameraSearchTask.java
@@ -24,18 +24,39 @@
 
 package io.github.mzmine.modules.dataprocessing.id_camera;
 
+import com.google.common.collect.Range;
+import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.FeatureIdentity;
+import io.github.mzmine.datamodel.IsotopePattern;
+import io.github.mzmine.datamodel.IsotopePattern.IsotopePatternStatus;
+import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
+import io.github.mzmine.datamodel.impl.SimpleDataPoint;
 import io.github.mzmine.datamodel.impl.SimpleFeatureIdentity;
+import io.github.mzmine.datamodel.impl.SimpleIsotopePattern;
+import io.github.mzmine.gui.Desktop;
+import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
+import io.github.mzmine.taskcontrol.AbstractTask;
+import io.github.mzmine.taskcontrol.TaskStatus;
+import io.github.mzmine.util.DataPointSorter;
 import io.github.mzmine.util.MemoryMapStorage;
+import io.github.mzmine.util.R.REngineType;
+import io.github.mzmine.util.R.RSessionWrapper;
+import io.github.mzmine.util.R.RSessionWrapperException;
+import io.github.mzmine.util.SortingDirection;
+import io.github.mzmine.util.SortingProperty;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -47,27 +68,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import com.google.common.collect.Range;
-import io.github.mzmine.datamodel.DataPoint;
-import io.github.mzmine.datamodel.IsotopePattern;
-import io.github.mzmine.datamodel.IsotopePattern.IsotopePatternStatus;
-import io.github.mzmine.datamodel.MZmineProject;
-import io.github.mzmine.datamodel.RawDataFile;
-import io.github.mzmine.datamodel.Scan;
-import io.github.mzmine.datamodel.impl.SimpleDataPoint;
-import io.github.mzmine.datamodel.impl.SimpleIsotopePattern;
-import io.github.mzmine.gui.Desktop;
-import io.github.mzmine.main.MZmineCore;
-import io.github.mzmine.parameters.ParameterSet;
-import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
-import io.github.mzmine.taskcontrol.AbstractTask;
-import io.github.mzmine.taskcontrol.TaskStatus;
-import io.github.mzmine.util.DataPointSorter;
-import io.github.mzmine.util.SortingDirection;
-import io.github.mzmine.util.SortingProperty;
-import io.github.mzmine.util.R.REngineType;
-import io.github.mzmine.util.R.RSessionWrapper;
-import io.github.mzmine.util.R.RSessionWrapperException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -129,7 +129,7 @@ public class CameraSearchTask extends AbstractTask {
   private REngineType rEngineType;
 
   public CameraSearchTask(final MZmineProject project, final ParameterSet parameters,
-      final FeatureList list, @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      final FeatureList list, @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     // Initialize.

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_ccscalc/CCSCalcModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_ccscalc/CCSCalcModule.java
@@ -25,8 +25,8 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -70,7 +70,7 @@ public class CCSCalcModule implements MZmineProcessingModule {
   @NotNull
   @Override
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     Task task = new CCSCalcTask(project, parameters, MemoryMapStorage.forFeatureList(), moduleCallDate);
     tasks.add(task);
     return ExitCode.OK;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_ccscalc/CCSCalcTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_ccscalc/CCSCalcTask.java
@@ -29,7 +29,7 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.MemoryMapStorage;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -55,7 +55,7 @@ public class CCSCalcTask extends AbstractTask {
   private int annotatedFeatures;
 
   public CCSCalcTask(MZmineProject project, ParameterSet parameters,
-      @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
     this.assumeChargeState = parameters.getParameter(CCSCalcParameters.assumeChargeStage)
         .getValue();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_cliquems/CliqueMSModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_cliquems/CliqueMSModule.java
@@ -26,8 +26,8 @@ import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public class CliqueMSModule implements MZmineProcessingModule {
@@ -52,7 +52,7 @@ public class CliqueMSModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     FeatureList peakLists[] = parameters.getParameter(CliqueMSParameters.PEAK_LISTS).getValue()
         .getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_cliquems/CliqueMSTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_cliquems/CliqueMSTask.java
@@ -33,7 +33,7 @@ import io.github.mzmine.modules.dataprocessing.id_cliquems.cliquemsimplementatio
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
-import java.util.Date;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -66,7 +66,7 @@ public class CliqueMSTask extends AbstractTask {
   private final ParameterSet parameters;
 
   public CliqueMSTask(final ParameterSet parameters,
-      final FeatureList list, @NotNull Date moduleCallDate) {
+      final FeatureList list, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     this.parameters = parameters;
     peakList = list;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_complexsearch/ComplexSearchModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_complexsearch/ComplexSearchModule.java
@@ -18,18 +18,16 @@
 
 package io.github.mzmine.modules.dataprocessing.id_complexsearch;
 
-import io.github.mzmine.datamodel.features.FeatureList;
-import java.util.Collection;
-
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
-
 import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 public class ComplexSearchModule implements MZmineProcessingModule {
 
@@ -50,7 +48,7 @@ public class ComplexSearchModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     FeatureList peakLists[] = parameters.getParameter(ComplexSearchParameters.peakLists).getValue()
         .getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_complexsearch/ComplexSearchTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_complexsearch/ComplexSearchTask.java
@@ -18,23 +18,23 @@
 
 package io.github.mzmine.modules.dataprocessing.id_complexsearch;
 
+import com.google.common.collect.Range;
+import io.github.mzmine.datamodel.IonizationType;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
-import io.github.mzmine.util.FeatureListRowSorter;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.logging.Logger;
-import com.google.common.collect.Range;
-import io.github.mzmine.datamodel.IonizationType;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.parameters.parametertypes.tolerances.RTTolerance;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import io.github.mzmine.util.FeatureListRowSorter;
 import io.github.mzmine.util.SortingDirection;
 import io.github.mzmine.util.SortingProperty;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 
 public class ComplexSearchTask extends AbstractTask {
@@ -54,7 +54,7 @@ public class ComplexSearchTask extends AbstractTask {
    * @param parameters
    * @param peakList
    */
-  public ComplexSearchTask(ParameterSet parameters, FeatureList peakList, @NotNull Date moduleCallDate) {
+  public ComplexSearchTask(ParameterSet parameters, FeatureList peakList, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
 
     this.peakList = peakList;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_formula_sort/FormulaSortModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_formula_sort/FormulaSortModule.java
@@ -17,16 +17,16 @@
  */
 package io.github.mzmine.modules.dataprocessing.id_formula_sort;
 
-import io.github.mzmine.datamodel.features.ModularFeatureList;
-import java.util.Collection;
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
 import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 public class FormulaSortModule implements MZmineProcessingModule {
 
@@ -57,7 +57,7 @@ public class FormulaSortModule implements MZmineProcessingModule {
   @Override
   public @NotNull ExitCode runModule(@NotNull MZmineProject project,
       @NotNull ParameterSet parameters, @NotNull Collection<Task> tasks,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     ModularFeatureList featureLists[] =
         parameters.getParameter(FormulaSortParameters.FEATURE_LISTS).getValue().getMatchingFeatureLists();
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_formula_sort/FormulaSortTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_formula_sort/FormulaSortTask.java
@@ -24,7 +24,7 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.FormulaUtils;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -44,7 +44,7 @@ public class FormulaSortTask extends AbstractTask {
   /**
    * @param parameters
    */
-  public FormulaSortTask(ParameterSet parameters, @NotNull Date moduleCallDate) {
+  public FormulaSortTask(ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     weightIsotopeScore =
         parameters.getParameter(FormulaSortParameters.ISOTOPE_SCORE_WEIGHT).getValue().floatValue();
@@ -56,7 +56,7 @@ public class FormulaSortTask extends AbstractTask {
   }
 
   public FormulaSortTask(ModularFeatureList featureList, ParameterSet parameters,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     this(parameters, moduleCallDate);
     this.featureList = featureList;
     message = "Sorting formula lists of feature list " + featureList.getName();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_formulaprediction/FormulaPredictionModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_formulaprediction/FormulaPredictionModule.java
@@ -18,18 +18,17 @@
 
 package io.github.mzmine.modules.dataprocessing.id_formulaprediction;
 
-import io.github.mzmine.datamodel.features.FeatureListRow;
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
-
 import io.github.mzmine.datamodel.IonizationType;
 import io.github.mzmine.datamodel.PolarityType;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.MZmineModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
+import org.jetbrains.annotations.NotNull;
 
 public class FormulaPredictionModule implements MZmineModule {
 
@@ -72,7 +71,7 @@ public class FormulaPredictionModule implements MZmineModule {
     }
 
     SingleRowPredictionTask newTask =
-        new SingleRowPredictionTask(parameters.cloneParameterSet(), row, new Date());
+        new SingleRowPredictionTask(parameters.cloneParameterSet(), row, Instant.now());
 
     // execute the sequence
     MZmineCore.getTaskController().addTask(newTask);

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_formulaprediction/SingleRowPredictionTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_formulaprediction/SingleRowPredictionTask.java
@@ -40,6 +40,7 @@ import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.FormulaUtils;
+import java.time.Instant;
 import java.util.Date;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -77,7 +78,7 @@ public class SingleRowPredictionTask extends AbstractTask {
 
 
   SingleRowPredictionTask(ParameterSet parameters, FeatureListRow peakListRow,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
 
     searchedMass = parameters.getParameter(FormulaPredictionParameters.neutralMass).getValue();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_formulapredictionfeaturelist/FormulaPredictionFeatureListModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_formulapredictionfeaturelist/FormulaPredictionFeatureListModule.java
@@ -17,18 +17,16 @@
  */
 package io.github.mzmine.modules.dataprocessing.id_formulapredictionfeaturelist;
 
-import io.github.mzmine.datamodel.features.ModularFeatureList;
-import java.util.Collection;
-
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
-
 import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 public class FormulaPredictionFeatureListModule implements MZmineProcessingModule {
 
@@ -57,7 +55,7 @@ public class FormulaPredictionFeatureListModule implements MZmineProcessingModul
   @Override
   public @NotNull ExitCode runModule(@NotNull MZmineProject project,
       @NotNull ParameterSet parameters, @NotNull Collection<Task> tasks,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     ModularFeatureList featureLists[] = parameters.getParameter(FormulaPredictionFeatureListParameters.FEATURE_LISTS)
         .getValue().getMatchingFeatureLists();
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_formulapredictionfeaturelist/FormulaPredictionFeatureListTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_formulapredictionfeaturelist/FormulaPredictionFeatureListTask.java
@@ -41,8 +41,8 @@ import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.FormulaUtils;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -87,7 +87,7 @@ public class FormulaPredictionFeatureListTask extends AbstractTask {
    * @param parameters
    * @param featureList
    */
-  FormulaPredictionFeatureListTask(ModularFeatureList featureList, ParameterSet parameters, @NotNull Date moduleCallDate) {
+  FormulaPredictionFeatureListTask(ModularFeatureList featureList, ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
 
     this.featureList = featureList;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_fragmentsearch/FragmentSearchModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_fragmentsearch/FragmentSearchModule.java
@@ -18,18 +18,16 @@
 
 package io.github.mzmine.modules.dataprocessing.id_fragmentsearch;
 
-import io.github.mzmine.datamodel.features.FeatureList;
-import java.util.Collection;
-
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
-
 import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 public class FragmentSearchModule implements MZmineProcessingModule {
 
@@ -50,7 +48,7 @@ public class FragmentSearchModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     FeatureList peakLists[] = parameters.getParameter(FragmentSearchParameters.peakLists).getValue()
         .getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_fragmentsearch/FragmentSearchTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_fragmentsearch/FragmentSearchTask.java
@@ -18,9 +18,6 @@
 
 package io.github.mzmine.modules.dataprocessing.id_fragmentsearch;
 
-import java.util.Arrays;
-import java.util.Date;
-import java.util.logging.Logger;
 import com.google.common.collect.Range;
 import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.Scan;
@@ -37,6 +34,9 @@ import io.github.mzmine.util.FeatureListRowSorter;
 import io.github.mzmine.util.SortingDirection;
 import io.github.mzmine.util.SortingProperty;
 import io.github.mzmine.util.scans.ScanUtils;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 
 public class FragmentSearchTask extends AbstractTask {
@@ -56,7 +56,7 @@ public class FragmentSearchTask extends AbstractTask {
    * @param parameters
    * @param peakList
    */
-  public FragmentSearchTask(ParameterSet parameters, FeatureList peakList, @NotNull Date moduleCallDate) {
+  public FragmentSearchTask(ParameterSet parameters, FeatureList peakList, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
 
     this.peakList = peakList;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_gnpsresultsimport/GNPSResultsImportModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_gnpsresultsimport/GNPSResultsImportModule.java
@@ -25,8 +25,8 @@ import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public class GNPSResultsImportModule implements MZmineProcessingModule {
@@ -50,7 +50,7 @@ public class GNPSResultsImportModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     // max 1
     ModularFeatureList featureList = parameters.getParameter(GNPSResultsImportParameters.FEATURE_LIST)

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_gnpsresultsimport/GNPSResultsImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_gnpsresultsimport/GNPSResultsImportTask.java
@@ -37,8 +37,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.MessageFormat;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
@@ -70,7 +70,7 @@ public class GNPSResultsImportTask extends AbstractTask {
   private final FeatureListRowIdCache rowIdCache;
 
   public GNPSResultsImportTask(ParameterSet parameters, ModularFeatureList featureList,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     this.parameters = parameters;
     this.featureList = featureList;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/addionannotations/AddIonNetworkingModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/addionannotations/AddIonNetworkingModule.java
@@ -26,10 +26,9 @@ import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
-
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
+import java.time.Instant;
 import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 public class AddIonNetworkingModule implements MZmineProcessingModule {
 
@@ -62,7 +61,7 @@ public class AddIonNetworkingModule implements MZmineProcessingModule {
   @NotNull
   @Override
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     ModularFeatureList[] pkl = parameters.getParameter(AddIonNetworkingParameters.PEAK_LISTS).getValue()
         .getMatchingFeatureLists();
     for (ModularFeatureList p : pkl)

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/addionannotations/AddIonNetworkingTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/addionannotations/AddIonNetworkingTask.java
@@ -38,7 +38,7 @@ import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.SortingDirection;
 import io.github.mzmine.util.SortingProperty;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
@@ -70,7 +70,7 @@ public class AddIonNetworkingTask extends AbstractTask {
    * @param parameterSet the parameters.
    */
   public AddIonNetworkingTask(final MZmineProject project, final ParameterSet parameterSet,
-      final ModularFeatureList featureLists, @NotNull Date moduleCallDate) {
+      final ModularFeatureList featureLists, @NotNull Instant moduleCallDate) {
     super(featureLists.getMemoryMapStorage(), moduleCallDate);
     this.project = project;
     this.featureList = featureLists;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/checkmsms/IonNetworkMSMSCheckModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/checkmsms/IonNetworkMSMSCheckModule.java
@@ -26,8 +26,8 @@ import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public class IonNetworkMSMSCheckModule implements MZmineProcessingModule {
@@ -65,7 +65,7 @@ public class IonNetworkMSMSCheckModule implements MZmineProcessingModule {
   @NotNull
   @Override
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     ModularFeatureList[] pkl = parameters.getParameter(IonNetworkMSMSCheckParameters.PEAK_LISTS)
         .getValue()

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/checkmsms/IonNetworkMSMSCheckTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/checkmsms/IonNetworkMSMSCheckTask.java
@@ -40,6 +40,7 @@ import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import java.text.MessageFormat;
+import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.logging.Logger;
@@ -66,7 +67,7 @@ public class IonNetworkMSMSCheckTask extends AbstractTask {
    * @param parameterSet the parameters.
    */
   public IonNetworkMSMSCheckTask(final MZmineProject project, final ParameterSet parameterSet,
-      final ModularFeatureList featureLists, @NotNull Date moduleCallDate) {
+      final ModularFeatureList featureLists, @NotNull Instant moduleCallDate) {
     super(featureLists.getMemoryMapStorage(), moduleCallDate);
     this.featureList = featureLists;
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/clearionids/ClearIonIdentitiesModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/clearionids/ClearIonIdentitiesModule.java
@@ -26,10 +26,9 @@ import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
-
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
+import java.time.Instant;
 import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 public class ClearIonIdentitiesModule implements MZmineProcessingModule {
 
@@ -64,7 +63,7 @@ public class ClearIonIdentitiesModule implements MZmineProcessingModule {
   @NotNull
   @Override
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     ModularFeatureList[] pkl = parameters.getParameter(ClearIonIdentitiesParameters.PEAK_LISTS).getValue().getMatchingFeatureLists();
     for (ModularFeatureList p : pkl)

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/clearionids/ClearIonIdentitiesTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/clearionids/ClearIonIdentitiesTask.java
@@ -27,8 +27,7 @@ import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
-
-import java.util.Date;
+import java.time.Instant;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -51,7 +50,7 @@ public class ClearIonIdentitiesTask extends AbstractTask {
    * @param parameterSet the parameters.
    */
   public ClearIonIdentitiesTask(final MZmineProject project, final ParameterSet parameterSet,
-      final ModularFeatureList featureLists, @NotNull Date moduleCallDate) {
+      final ModularFeatureList featureLists, @NotNull Instant moduleCallDate) {
     super(featureLists.getMemoryMapStorage(), moduleCallDate);
     this.project = project;
     this.featureList = featureLists;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/formula/createavgformulas/CreateAvgNetworkFormulasModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/formula/createavgformulas/CreateAvgNetworkFormulasModule.java
@@ -25,10 +25,9 @@ import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
-
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
+import java.time.Instant;
 import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 public class CreateAvgNetworkFormulasModule implements MZmineProcessingModule {
 
@@ -61,7 +60,7 @@ public class CreateAvgNetworkFormulasModule implements MZmineProcessingModule {
   @Override
   public @NotNull
   ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     ModularFeatureList featureLists[] = parameters.getParameter(CreateAvgNetworkFormulasParameters.PEAK_LISTS)
         .getValue().getMatchingFeatureLists();
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/formula/createavgformulas/CreateAvgNetworkFormulasTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/formula/createavgformulas/CreateAvgNetworkFormulasTask.java
@@ -29,9 +29,9 @@ import io.github.mzmine.modules.dataprocessing.id_formulaprediction.ResultFormul
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -58,7 +58,7 @@ public class CreateAvgNetworkFormulasTask extends AbstractTask {
     message = "Creation of average molecular formulas for MS annotation networks";
   }*/
 
-  public CreateAvgNetworkFormulasTask(FormulaSortTask sorter, @NotNull Date moduleCallDate) {
+  public CreateAvgNetworkFormulasTask(FormulaSortTask sorter, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate);
     sortResults = sorter != null;
     this.sorter = sorter;
@@ -74,7 +74,7 @@ public class CreateAvgNetworkFormulasTask extends AbstractTask {
     message = "Creation of average molecular formulas for MS annotation networks";
   }*/
 
-  public CreateAvgNetworkFormulasTask(ModularFeatureList featureList, ParameterSet parameters, @NotNull Date moduleCallDate) {
+  public CreateAvgNetworkFormulasTask(ModularFeatureList featureList, ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(featureList.getMemoryMapStorage(), moduleCallDate);
     this.featureList = featureList;
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/formula/prediction/FormulaPredictionIonNetworkModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/formula/prediction/FormulaPredictionIonNetworkModule.java
@@ -25,10 +25,9 @@ import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
-
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
+import java.time.Instant;
 import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 public class FormulaPredictionIonNetworkModule implements MZmineProcessingModule {
 
@@ -61,7 +60,7 @@ public class FormulaPredictionIonNetworkModule implements MZmineProcessingModule
   @Override
   public @NotNull
   ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     ModularFeatureList featureLists[] =
         parameters.getParameter(FormulaPredictionIonNetworkParameters.PEAK_LISTS).getValue()
             .getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/formula/prediction/FormulaPredictionIonNetworkTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/formula/prediction/FormulaPredictionIonNetworkTask.java
@@ -45,8 +45,8 @@ import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import java.text.MessageFormat;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -90,7 +90,7 @@ public class FormulaPredictionIonNetworkTask extends AbstractTask {
   /**
    * @param parameters
    */
-  public FormulaPredictionIonNetworkTask(ModularFeatureList featureList, ParameterSet parameters, @NotNull Date moduleCallDate) {
+  public FormulaPredictionIonNetworkTask(ModularFeatureList featureList, ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(featureList.getMemoryMapStorage(), moduleCallDate);
     this.featureList = featureList;
     mzTolerance =

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/ionidnetworking/IonNetworkingModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/ionidnetworking/IonNetworkingModule.java
@@ -26,8 +26,8 @@ import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public class IonNetworkingModule implements MZmineProcessingModule {
@@ -64,7 +64,7 @@ public class IonNetworkingModule implements MZmineProcessingModule {
   @NotNull
   @Override
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull final ParameterSet parameters,
-      @NotNull final Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull final Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     ModularFeatureList[] pkl = parameters.getParameter(IonNetworkingParameters.PEAK_LISTS)
         .getValue()

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/ionidnetworking/IonNetworkingTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/ionidnetworking/IonNetworkingTask.java
@@ -35,6 +35,7 @@ import io.github.mzmine.parameters.parametertypes.ionidentity.IonLibraryParamete
 import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -72,7 +73,7 @@ public class IonNetworkingTask extends AbstractTask {
    * @param parameterSet the parameters.
    */
   public IonNetworkingTask(final MZmineProject project, final ParameterSet parameterSet,
-      final ModularFeatureList featureLists, MinimumFeatureFilter minFeaturesFilter, @NotNull Date moduleCallDate) {
+      final ModularFeatureList featureLists, MinimumFeatureFilter minFeaturesFilter, @NotNull Instant moduleCallDate) {
     super(featureLists.getMemoryMapStorage(), moduleCallDate);
     this.project = project;
     this.featureList = featureLists;
@@ -91,7 +92,7 @@ public class IonNetworkingTask extends AbstractTask {
   }
 
   public IonNetworkingTask(final MZmineProject project, final ParameterSet parameterSet,
-      final ModularFeatureList featureLists, @NotNull Date moduleCallDate) {
+      final ModularFeatureList featureLists, @NotNull Instant moduleCallDate) {
     this(project, parameterSet, featureLists, null, moduleCallDate);
   }
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/refinement/IonNetworkRefinementModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/refinement/IonNetworkRefinementModule.java
@@ -26,8 +26,8 @@ import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public class IonNetworkRefinementModule implements MZmineProcessingModule {
@@ -65,7 +65,7 @@ public class IonNetworkRefinementModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull final ParameterSet parameters,
-      @NotNull final Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull final Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     ModularFeatureList[] pkl = parameters.getParameter(IonNetworkRefinementParameters.PEAK_LISTS)
         .getValue()

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/refinement/IonNetworkRefinementTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/refinement/IonNetworkRefinementTask.java
@@ -31,6 +31,7 @@ import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -66,7 +67,7 @@ public class IonNetworkRefinementTask extends AbstractTask {
    * @param parameterSet the parameters.
    */
   public IonNetworkRefinementTask(final MZmineProject project, final ParameterSet parameterSet,
-      final ModularFeatureList featureLists, @NotNull Date moduleCallDate) {
+      final ModularFeatureList featureLists, @NotNull Instant moduleCallDate) {
     super(featureLists.getMemoryMapStorage(), moduleCallDate);
 
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/relations/IonNetRelationsModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/relations/IonNetRelationsModule.java
@@ -25,8 +25,8 @@ import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public class IonNetRelationsModule implements MZmineProcessingModule {
@@ -63,7 +63,7 @@ public class IonNetRelationsModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull final ParameterSet parameters,
-      @NotNull final Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull final Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     ModularFeatureList[] pkl = parameters.getParameter(IonNetRelationsParameters.PEAK_LISTS)
         .getValue()
         .getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/relations/IonNetRelationsTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_ion_identity_networking/relations/IonNetRelationsTask.java
@@ -33,6 +33,7 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.logging.Level;
@@ -61,7 +62,7 @@ public class IonNetRelationsTask extends AbstractTask {
    * @param parameterSet the parameters.
    */
   public IonNetRelationsTask(final MZmineProject project, final ParameterSet parameterSet,
-      final ModularFeatureList featureLists, @NotNull Date moduleCallDate) {
+      final ModularFeatureList featureLists, @NotNull Instant moduleCallDate) {
     super(featureLists.getMemoryMapStorage(), moduleCallDate);
 
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_isotopepeakscanner/IsotopePeakScannerModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_isotopepeakscanner/IsotopePeakScannerModule.java
@@ -20,8 +20,8 @@ package io.github.mzmine.modules.dataprocessing.id_isotopepeakscanner;
 
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -63,7 +63,7 @@ public class IsotopePeakScannerModule implements MZmineProcessingModule {
   @Override
   public @NotNull ExitCode runModule(@NotNull MZmineProject project,
       @NotNull ParameterSet parameters, @NotNull Collection<Task> tasks,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     FeatureList peakLists[] = parameters.getParameter(IsotopePeakScannerParameters.PEAK_LISTS)
         .getValue().getMatchingFeatureLists();
     final MemoryMapStorage storage = MemoryMapStorage.forFeatureList();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_isotopepeakscanner/IsotopePeakScannerTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_isotopepeakscanner/IsotopePeakScannerTask.java
@@ -50,6 +50,7 @@ import io.github.mzmine.util.SortingProperty;
 import io.github.mzmine.util.scans.ScanUtils;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -112,7 +113,7 @@ public class IsotopePeakScannerTask extends AbstractTask {
    * @param peakList
    */
   IsotopePeakScannerTask(MZmineProject project, FeatureList peakList, ParameterSet parameters,
-      @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
     this.parameters = parameters;
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_lipididentification/LipidSearchModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_lipididentification/LipidSearchModule.java
@@ -18,8 +18,8 @@
 
 package io.github.mzmine.modules.dataprocessing.id_lipididentification;
 
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.datamodel.features.FeatureList;
@@ -53,7 +53,7 @@ public class LipidSearchModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     FeatureList[] featureLists = parameters.getParameter(LipidSearchParameters.featureLists)
         .getValue().getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_lipididentification/LipidSearchTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_lipididentification/LipidSearchTask.java
@@ -42,6 +42,7 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
@@ -86,7 +87,7 @@ public class LipidSearchTask extends AbstractTask {
    * @param parameters
    * @param featureList
    */
-  public LipidSearchTask(ParameterSet parameters, FeatureList featureList, @NotNull Date moduleCallDate) {
+  public LipidSearchTask(ParameterSet parameters, FeatureList featureList, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate);
     this.featureList = featureList;
     this.parameters = parameters;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_localcsvsearch/LocalCSVDatabaseSearchModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_localcsvsearch/LocalCSVDatabaseSearchModule.java
@@ -19,9 +19,9 @@
 package io.github.mzmine.modules.dataprocessing.id_localcsvsearch;
 
 import io.github.mzmine.datamodel.features.FeatureList;
+import java.time.Instant;
 import java.util.Collection;
 
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -50,7 +50,7 @@ public class LocalCSVDatabaseSearchModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     FeatureList peakLists[] = parameters.getParameter(LocalCSVDatabaseSearchParameters.peakLists)
         .getValue().getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_localcsvsearch/LocalCSVDatabaseSearchTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_localcsvsearch/LocalCSVDatabaseSearchTask.java
@@ -24,6 +24,7 @@ import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
 import io.github.mzmine.datamodel.impl.SimpleFeatureIdentity;
 import java.io.File;
 import java.io.FileReader;
+import java.time.Instant;
 import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -53,7 +54,7 @@ class LocalCSVDatabaseSearchTask extends AbstractTask {
   private RTTolerance rtTolerance;
   private ParameterSet parameters;
 
-  LocalCSVDatabaseSearchTask(FeatureList peakList, ParameterSet parameters, @NotNull Date moduleCallDate) {
+  LocalCSVDatabaseSearchTask(FeatureList peakList, ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
 
     this.peakList = peakList;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_ms2search/Ms2SearchModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_ms2search/Ms2SearchModule.java
@@ -19,9 +19,9 @@
 package io.github.mzmine.modules.dataprocessing.id_ms2search;
 
 import io.github.mzmine.datamodel.features.FeatureList;
+import java.time.Instant;
 import java.util.Collection;
 
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -50,7 +50,7 @@ public class Ms2SearchModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     FeatureList peakList1[] =
         parameters.getParameter(Ms2SearchParameters.peakList1).getValue().getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_ms2search/Ms2SearchTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_ms2search/Ms2SearchTask.java
@@ -30,6 +30,7 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -54,7 +55,7 @@ class Ms2SearchTask extends AbstractTask {
   /**
    * @param parameters
    */
-  public Ms2SearchTask(ParameterSet parameters, FeatureList peakList1, FeatureList peakList2, @NotNull Date moduleCallDate) {
+  public Ms2SearchTask(ParameterSet parameters, FeatureList peakList1, FeatureList peakList2, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
 
     this.peakList1 = peakList1;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_nist/NistMsSearchModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_nist/NistMsSearchModule.java
@@ -20,6 +20,7 @@ package io.github.mzmine.modules.dataprocessing.id_nist;
 
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Date;
 import org.jetbrains.annotations.NotNull;
@@ -66,7 +67,7 @@ public class NistMsSearchModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     for (final FeatureList peakList : parameters.getParameter(NistMsSearchParameters.PEAK_LISTS)
         .getValue().getMatchingFeatureLists()) {
@@ -89,7 +90,7 @@ public class NistMsSearchModule implements MZmineProcessingModule {
         MZmineCore.getConfiguration().getModuleParameters(NistMsSearchModule.class);
     if (parameters.showSetupDialog(true) == ExitCode.OK) {
 
-      MZmineCore.getTaskController().addTask(new NistMsSearchTask(row, peakList, parameters, new Date()));
+      MZmineCore.getTaskController().addTask(new NistMsSearchTask(row, peakList, parameters, Instant.now()));
     }
   }
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_nist/NistMsSearchTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_nist/NistMsSearchTask.java
@@ -48,6 +48,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Hashtable;
@@ -142,7 +143,7 @@ public class NistMsSearchTask extends AbstractTask {
    * @param list   the feature list to search.
    * @param params search parameters.
    */
-  public NistMsSearchTask(final FeatureList list, final ParameterSet params, @NotNull Date moduleCallDate) {
+  public NistMsSearchTask(final FeatureList list, final ParameterSet params, @NotNull Instant moduleCallDate) {
 
     this(null, list, params, moduleCallDate);
   }
@@ -155,7 +156,7 @@ public class NistMsSearchTask extends AbstractTask {
    * @param params search parameters.
    */
   public NistMsSearchTask(final FeatureListRow row, final FeatureList list,
-      final ParameterSet params, @NotNull Date moduleCallDate) {
+      final ParameterSet params, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
 
     // Initialize.

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_onlinecompounddb/OnlineDBSearchModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_onlinecompounddb/OnlineDBSearchModule.java
@@ -20,6 +20,7 @@ package io.github.mzmine.modules.dataprocessing.id_onlinecompounddb;
 
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Date;
 import org.jetbrains.annotations.NotNull;
@@ -53,7 +54,7 @@ public class OnlineDBSearchModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     final FeatureList[] featureLists = parameters
         .getParameter(PeakListIdentificationParameters.peakLists).getValue()
@@ -72,7 +73,7 @@ public class OnlineDBSearchModule implements MZmineProcessingModule {
    * @param row the feature list row.
    */
   public static void showSingleRowIdentificationDialog(final FeatureListRow row,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
 
     assert Platform.isFxApplicationThread();
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_onlinecompounddb/PeakListIdentificationTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_onlinecompounddb/PeakListIdentificationTask.java
@@ -25,6 +25,7 @@ import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
 import io.github.mzmine.util.FeatureListRowSorter;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.logging.Level;
@@ -74,7 +75,7 @@ public class PeakListIdentificationTask extends AbstractTask {
    * @param parameters task parameters.
    * @param list feature list to operate on.
    */
-  PeakListIdentificationTask(final ParameterSet parameters, final FeatureList list, @NotNull Date moduleCallDate) {
+  PeakListIdentificationTask(final ParameterSet parameters, final FeatureList list, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
 
     peakList = list;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_onlinecompounddb/SingleRowIdentificationTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_onlinecompounddb/SingleRowIdentificationTask.java
@@ -27,6 +27,7 @@ import static io.github.mzmine.modules.dataprocessing.id_onlinecompounddb.Single
 import io.github.mzmine.datamodel.FeatureIdentity;
 import io.github.mzmine.datamodel.features.FeatureListRow;
 import java.text.NumberFormat;
+import java.time.Instant;
 import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -74,7 +75,7 @@ public class SingleRowIdentificationTask extends AbstractTask {
    * @param parameters task parameters.
    * @param peakListRow peak-list row to identify.
    */
-  public SingleRowIdentificationTask(ParameterSet parameters, FeatureListRow peakListRow, @NotNull Date moduleCallDate) {
+  public SingleRowIdentificationTask(ParameterSet parameters, FeatureListRow peakListRow, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
 
     this.peakListRow = peakListRow;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_precursordbsearch/PrecursorDBSearchModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_precursordbsearch/PrecursorDBSearchModule.java
@@ -19,8 +19,8 @@
 package io.github.mzmine.modules.dataprocessing.id_precursordbsearch;
 
 import io.github.mzmine.datamodel.features.FeatureList;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -49,7 +49,7 @@ public class PrecursorDBSearchModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     FeatureList peakLists[] = parameters.getParameter(PrecursorDBSearchParameters.peakLists).getValue()
         .getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_precursordbsearch/PrecursorDBSearchTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_precursordbsearch/PrecursorDBSearchTask.java
@@ -24,6 +24,7 @@ import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
 import io.github.mzmine.util.spectraldb.entry.PrecursorDBFeatureIdentity;
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -66,7 +67,7 @@ class PrecursorDBSearchTask extends AbstractTask {
   private int totalTasks;
   private AtomicInteger matches = new AtomicInteger(0);
 
-  public PrecursorDBSearchTask(FeatureList peakList, ParameterSet parameters, @NotNull Date moduleCallDate) {
+  public PrecursorDBSearchTask(FeatureList peakList, ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     this.peakList = peakList;
     this.parameters = parameters;
@@ -161,7 +162,7 @@ class PrecursorDBSearchTask extends AbstractTask {
       @Override
       public void processNextEntries(List<SpectralDBEntry> list, int alreadyProcessed) {
 
-        AbstractTask task = new AbstractTask(null, new Date()) {
+        AbstractTask task = new AbstractTask(null, Instant.now()) {
           private int total = peakList.getNumberOfRows();
           private int done = 0;
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_sirius/FingerIdWebMethodTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_sirius/FingerIdWebMethodTask.java
@@ -18,13 +18,6 @@
 
 package io.github.mzmine.modules.dataprocessing.id_sirius;
 
-import java.util.Date;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.logging.Logger;
-import org.jetbrains.annotations.NotNull;
-import org.openscience.cdk.tools.manipulator.MolecularFormulaManipulator;
 import de.unijena.bioinf.ChemistryBase.ms.Ms2Experiment;
 import io.github.msdk.MSDKException;
 import io.github.msdk.datamodel.IonAnnotation;
@@ -33,6 +26,13 @@ import io.github.msdk.id.sirius.SiriusIonAnnotation;
 import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import java.time.Instant;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.logging.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.openscience.cdk.tools.manipulator.MolecularFormulaManipulator;
 
 /**
  * Class FingerIdWebMethodTask Wrapper around FingerIdWebMethod - calculates the result as a
@@ -70,7 +70,7 @@ public class FingerIdWebMethodTask extends AbstractTask {
    * @param row - one of possible result containers
    */
   private FingerIdWebMethodTask(SiriusIonAnnotation annotation, Ms2Experiment experiment,
-      Integer candidatesAmount, ResultWindowFX windowFX, FeatureListRow row, @NotNull Date moduleCallDate) {
+      Integer candidatesAmount, ResultWindowFX windowFX, FeatureListRow row, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     if (windowFX == null && row == null)
       throw new RuntimeException("Only one result container can be null at a time");
@@ -101,7 +101,7 @@ public class FingerIdWebMethodTask extends AbstractTask {
    * @param windowFX - Result container for SingleRowIdentificationTask
    */
   public FingerIdWebMethodTask(SiriusIonAnnotation annotation, Ms2Experiment experiment,
-      Integer candidatesAmount, ResultWindowFX windowFX, @NotNull Date moduleCallDate) {
+      Integer candidatesAmount, ResultWindowFX windowFX, @NotNull Instant moduleCallDate) {
     this(annotation, experiment, candidatesAmount, windowFX, null, moduleCallDate);
   }
 
@@ -114,7 +114,7 @@ public class FingerIdWebMethodTask extends AbstractTask {
    * @param row - Result container for PeakListIdentificationTask
    */
   public FingerIdWebMethodTask(SiriusIonAnnotation annotation, Ms2Experiment experiment,
-      Integer candidatesAmount, FeatureListRow row, @NotNull Date moduleCallDate) {
+      Integer candidatesAmount, FeatureListRow row, @NotNull Instant moduleCallDate) {
     this(annotation, experiment, candidatesAmount, null, row, moduleCallDate);
   }
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_sirius/PeakListIdentificationTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_sirius/PeakListIdentificationTask.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.modules.dataprocessing.id_sirius;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -65,7 +66,7 @@ public class PeakListIdentificationTask extends AbstractTask {
    * @param parameters task parameters.
    * @param list feature list to operate on.
    */
-  PeakListIdentificationTask(final ParameterSet parameters, final FeatureList list, @NotNull Date moduleCallDate) {
+  PeakListIdentificationTask(final ParameterSet parameters, final FeatureList list, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     peakList = list;
     numItems = 0;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_sirius/SingleRowIdentificationTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_sirius/SingleRowIdentificationTask.java
@@ -26,6 +26,7 @@ import static io.github.mzmine.modules.dataprocessing.id_sirius.SiriusParameters
 import static io.github.mzmine.modules.dataprocessing.id_sirius.SiriusParameters.MZ_TOLERANCE;
 import static io.github.mzmine.modules.dataprocessing.id_sirius.SiriusParameters.ionizationType;
 import java.text.NumberFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -104,7 +105,7 @@ public class SingleRowIdentificationTask extends AbstractTask {
    * @param parameters task parameters.
    * @param peakListRow peak-list row to identify.
    */
-  public SingleRowIdentificationTask(ParameterSet parameters, FeatureListRow peakListRow, @NotNull Date moduleCallDate) {
+  public SingleRowIdentificationTask(ParameterSet parameters, FeatureListRow peakListRow, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     this.peakListRow = peakListRow;
     siriusCandidates = parameters.getParameter(SIRIUS_CANDIDATES).getValue();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_sirius/SiriusIdentificationModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_sirius/SiriusIdentificationModule.java
@@ -20,6 +20,7 @@ package io.github.mzmine.modules.dataprocessing.id_sirius;
 
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Date;
 import org.jetbrains.annotations.NotNull;
@@ -50,7 +51,7 @@ public class SiriusIdentificationModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     final FeatureList[] peakLists = parameters.getParameter(PeakListIdentificationParameters.peakLists)
         .getValue().getMatchingFeatureLists();
@@ -67,7 +68,7 @@ public class SiriusIdentificationModule implements MZmineProcessingModule {
    *
    * @param row the feature list row.
    */
-  public static void showSingleRowIdentificationDialog(final FeatureListRow row, @NotNull Date moduleCallDate) {
+  public static void showSingleRowIdentificationDialog(final FeatureListRow row, @NotNull Instant moduleCallDate) {
 
     assert Platform.isFxApplicationThread();
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_sirius/SiriusThread.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_sirius/SiriusThread.java
@@ -19,6 +19,8 @@
 package io.github.mzmine.modules.dataprocessing.id_sirius;
 
 import static io.github.mzmine.modules.dataprocessing.id_sirius.PeakListIdentificationTask.addSiriusCompounds;
+
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -167,7 +169,7 @@ public class SiriusThread implements Runnable {
           SiriusIonAnnotation annotation = (SiriusIonAnnotation) siriusResults.get(index);
           try {
             FingerIdWebMethodTask task =
-                new FingerIdWebMethodTask(annotation, experiment, fingeridCandidates, peakListRow, new Date()); // new date here might be a problem
+                new FingerIdWebMethodTask(annotation, experiment, fingeridCandidates, peakListRow, Instant.now()); // new date here might be a problem
             MZmineCore.getTaskController().addTask(task, TaskPriority.NORMAL);
             Thread.sleep(1000);
           } catch (InterruptedException interrupt) {

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_spectraldbsearch/LocalSpectralDBSearchModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_spectraldbsearch/LocalSpectralDBSearchModule.java
@@ -20,6 +20,7 @@ package io.github.mzmine.modules.dataprocessing.id_spectraldbsearch;
 
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Date;
 import org.jetbrains.annotations.NotNull;
@@ -52,7 +53,7 @@ public class LocalSpectralDBSearchModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     FeatureList featureLists[] = parameters.getParameter(LocalSpectralDBSearchParameters.peakLists)
         .getValue().getMatchingFeatureLists();
@@ -72,7 +73,7 @@ public class LocalSpectralDBSearchModule implements MZmineProcessingModule {
    * @param row the feature list row.
    */
   public static void showSelectedRowsIdentificationDialog(final FeatureListRow[] rows,
-      FeatureTableFX table, @NotNull Date moduleCallDate) {
+      FeatureTableFX table, @NotNull Instant moduleCallDate) {
 
     final ParameterSet parameters = new SelectedRowsLocalSpectralDBSearchParameters();
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_spectraldbsearch/LocalSpectralDBSearchTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_spectraldbsearch/LocalSpectralDBSearchTask.java
@@ -31,6 +31,7 @@ import io.github.mzmine.util.spectraldb.parser.LibraryEntryProcessor;
 import io.github.mzmine.util.spectraldb.parser.UnsupportedFormatException;
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -52,7 +53,7 @@ class LocalSpectralDBSearchTask extends AbstractTask {
   private int totalTasks;
   private FeatureListRow[] rows;
 
-  public LocalSpectralDBSearchTask(FeatureList featureList, ParameterSet parameters, @NotNull Date moduleCallDate) {
+  public LocalSpectralDBSearchTask(FeatureList featureList, ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     this.featureList = featureList;
     this.rows = featureList.getRows().toArray(FeatureListRow[]::new);

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_spectraldbsearch/RowsSpectralMatchTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_spectraldbsearch/RowsSpectralMatchTask.java
@@ -42,6 +42,7 @@ import io.github.mzmine.util.spectraldb.entry.SpectralDBEntry;
 import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
 import java.io.File;
 import java.text.MessageFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -99,13 +100,13 @@ public class RowsSpectralMatchTask extends AbstractTask {
   private int minMatchedIsoSignals;
 
   public RowsSpectralMatchTask(String description, @NotNull FeatureListRow[] rows,
-      ParameterSet parameters, int startEntry, List<SpectralDBEntry> list, @NotNull Date moduleCallDate) {
+      ParameterSet parameters, int startEntry, List<SpectralDBEntry> list, @NotNull Instant moduleCallDate) {
     this(description, rows, parameters, startEntry, list, null, moduleCallDate);
   }
 
   public RowsSpectralMatchTask(String description, @NotNull FeatureListRow[] rows,
       ParameterSet parameters, int startEntry, List<SpectralDBEntry> list,
-      Consumer<SpectralDBFeatureIdentity> matchListener, @NotNull Date moduleCallDate) {
+      Consumer<SpectralDBFeatureIdentity> matchListener, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     this.description = description;
     this.rows = rows;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_spectraldbsearch/SelectedRowsLocalSpectralDBSearchTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_spectraldbsearch/SelectedRowsLocalSpectralDBSearchTask.java
@@ -32,6 +32,7 @@ import io.github.mzmine.util.spectraldb.parser.LibraryEntryProcessor;
 import io.github.mzmine.util.spectraldb.parser.UnsupportedFormatException;
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -59,7 +60,7 @@ public class SelectedRowsLocalSpectralDBSearchTask extends AbstractTask {
   private int totalTasks;
 
   public SelectedRowsLocalSpectralDBSearchTask(FeatureListRow[] peakListRows, FeatureTableFX table,
-      ParameterSet parameters, @NotNull Date moduleCallDate) {
+      ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     this.peakListRows = peakListRows;
     this.parameters = parameters;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_spectraldbsearch/sort/SortSpectralDBIdentitiesModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_spectraldbsearch/sort/SortSpectralDBIdentitiesModule.java
@@ -19,8 +19,8 @@
 package io.github.mzmine.modules.dataprocessing.id_spectraldbsearch.sort;
 
 import io.github.mzmine.datamodel.features.FeatureList;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -49,7 +49,7 @@ public class SortSpectralDBIdentitiesModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     FeatureList featureLists[] = parameters.getParameter(SortSpectralDBIdentitiesParameters.peakLists)
         .getValue().getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_spectraldbsearch/sort/SortSpectralDBIdentitiesTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_spectraldbsearch/sort/SortSpectralDBIdentitiesTask.java
@@ -24,6 +24,7 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
+import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.logging.Logger;
@@ -42,7 +43,7 @@ public class SortSpectralDBIdentitiesTask extends AbstractTask {
   private Double minScore;
 
   SortSpectralDBIdentitiesTask(FeatureList featureList, ParameterSet parameters,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     this.featureList = featureList;
     this.parameters = parameters;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/norm_linear/LinearNormalizerModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/norm_linear/LinearNormalizerModule.java
@@ -20,9 +20,9 @@ package io.github.mzmine.modules.dataprocessing.norm_linear;
 
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
 
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -51,7 +51,7 @@ public class LinearNormalizerModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     FeatureList featureLists[] = parameters.getParameter(LinearNormalizerParameters.featureLists).getValue()
         .getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/norm_linear/LinearNormalizerTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/norm_linear/LinearNormalizerTask.java
@@ -34,6 +34,7 @@ import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.FeatureMeasurementType;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Date;
 import java.util.Hashtable;
 import java.util.Objects;
@@ -60,7 +61,7 @@ class LinearNormalizerTask extends AbstractTask {
   private ParameterSet parameters;
 
   public LinearNormalizerTask(MZmineProject project, FeatureList featureList, ParameterSet parameters, @Nullable
-      MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate); // no new data stored -> null
 
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/norm_rtcalibration/RTCalibrationModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/norm_rtcalibration/RTCalibrationModule.java
@@ -19,9 +19,9 @@
 package io.github.mzmine.modules.dataprocessing.norm_rtcalibration;
 
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
 
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -50,7 +50,7 @@ public class RTCalibrationModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     RTCalibrationTask newTask = new RTCalibrationTask(project, parameters,
         MemoryMapStorage.forFeatureList(), moduleCallDate);
     tasks.add(newTask);

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/norm_rtcalibration/RTCalibrationTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/norm_rtcalibration/RTCalibrationTask.java
@@ -35,6 +35,7 @@ import io.github.mzmine.parameters.parametertypes.tolerances.RTTolerance;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Date;
 import java.util.Vector;
 import java.util.logging.Logger;
@@ -60,7 +61,7 @@ class RTCalibrationTask extends AbstractTask {
   private ParameterSet parameters;
 
   public RTCalibrationTask(MZmineProject project, ParameterSet parameters, @Nullable
-      MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/norm_standardcompound/StandardCompoundNormalizerModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/norm_standardcompound/StandardCompoundNormalizerModule.java
@@ -20,9 +20,9 @@ package io.github.mzmine.modules.dataprocessing.norm_standardcompound;
 
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
 
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -54,7 +54,7 @@ public class StandardCompoundNormalizerModule implements MZmineProcessingModule 
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     FeatureList featureLists[] = parameters.getParameter(StandardCompoundNormalizerParameters.featureList)
         .getValue().getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/norm_standardcompound/StandardCompoundNormalizerTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/norm_standardcompound/StandardCompoundNormalizerTask.java
@@ -31,6 +31,7 @@ import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.FeatureMeasurementType;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Date;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -54,7 +55,7 @@ public class StandardCompoundNormalizerTask extends AbstractTask {
   private ParameterSet parameters;
 
   public StandardCompoundNormalizerTask(MZmineProject project, FeatureList featureList,
-      ParameterSet parameters,  @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      ParameterSet parameters,  @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/example/FeatureLearnerTask.java
+++ b/src/main/java/io/github/mzmine/modules/example/FeatureLearnerTask.java
@@ -35,8 +35,8 @@ import io.github.mzmine.util.FeatureSorter;
 import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.SortingDirection;
 import io.github.mzmine.util.SortingProperty;
+import java.time.Instant;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -66,7 +66,7 @@ class FeatureLearnerTask extends AbstractTask {
    * @param parameters
    */
   public FeatureLearnerTask(MZmineProject project, FeatureList featureList, ParameterSet parameters, @Nullable
-      MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
     this.project = project;
     this.featureList = (ModularFeatureList) featureList;

--- a/src/main/java/io/github/mzmine/modules/example/FeatureListRowLearnerTask.java
+++ b/src/main/java/io/github/mzmine/modules/example/FeatureListRowLearnerTask.java
@@ -34,8 +34,8 @@ import io.github.mzmine.util.FeatureListRowSorter;
 import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.SortingDirection;
 import io.github.mzmine.util.SortingProperty;
+import java.time.Instant;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -64,7 +64,7 @@ class FeatureListRowLearnerTask extends AbstractTask {
    *
    */
   public FeatureListRowLearnerTask(MZmineProject project, FeatureList featureList, ParameterSet parameters, @Nullable
-      MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
     this.project = project;
     this.featureList = featureList;

--- a/src/main/java/io/github/mzmine/modules/example/LearnerModule.java
+++ b/src/main/java/io/github/mzmine/modules/example/LearnerModule.java
@@ -20,8 +20,8 @@ package io.github.mzmine.modules.example;
 
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -47,7 +47,7 @@ public class LearnerModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     // get parameters
     FeatureList featureLists[] =

--- a/src/main/java/io/github/mzmine/modules/example/MultiRawDataLearnerTask.java
+++ b/src/main/java/io/github/mzmine/modules/example/MultiRawDataLearnerTask.java
@@ -35,6 +35,7 @@ import io.github.mzmine.util.FeatureListRowSorter;
 import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.SortingDirection;
 import io.github.mzmine.util.SortingProperty;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.logging.Logger;
@@ -64,7 +65,7 @@ class MultiRawDataLearnerTask extends AbstractTask {
    * Constructor to set all parameters and the project
    */
   public MultiRawDataLearnerTask(MZmineProject project, FeatureList featureList,
-      ParameterSet parameters, @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      ParameterSet parameters, @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
     this.project = project;
     this.featureList = featureList;

--- a/src/main/java/io/github/mzmine/modules/example/StreamFeatureListRowLearnerTask.java
+++ b/src/main/java/io/github/mzmine/modules/example/StreamFeatureListRowLearnerTask.java
@@ -35,6 +35,7 @@ import io.github.mzmine.util.FeatureListRowSorter;
 import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.SortingDirection;
 import io.github.mzmine.util.SortingProperty;
+import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.logging.Logger;
@@ -68,7 +69,7 @@ class StreamFeatureListRowLearnerTask extends AbstractTask {
    * @param parameters
    */
   public StreamFeatureListRowLearnerTask(MZmineProject project, FeatureList featureList,
-      ParameterSet parameters, @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      ParameterSet parameters, @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
     this.project = project;
     this.featureList = (ModularFeatureList) featureList;

--- a/src/main/java/io/github/mzmine/modules/io/deprecated_jmzml/MzMLImportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/deprecated_jmzml/MzMLImportModule.java
@@ -33,9 +33,9 @@ import io.github.mzmine.util.RawDataFileTypeDetector;
 import io.github.mzmine.util.RawDataFileUtils;
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -74,7 +74,7 @@ public class MzMLImportModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(final @NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     File fileNames[] = parameters.getParameter(MzMLImportParameters.fileNames).getValue();
 

--- a/src/main/java/io/github/mzmine/modules/io/deprecated_jmzml/MzMLImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/deprecated_jmzml/MzMLImportTask.java
@@ -34,6 +34,7 @@ import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.ExceptionUtils;
 import io.github.mzmine.util.scans.ScanUtils;
 import java.io.File;
+import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -90,7 +91,7 @@ public class MzMLImportTask extends AbstractTask {
   private Map<Integer, Double> buildingMobilities;
 
   public MzMLImportTask(MZmineProject project, File fileToOpen, RawDataFile newMZmineFile,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // storage in raw data file
     this.project = project;
     this.file = fileToOpen;

--- a/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularModule.java
@@ -24,8 +24,8 @@ import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public class CSVExportModularModule implements MZmineProcessingModule {
@@ -47,7 +47,7 @@ public class CSVExportModularModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     CSVExportModularTask task = new CSVExportModularTask(parameters, moduleCallDate);
     tasks.add(task);
     return ExitCode.OK;

--- a/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularTask.java
@@ -39,8 +39,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.text.MessageFormat;
+import java.time.Instant;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -64,7 +64,7 @@ public class CSVExportModularTask extends AbstractTask {
   private String headerSeparator = ":";
   private FeatureListRowsFilter filter;
 
-  public CSVExportModularTask(ParameterSet parameters, @NotNull Date moduleCallDate) {
+  public CSVExportModularTask(ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     this.featureLists =
         parameters.getParameter(CSVExportModularParameters.featureLists).getValue()
@@ -85,7 +85,7 @@ public class CSVExportModularTask extends AbstractTask {
    */
   public CSVExportModularTask(ModularFeatureList[] featureLists, File fileName,
       String fieldSeparator,
-      String idSeparator, FeatureListRowsFilter filter, @NotNull Date moduleCallDate) {
+      String idSeparator, FeatureListRowsFilter filter, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     if (fieldSeparator.equals(idSeparator)) {
       throw new IllegalArgumentException(MessageFormat

--- a/src/main/java/io/github/mzmine/modules/io/export_features_csv_legacy/LegacyCSVExportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_csv_legacy/LegacyCSVExportModule.java
@@ -18,9 +18,9 @@
 
 package io.github.mzmine.modules.io.export_features_csv_legacy;
 
+import java.time.Instant;
 import java.util.Collection;
 
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -49,7 +49,7 @@ public class LegacyCSVExportModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     LegacyCSVExportTask task = new LegacyCSVExportTask(parameters, moduleCallDate);
     tasks.add(task);
     return ExitCode.OK;

--- a/src/main/java/io/github/mzmine/modules/io/export_features_csv_legacy/LegacyCSVExportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_csv_legacy/LegacyCSVExportTask.java
@@ -36,6 +36,7 @@ import io.github.mzmine.util.RangeUtils;
 import java.io.File;
 import java.io.FileWriter;
 import java.text.NumberFormat;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
@@ -59,7 +60,7 @@ public class LegacyCSVExportTask extends AbstractTask {
   private final FeatureListRowsFilter filter;
   private int processedRows = 0, totalRows = 0;
 
-  public LegacyCSVExportTask(ParameterSet parameters, @NotNull Date moduleCallDate) {
+  public LegacyCSVExportTask(ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     this.featureLists =
         parameters.getParameter(LegacyCSVExportParameters.featureLists).getValue()
@@ -101,7 +102,7 @@ public class LegacyCSVExportTask extends AbstractTask {
       LegacyExportRowCommonElement[] commonElements,
       LegacyExportRowDataFileElement[] dataFileElements,
       Boolean exportAllFeatureInfo, String idSeparator, FeatureListRowsFilter filter,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     this.featureLists = featureLists;
     this.fileName = fileName;

--- a/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnExportAndSubmitModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnExportAndSubmitModule.java
@@ -31,17 +31,16 @@
 
 package io.github.mzmine.modules.io.export_features_gnps.fbmn;
 
-import java.util.Collection;
-import java.util.Date;
-import java.util.logging.Logger;
-import org.jetbrains.annotations.NotNull;
-
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.logging.Logger;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Exports all files needed for GNPS feature based molecular networking (quant table (csv export)),
@@ -65,7 +64,7 @@ public class GnpsFbmnExportAndSubmitModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(MZmineProject project, ParameterSet parameters, Collection<Task> tasks,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     // add gnps export task
     GnpsFbmnExportAndSubmitTask task = new GnpsFbmnExportAndSubmitTask(parameters, moduleCallDate);
     /*

--- a/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnExportAndSubmitTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnExportAndSubmitTask.java
@@ -29,25 +29,15 @@
 
 package io.github.mzmine.modules.io.export_features_gnps.fbmn;
 
+import com.google.common.util.concurrent.AtomicDouble;
+import io.github.msdk.MSDKRuntimeException;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
+import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.dataprocessing.group_metacorrelate.export.ExportCorrAnnotationTask;
 import io.github.mzmine.modules.io.export_features_csv.CSVExportModularTask;
 import io.github.mzmine.modules.io.export_features_csv_legacy.LegacyCSVExportTask;
 import io.github.mzmine.modules.io.export_features_csv_legacy.LegacyExportRowCommonElement;
 import io.github.mzmine.modules.io.export_features_csv_legacy.LegacyExportRowDataFileElement;
-import io.github.mzmine.util.FeatureMeasurementType;
-import java.awt.Desktop;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import org.apache.commons.io.FilenameUtils;
-import com.google.common.util.concurrent.AtomicDouble;
-import io.github.msdk.MSDKRuntimeException;
-import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.io.export_features_gnps.GNPSUtils;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
@@ -55,7 +45,17 @@ import io.github.mzmine.taskcontrol.AllTasksFinishedListener;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.taskcontrol.TaskPriority;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import io.github.mzmine.util.FeatureMeasurementType;
 import io.github.mzmine.util.files.FileAndPathUtil;
+import java.awt.Desktop;
+import java.io.File;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.commons.io.FilenameUtils;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -72,7 +72,7 @@ public class GnpsFbmnExportAndSubmitTask extends AbstractTask {
   private AtomicDouble progress = new AtomicDouble(0);
   private FeatureMeasurementType featureMeasure;
 
-  GnpsFbmnExportAndSubmitTask(ParameterSet parameters, @NotNull Date moduleCallDate) {
+  GnpsFbmnExportAndSubmitTask(ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     this.parameters = parameters;
   }

--- a/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnExportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnExportTask.java
@@ -47,8 +47,8 @@ import io.github.mzmine.taskcontrol.TaskStatus;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.Objects;
 import java.util.regex.Pattern;
 import javafx.collections.ObservableList;
@@ -67,7 +67,7 @@ public class GnpsFbmnExportTask extends AbstractTask {
   private int currentIndex = 0;
   private final MsMsSpectraMergeParameters mergeParameters;
 
-  GnpsFbmnExportTask(ParameterSet parameters, @NotNull Date moduleCallDate) {
+  GnpsFbmnExportTask(ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     this.featureLists = parameters.getParameter(GnpsFbmnExportAndSubmitParameters.FEATURE_LISTS)
         .getValue().getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnMgfExportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnMgfExportTask.java
@@ -49,8 +49,8 @@ import java.io.IOException;
 import java.text.DecimalFormat;
 import java.text.MessageFormat;
 import java.text.NumberFormat;
+import java.time.Instant;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -84,7 +84,7 @@ public class GnpsFbmnMgfExportTask extends AbstractTask {
 
   private FeatureListRowsFilter filter;
 
-  GnpsFbmnMgfExportTask(ParameterSet parameters, @NotNull Date moduleCallDate) {
+  GnpsFbmnMgfExportTask(ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     this.featureLists = parameters.getParameter(GnpsFbmnExportAndSubmitParameters.FEATURE_LISTS)
         .getValue().getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/io/export_features_gnps/gc/GnpsGcExportAndSubmitModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_gnps/gc/GnpsGcExportAndSubmitModule.java
@@ -31,17 +31,16 @@
 
 package io.github.mzmine.modules.io.export_features_gnps.gc;
 
-import java.util.Collection;
-import java.util.Date;
-import java.util.logging.Logger;
-import org.jetbrains.annotations.NotNull;
-
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.logging.Logger;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Exports all files needed for GNPS GC-MS (quant table (csv export)), mgf (ADAP mgf export)
@@ -65,7 +64,7 @@ public class GnpsGcExportAndSubmitModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(MZmineProject project, ParameterSet parameters, Collection<Task> tasks,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     // add gnps export task
     GnpsGcExportAndSubmitTask task = new GnpsGcExportAndSubmitTask(parameters, moduleCallDate);
     /*

--- a/src/main/java/io/github/mzmine/modules/io/export_features_gnps/gc/GnpsGcExportAndSubmitTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_gnps/gc/GnpsGcExportAndSubmitTask.java
@@ -55,9 +55,9 @@ import io.github.mzmine.util.FeatureMeasurementType;
 import io.github.mzmine.util.files.FileAndPathUtil;
 import java.awt.Desktop;
 import java.io.File;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -85,7 +85,7 @@ public class GnpsGcExportAndSubmitTask extends AbstractTask {
   private boolean submit;
   private boolean openFolder;
 
-  GnpsGcExportAndSubmitTask(ParameterSet parameters, @NotNull Date moduleCallDate) {
+  GnpsGcExportAndSubmitTask(ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     this.parameters = parameters;
 

--- a/src/main/java/io/github/mzmine/modules/io/export_features_metaboanalyst/MetaboAnalystExportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_metaboanalyst/MetaboAnalystExportModule.java
@@ -18,9 +18,9 @@
 
 package io.github.mzmine.modules.io.export_features_metaboanalyst;
 
+import java.time.Instant;
 import java.util.Collection;
 
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -49,7 +49,7 @@ public class MetaboAnalystExportModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     MetaboAnalystExportTask task = new MetaboAnalystExportTask(project, parameters, moduleCallDate);
     tasks.add(task);
     return ExitCode.OK;

--- a/src/main/java/io/github/mzmine/modules/io/export_features_metaboanalyst/MetaboAnalystExportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_metaboanalyst/MetaboAnalystExportTask.java
@@ -25,6 +25,7 @@ import io.github.mzmine.datamodel.features.FeatureListRow;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.regex.Pattern;
@@ -50,7 +51,7 @@ class MetaboAnalystExportTask extends AbstractTask {
   private File fileName;
   private UserParameter<?, ?> groupParameter;
 
-  MetaboAnalystExportTask(MZmineProject project, ParameterSet parameters, @NotNull Date moduleCallDate) {
+  MetaboAnalystExportTask(MZmineProject project, ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
 
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/io/export_features_mgf/AdapMgfExportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_mgf/AdapMgfExportModule.java
@@ -16,16 +16,15 @@
 
 package io.github.mzmine.modules.io.export_features_mgf;
 
-import java.util.Collection;
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
-
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 /**
  *
@@ -49,7 +48,7 @@ public class AdapMgfExportModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     AdapMgfExportTask task = new AdapMgfExportTask(parameters, moduleCallDate);
     tasks.add(task);
     return ExitCode.OK;

--- a/src/main/java/io/github/mzmine/modules/io/export_features_mgf/AdapMgfExportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_mgf/AdapMgfExportTask.java
@@ -16,15 +16,6 @@
 
 package io.github.mzmine.modules.io.export_features_mgf;
 
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.text.DecimalFormat;
-import java.text.NumberFormat;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.regex.Pattern;
-import java.util.stream.Stream;
 import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.IsotopePattern;
 import io.github.mzmine.datamodel.features.FeatureList;
@@ -36,6 +27,15 @@ import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.scans.ScanUtils;
 import io.github.mzmine.util.scans.ScanUtils.IntegerMode;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -62,13 +62,13 @@ public class AdapMgfExportTask extends AbstractTask {
   private final int totalRows;
   private int finishedRows = 0;
 
-  public AdapMgfExportTask(ParameterSet parameters, @NotNull Date moduleCallDate) {
+  public AdapMgfExportTask(ParameterSet parameters, @NotNull Instant moduleCallDate) {
     this(parameters, parameters.getParameter(AdapMgfExportParameters.FEATURE_LISTS).getValue()
         .getMatchingFeatureLists(), moduleCallDate);
   }
 
   public AdapMgfExportTask(ParameterSet parameters, FeatureList[] featureLists,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     this.featureLists = featureLists;
     totalRows = (int) Stream.of(featureLists).map(FeatureList::getRows).count();

--- a/src/main/java/io/github/mzmine/modules/io/export_features_msp/AdapMspExportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_msp/AdapMspExportModule.java
@@ -16,16 +16,15 @@
 
 package io.github.mzmine.modules.io.export_features_msp;
 
-import java.util.Collection;
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
-
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 /**
  *
@@ -50,7 +49,7 @@ public class AdapMspExportModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     AdapMspExportTask task = new AdapMspExportTask(parameters, moduleCallDate);
     tasks.add(task);
     return ExitCode.OK;

--- a/src/main/java/io/github/mzmine/modules/io/export_features_msp/AdapMspExportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_msp/AdapMspExportTask.java
@@ -16,13 +16,6 @@
 
 package io.github.mzmine.modules.io.export_features_msp;
 
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.FeatureIdentity;
 import io.github.mzmine.datamodel.FeatureInformation;
@@ -34,6 +27,13 @@ import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.scans.ScanUtils;
 import io.github.mzmine.util.scans.ScanUtils.IntegerMode;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -55,7 +55,7 @@ public class AdapMspExportTask extends AbstractTask {
   private final boolean integerMZ;
   private final IntegerMode roundMode;
 
-  AdapMspExportTask(ParameterSet parameters, @NotNull Date moduleCallDate) {
+  AdapMspExportTask(ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     this.featureLists = parameters.getParameter(AdapMspExportParameters.FEATURE_LISTS).getValue()
         .getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/io/export_features_mztab/MzTabExportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_mztab/MzTabExportModule.java
@@ -18,9 +18,9 @@
 
 package io.github.mzmine.modules.io.export_features_mztab;
 
+import java.time.Instant;
 import java.util.Collection;
 
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -59,7 +59,7 @@ public class MzTabExportModule implements MZmineProcessingModule {
   @Override
   public @NotNull ExitCode runModule(@NotNull MZmineProject project,
       @NotNull ParameterSet parameters, @NotNull Collection<Task> tasks,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     MzTabExportTask task = new MzTabExportTask(project, parameters, moduleCallDate);
     tasks.add(task);
     return ExitCode.OK;

--- a/src/main/java/io/github/mzmine/modules/io/export_features_mztab/MzTabExportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_mztab/MzTabExportTask.java
@@ -25,6 +25,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.net.URL;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.regex.Pattern;
@@ -61,7 +62,7 @@ class MzTabExportTask extends AbstractTask {
   private FeatureList[] featureLists;
   private final boolean exportall;
 
-  MzTabExportTask(MZmineProject project, ParameterSet parameters, @NotNull Date moduleCallDate) {
+  MzTabExportTask(MZmineProject project, ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     this.project = project;
     this.featureLists =

--- a/src/main/java/io/github/mzmine/modules/io/export_features_mztabm/MZTabmExportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_mztabm/MZTabmExportModule.java
@@ -25,7 +25,7 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 
-import java.util.Date;
+import java.time.Instant;
 import org.jetbrains.annotations.NotNull;
 import java.util.Collection;
 
@@ -46,7 +46,7 @@ public class MZTabmExportModule implements MZmineProcessingModule {
   @Override
   public @NotNull
   ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     MZTabmExportTask task = new MZTabmExportTask(project, parameters, moduleCallDate);
     tasks.add(task);
     return ExitCode.OK;

--- a/src/main/java/io/github/mzmine/modules/io/export_features_mztabm/MZTabmExportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_mztabm/MZTabmExportTask.java
@@ -29,6 +29,7 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.UserParameter;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import java.time.Instant;
 import org.jetbrains.annotations.NotNull;
 import uk.ac.ebi.pride.jmztab2.model.*;
 
@@ -47,7 +48,7 @@ public class MZTabmExportTask extends AbstractTask {
   private FeatureList[] featureLists;
   private final boolean exportAll;
 
-  MZTabmExportTask(MZmineProject project, ParameterSet parameters, @NotNull Date moduleCallDate) {
+  MZTabmExportTask(MZmineProject project, ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     this.project = project;
     this.featureLists =

--- a/src/main/java/io/github/mzmine/modules/io/export_features_sirius/SiriusExportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_sirius/SiriusExportModule.java
@@ -31,6 +31,7 @@
 package io.github.mzmine.modules.io.export_features_sirius;
 
 import io.github.mzmine.datamodel.features.FeatureListRow;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Date;
 import org.jetbrains.annotations.NotNull;
@@ -61,14 +62,14 @@ public class SiriusExportModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     SiriusExportTask task = new SiriusExportTask(parameters, moduleCallDate);
     tasks.add(task);
     return ExitCode.OK;
 
   }
 
-  public static void exportSingleFeatureList(FeatureListRow row, @NotNull Date moduleCallDate) {
+  public static void exportSingleFeatureList(FeatureListRow row, @NotNull Instant moduleCallDate) {
 
     try {
       ParameterSet parameters =
@@ -88,7 +89,7 @@ public class SiriusExportModule implements MZmineProcessingModule {
 
   }
 
-  public static void exportSingleRows(FeatureListRow[] row, @NotNull Date moduleCallDate) {
+  public static void exportSingleRows(FeatureListRow[] row, @NotNull Instant moduleCallDate) {
     try {
       ParameterSet parameters =
           MZmineCore.getConfiguration().getModuleParameters(SiriusExportModule.class);

--- a/src/main/java/io/github/mzmine/modules/io/export_features_sirius/SiriusExportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_sirius/SiriusExportTask.java
@@ -57,6 +57,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -118,7 +119,7 @@ public class SiriusExportTask extends AbstractTask {
   private int nextID = 1;
   private boolean renumberID;
 
-  SiriusExportTask(ParameterSet parameters, @NotNull Date moduleCallDate) {
+  SiriusExportTask(ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     this.featureLists = parameters.getParameter(SiriusExportParameters.FEATURE_LISTS).getValue()
         .getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/io/export_features_sql/SQLExportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_sql/SQLExportModule.java
@@ -18,9 +18,9 @@
 
 package io.github.mzmine.modules.io.export_features_sql;
 
+import java.time.Instant;
 import java.util.Collection;
 
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -49,7 +49,7 @@ public class SQLExportModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     SQLExportTask newTask = new SQLExportTask(parameters, moduleCallDate);
     tasks.add(newTask);
     return ExitCode.OK;

--- a/src/main/java/io/github/mzmine/modules/io/export_features_sql/SQLExportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_sql/SQLExportTask.java
@@ -38,6 +38,7 @@ import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.RangeUtils;
 import io.github.mzmine.util.scans.ScanUtils;
+import java.time.Instant;
 import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
@@ -53,7 +54,7 @@ class SQLExportTask extends AbstractTask {
 
   private Connection dbConnection;
 
-  SQLExportTask(ParameterSet parameters, @NotNull Date moduleCallDate) {
+  SQLExportTask(ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
 
     this.featureList = parameters.getParameter(SQLExportParameters.featureList).getValue()

--- a/src/main/java/io/github/mzmine/modules/io/export_features_venn/VennExportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_venn/VennExportModule.java
@@ -25,8 +25,8 @@ import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -50,7 +50,7 @@ public class VennExportModule implements MZmineProcessingModule {
   @Override
   public @NotNull ExitCode runModule(@NotNull MZmineProject project,
       @NotNull ParameterSet parameters, @NotNull Collection<Task> tasks,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     ModularFeatureList[] matchingFeatureLists = parameters.getParameter(VennExportParameters.flists)
         .getValue().getMatchingFeatureLists();
 

--- a/src/main/java/io/github/mzmine/modules/io/export_features_venn/VennExportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_venn/VennExportTask.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
@@ -55,7 +56,7 @@ public class VennExportTask extends AbstractTask {
   private int processedRows;
 
 
-  protected VennExportTask(@Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate,
+  protected VennExportTask(@Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate,
       ModularFeatureList flist, ParameterSet parameterSet) {
     super(storage, moduleCallDate);
     this.flist = flist;

--- a/src/main/java/io/github/mzmine/modules/io/export_image_csv/ImageToCsvExportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_image_csv/ImageToCsvExportModule.java
@@ -25,6 +25,7 @@ import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.MZmineModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -33,7 +34,7 @@ import org.jetbrains.annotations.Nullable;
 
 public class ImageToCsvExportModule implements MZmineModule {
 
-  public static void showExportDialog(Collection<ModularFeatureListRow> rows, @NotNull Date moduleCallDate) {
+  public static void showExportDialog(Collection<ModularFeatureListRow> rows, @NotNull Instant moduleCallDate) {
 
     final List<ModularFeature> features = rows.stream()
         .flatMap(ModularFeatureListRow::streamFeatures)

--- a/src/main/java/io/github/mzmine/modules/io/export_image_csv/ImageToCsvExportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_image_csv/ImageToCsvExportTask.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.text.NumberFormat;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -71,7 +72,7 @@ public class ImageToCsvExportTask extends AbstractTask {
   private int processed;
 
   public ImageToCsvExportTask(ParameterSet param,
-      Collection<ModularFeature> features, @NotNull Date moduleCallDate) {
+      Collection<ModularFeature> features, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate);
     this.dir = param.getParameter(ImageToCsvExportParameters.dir).getValue();
     this.sep = param.getParameter(ImageToCsvExportParameters.delimiter).getValue().trim();

--- a/src/main/java/io/github/mzmine/modules/io/export_rawdata_mzml/MzMLExportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_rawdata_mzml/MzMLExportModule.java
@@ -27,8 +27,8 @@ import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.files.FileAndPathUtil;
 import java.io.File;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -53,7 +53,7 @@ public class MzMLExportModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(final @NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     String extension = "mzML";
 

--- a/src/main/java/io/github/mzmine/modules/io/export_rawdata_mzml/MzMLExportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_rawdata_mzml/MzMLExportTask.java
@@ -19,6 +19,7 @@
 package io.github.mzmine.modules.io.export_rawdata_mzml;
 
 import java.io.File;
+import java.time.Instant;
 import java.util.Date;
 import java.util.logging.Logger;
 
@@ -46,7 +47,7 @@ public class MzMLExportTask extends AbstractTask {
    * @param dataFile
    * @param parameters
    */
-  public MzMLExportTask(RawDataFile dataFile, File outFilename, @NotNull Date moduleCallDate) {
+  public MzMLExportTask(RawDataFile dataFile, File outFilename, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     this.dataFile = dataFile;
     this.outFilename = outFilename;

--- a/src/main/java/io/github/mzmine/modules/io/export_rawdata_netcdf/NetCDFExportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_rawdata_netcdf/NetCDFExportModule.java
@@ -27,8 +27,8 @@ import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.files.FileAndPathUtil;
 import java.io.File;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -53,7 +53,7 @@ public class NetCDFExportModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(final @NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     String extension = "cdf";
 
     File folder = parameters.getParameter(NetCDFExportParameters.fileName).getValue();

--- a/src/main/java/io/github/mzmine/modules/io/export_rawdata_netcdf/NetCDFExportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_rawdata_netcdf/NetCDFExportTask.java
@@ -19,6 +19,7 @@
 package io.github.mzmine.modules.io.export_rawdata_netcdf;
 
 import java.io.File;
+import java.time.Instant;
 import java.util.Date;
 import java.util.logging.Logger;
 
@@ -46,7 +47,7 @@ public class NetCDFExportTask extends AbstractTask {
    * @param dataFile
    * @param parameters
    */
-  public NetCDFExportTask(RawDataFile dataFile, File outFilename, @NotNull Date moduleCallDate) {
+  public NetCDFExportTask(RawDataFile dataFile, File outFilename, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     this.dataFile = dataFile;
     this.outFilename = outFilename;

--- a/src/main/java/io/github/mzmine/modules/io/export_scans/ExportScansFromRawFilesModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_scans/ExportScansFromRawFilesModule.java
@@ -27,10 +27,10 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.parametertypes.selectors.ScanSelection;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
 import org.apache.commons.lang3.ArrayUtils;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Exports scans around a center time
@@ -53,7 +53,7 @@ public class ExportScansFromRawFilesModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     ScanSelection select =
         parameters.getParameter(ExportScansFromRawFilesParameters.scanSelect).getValue();

--- a/src/main/java/io/github/mzmine/modules/io/export_scans/ExportScansTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_scans/ExportScansTask.java
@@ -37,7 +37,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.logging.Level;
@@ -61,7 +61,7 @@ public class ExportScansTask extends AbstractTask {
   private boolean useMassList;
 
   public ExportScansTask(Scan[] scans, ParameterSet parameters) {
-    super(null, new Date()); // no new data stored -> null, date irrelevant (not used in batch)
+    super(null, Instant.now()); // no new data stored -> null, date irrelevant (not used in batch)
     progress = 0;
     progressMax = 0;
     this.scans = scans;

--- a/src/main/java/io/github/mzmine/modules/io/import_features_csv/CsvImportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_features_csv/CsvImportModule.java
@@ -25,8 +25,8 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public class CsvImportModule implements MZmineProcessingModule {
@@ -45,7 +45,7 @@ public class CsvImportModule implements MZmineProcessingModule {
   @Override
   public @NotNull
   ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     CsvImportTask task = new CsvImportTask(project, parameters, MemoryMapStorage.forFeatureList(), moduleCallDate);
     tasks.add(task);
     return ExitCode.OK;

--- a/src/main/java/io/github/mzmine/modules/io/import_features_csv/CsvImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_features_csv/CsvImportTask.java
@@ -36,7 +36,7 @@ import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.MemoryMapStorage;
 import java.io.File;
 import java.io.FileReader;
-import java.util.Date;
+import java.time.Instant;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -48,7 +48,7 @@ public class CsvImportTask extends AbstractTask {
   private double percent = 0.0;
 
   CsvImportTask(MZmineProject project, ParameterSet parameters, @Nullable MemoryMapStorage storage,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate); this.project = project;
     // first file only
     this.rawDataFile = parameters.getParameter(CsvImportParameters.dataFiles).getValue()

--- a/src/main/java/io/github/mzmine/modules/io/import_features_mztab/MzTabImportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_features_mztab/MzTabImportModule.java
@@ -20,9 +20,9 @@ package io.github.mzmine.modules.io.import_features_mztab;
 
 import io.github.mzmine.util.MemoryMapStorage;
 import java.io.File;
+import java.time.Instant;
 import java.util.Collection;
 
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -61,7 +61,7 @@ public class MzTabImportModule implements MZmineProcessingModule {
   @Override
   public @NotNull ExitCode runModule(@NotNull MZmineProject project,
       @NotNull ParameterSet parameters, @NotNull Collection<Task> tasks,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     File inputFiles[] = parameters.getParameter(MzTabImportParameters.file).getValue();
     final MemoryMapStorage storage = MemoryMapStorage.forFeatureList();
     for (File inputFile : inputFiles) {

--- a/src/main/java/io/github/mzmine/modules/io/import_features_mztab/MzTabImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_features_mztab/MzTabImportTask.java
@@ -21,6 +21,7 @@ package io.github.mzmine.modules.io.import_features_mztab;
 import io.github.mzmine.util.MemoryMapStorage;
 import java.io.File;
 import java.io.OutputStream;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -73,7 +74,7 @@ class MzTabImportTask extends AbstractTask {
   // underlying tasks for importing raw data
   private final List<Task> underlyingTasks = new ArrayList<Task>();
 
-  MzTabImportTask(MZmineProject project, ParameterSet parameters, File inputFile, @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+  MzTabImportTask(MZmineProject project, ParameterSet parameters, File inputFile, @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
     this.project = project;
     this.parameters = parameters;

--- a/src/main/java/io/github/mzmine/modules/io/import_features_mztabm/MZTabmImportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_features_mztabm/MZTabmImportModule.java
@@ -26,7 +26,7 @@ import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 
 import io.github.mzmine.util.MemoryMapStorage;
-import java.util.Date;
+import java.time.Instant;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import java.io.File;
@@ -47,7 +47,7 @@ public class MZTabmImportModule implements MZmineProcessingModule {
   @NotNull
   @Override
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     File inputFiles[] = parameters.getParameter(MzTabmImportParameters.file).getValue();
     final MemoryMapStorage storage = MemoryMapStorage.forFeatureList();
     for (File inputFile : inputFiles) {

--- a/src/main/java/io/github/mzmine/modules/io/import_features_mztabm/MzTabmImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_features_mztabm/MzTabmImportTask.java
@@ -20,6 +20,7 @@ package io.github.mzmine.modules.io.import_features_mztabm;
 
 import io.github.mzmine.util.MemoryMapStorage;
 import java.io.File;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -74,7 +75,7 @@ public class MzTabmImportTask extends AbstractTask {
   private final List<Task> underlyingTasks = new ArrayList<Task>();
 
   MzTabmImportTask(MZmineProject project, ParameterSet parameters, File inputFile,
-      @Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+      @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
     this.project = project;
     this.parameters = parameters;

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_all/AllSpectralDataImportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_all/AllSpectralDataImportModule.java
@@ -51,9 +51,9 @@ import io.github.mzmine.util.RawDataFileTypeDetector;
 import io.github.mzmine.util.RawDataFileUtils;
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -100,7 +100,7 @@ public class AllSpectralDataImportModule implements MZmineProcessingModule {
   @NotNull
   @Override
   public ExitCode runModule(final @NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     File[] fileNames = parameters.getParameter(AllSpectralDataImportParameters.fileNames)
         .getValue();
@@ -198,7 +198,7 @@ public class AllSpectralDataImportModule implements MZmineProcessingModule {
 
   private AbstractTask createTask(RawDataFileType fileType, MZmineProject project, File file,
       RawDataFile newMZmineFile, Class<? extends MZmineModule> module, ParameterSet parameters,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     return switch (fileType) {
       // imaging
       case IMZML -> new ImzMLImportTask(project, file, (ImagingRawDataFile) newMZmineFile, module,
@@ -232,7 +232,7 @@ public class AllSpectralDataImportModule implements MZmineProcessingModule {
    */
   private AbstractTask createAdvancedTask(RawDataFileType fileType, MZmineProject project,
       File file, RawDataFile newMZmineFile, @NotNull AdvancedSpectraImportParameters advancedParam,
-      Class<? extends MZmineModule> module, ParameterSet parameters, @NotNull Date moduleCallDate) {
+      Class<? extends MZmineModule> module, ParameterSet parameters, @NotNull Instant moduleCallDate) {
     return switch (fileType) {
       // MS
       case MZML -> new MSDKmzMLImportTask(project, file, newMZmineFile, advancedParam, module,
@@ -250,7 +250,7 @@ public class AllSpectralDataImportModule implements MZmineProcessingModule {
 
   private AbstractTask createWrappedAdvancedTask(RawDataFileType fileType, MZmineProject project,
       File file, RawDataFile newMZmineFile, @NotNull AdvancedSpectraImportParameters advancedParam,
-      Class<? extends MZmineModule> module, ParameterSet parameters, @NotNull Date moduleCallDate) {
+      Class<? extends MZmineModule> module, ParameterSet parameters, @NotNull Instant moduleCallDate) {
     // log
     logger.warning("Advanced processing is not available for MS data type: " + fileType.toString()
         + " and file " + file.getAbsolutePath());

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_all/MsDataImportAndMassDetectWrapperTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_all/MsDataImportAndMassDetectWrapperTask.java
@@ -28,6 +28,7 @@ import io.github.mzmine.modules.dataprocessing.featdet_massdetection.MassDetecto
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.Date;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -61,7 +62,7 @@ public class MsDataImportAndMassDetectWrapperTask extends AbstractTask {
    * @param advancedParam    advanced parameters to apply mass detection
    */
   public MsDataImportAndMassDetectWrapperTask(MemoryMapStorage storageMassLists, RawDataFile newMZmineFile,
-      AbstractTask importTask, @NotNull AdvancedSpectraImportParameters advancedParam, @NotNull Date moduleCallDate) {
+      AbstractTask importTask, @NotNull AdvancedSpectraImportParameters advancedParam, @NotNull Instant moduleCallDate) {
     super(storageMassLists, moduleCallDate);
     this.newMZmineFile = newMZmineFile;
     this.importTask = importTask;

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/TDFImportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/TDFImportModule.java
@@ -31,9 +31,9 @@ import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.RawDataFileUtils;
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -72,7 +72,7 @@ public class TDFImportModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(final @NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     File fileNames[] = parameters.getParameter(TDFImportParameters.fileNames).getValue();
 

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/TDFImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/TDFImportTask.java
@@ -56,6 +56,7 @@ import java.io.File;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.LinkedHashSet;
@@ -123,14 +124,14 @@ public class TDFImportTask extends AbstractTask {
    */
   public TDFImportTask(MZmineProject project, File file, IMSRawDataFile newMZmineFile,
       @NotNull final Class<? extends MZmineModule> module, @NotNull final ParameterSet parameters,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     this(project, file, newMZmineFile, null, module, parameters, moduleCallDate);
   }
 
   public TDFImportTask(MZmineProject project, File file, IMSRawDataFile newMZmineFile,
       @Nullable final AdvancedSpectraImportParameters advancedParam,
       @NotNull final Class<? extends MZmineModule> module, @NotNull final ParameterSet parameters,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     super(newMZmineFile.getMemoryMapStorage(), moduleCallDate);
     this.fileNameToOpen = file;
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tsf/TSFImportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tsf/TSFImportModule.java
@@ -30,9 +30,9 @@ import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.RawDataFileUtils;
 import java.io.File;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import org.jetbrains.annotations.NotNull;
@@ -63,7 +63,7 @@ public class TSFImportModule implements MZmineProcessingModule {
   @NotNull
   @Override
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     File fileNames[] = parameters.getParameter(TDFImportParameters.fileNames).getValue();
     final MemoryMapStorage storage = MemoryMapStorage.forRawDataFile();
 

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tsf/TSFImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tsf/TSFImportTask.java
@@ -41,6 +41,7 @@ import java.io.File;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.logging.Level;
@@ -71,7 +72,7 @@ public class TSFImportTask extends AbstractTask {
 
   public TSFImportTask(MZmineProject project, File fileName, @Nullable MemoryMapStorage storage,
       @NotNull final Class<? extends MZmineModule> module, @NotNull final ParameterSet parameters,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
 
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_icpms_csv/IcpMsCVSImportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_icpms_csv/IcpMsCVSImportModule.java
@@ -33,9 +33,9 @@ import io.github.mzmine.util.RawDataFileTypeDetector;
 import io.github.mzmine.util.RawDataFileUtils;
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -74,7 +74,7 @@ public class IcpMsCVSImportModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(final @NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     File fileNames[] = parameters.getParameter(IcpMsCVSImportParameters.fileNames).getValue();
 

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_icpms_csv/IcpMsCVSImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_icpms_csv/IcpMsCVSImportTask.java
@@ -31,6 +31,7 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import java.io.File;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -56,7 +57,7 @@ public class IcpMsCVSImportTask extends AbstractTask {
   private int totalScans, parsedScans;
 
   public IcpMsCVSImportTask(MZmineProject project, File fileToOpen, RawDataFile newMZmineFile,
-      @NotNull final Class<? extends MZmineModule> module, @NotNull final ParameterSet parameters, @NotNull Date moduleCallDate) {
+      @NotNull final Class<? extends MZmineModule> module, @NotNull final ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // storage in raw data file
     this.project = project;
     this.file = fileToOpen;

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_imzml/ImzMLImportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_imzml/ImzMLImportModule.java
@@ -33,9 +33,9 @@ import io.github.mzmine.util.RawDataFileTypeDetector;
 import io.github.mzmine.util.RawDataFileUtils;
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -74,7 +74,7 @@ public class ImzMLImportModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(final @NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     File fileNames[] = parameters.getParameter(ImzMLImportParameters.fileNames).getValue();
 

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_imzml/ImzMLImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_imzml/ImzMLImportTask.java
@@ -46,6 +46,7 @@ import io.github.mzmine.util.ExceptionUtils;
 import io.github.mzmine.util.scans.ScanUtils;
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Date;
 import java.util.Hashtable;
 import java.util.LinkedList;
@@ -86,7 +87,7 @@ public class ImzMLImportTask extends AbstractTask {
 
   public ImzMLImportTask(MZmineProject project, File fileToOpen, ImagingRawDataFile newMZmineFile,
       @NotNull final Class<? extends MZmineModule> module, @NotNull final ParameterSet parameters,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // storage in raw data file
     this.project = project;
     this.file = fileToOpen;

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzdata/MzDataImportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzdata/MzDataImportModule.java
@@ -33,9 +33,9 @@ import io.github.mzmine.util.RawDataFileTypeDetector;
 import io.github.mzmine.util.RawDataFileUtils;
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -74,7 +74,7 @@ public class MzDataImportModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(final @NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     File fileNames[] = parameters.getParameter(MzDataImportParameters.fileNames).getValue();
 

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzdata/MzDataImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzdata/MzDataImportTask.java
@@ -37,6 +37,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.time.Instant;
 import java.util.Base64;
 import java.util.Date;
 import java.util.LinkedList;
@@ -103,7 +104,7 @@ public class MzDataImportTask extends AbstractTask {
   private LinkedList<SimpleScan> parentStack;
 
   public MzDataImportTask(MZmineProject project, File fileToOpen, RawDataFile newMZmineFile,
-      @NotNull final Class<? extends MZmineModule> module, @NotNull final ParameterSet parameters, @NotNull Date moduleCallDate) {
+      @NotNull final Class<? extends MZmineModule> module, @NotNull final ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // storage in raw data file
     this.parameters = parameters;
     this.module = module;

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzml/MSDKmzMLImportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzml/MSDKmzMLImportModule.java
@@ -33,9 +33,9 @@ import io.github.mzmine.util.RawDataFileTypeDetector;
 import io.github.mzmine.util.RawDataFileUtils;
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -74,7 +74,7 @@ public class MSDKmzMLImportModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(final @NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     File fileNames[] = parameters.getParameter(MSDKmzMLImportParameters.fileNames).getValue();
 

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzml/MSDKmzMLImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzml/MSDKmzMLImportTask.java
@@ -44,6 +44,7 @@ import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.ExceptionUtils;
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
@@ -74,13 +75,13 @@ public class MSDKmzMLImportTask extends AbstractTask {
 
   public MSDKmzMLImportTask(MZmineProject project, File fileToOpen, RawDataFile newMZmineFile,
       @NotNull final Class<? extends MZmineModule> module, @NotNull final ParameterSet parameters,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     this(project, fileToOpen, newMZmineFile, null, module, parameters, moduleCallDate);
   }
 
   public MSDKmzMLImportTask(MZmineProject project, File fileToOpen, RawDataFile newMZmineFile,
       AdvancedSpectraImportParameters advancedParam, @NotNull final Class<? extends MZmineModule> module,
-      @NotNull final ParameterSet parameters, @NotNull Date moduleCallDate) {
+      @NotNull final ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(newMZmineFile.getMemoryMapStorage(), moduleCallDate); // storage in raw data file
     this.file = fileToOpen;
     this.project = project;

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzxml/MzXMLImportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzxml/MzXMLImportModule.java
@@ -31,9 +31,9 @@ import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.RawDataFileUtils;
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -72,7 +72,7 @@ public class MzXMLImportModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(final @NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     File fileNames[] = parameters.getParameter(MzXMLImportParameters.fileNames).getValue();
 

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzxml/MzXMLImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzxml/MzXMLImportTask.java
@@ -44,6 +44,7 @@ import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Base64;
 import java.util.Date;
 import java.util.LinkedList;
@@ -117,14 +118,14 @@ public class MzXMLImportTask extends AbstractTask {
 
   public MzXMLImportTask(MZmineProject project, File fileToOpen, RawDataFile newMZmineFile,
       @NotNull final Class<? extends MZmineModule> module, @NotNull final ParameterSet parameters,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     this(project, fileToOpen, newMZmineFile, null, module, parameters, moduleCallDate);
   }
 
   public MzXMLImportTask(MZmineProject project, File fileToOpen, RawDataFile newMZmineFile,
       AdvancedSpectraImportParameters advancedParam,
       @NotNull final Class<? extends MZmineModule> module, @NotNull final ParameterSet parameters,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // storage in raw data file
     this.parameters = parameters;
     this.module = module;

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_netcdf/NetCDFImportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_netcdf/NetCDFImportModule.java
@@ -31,9 +31,9 @@ import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.RawDataFileUtils;
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -72,7 +72,7 @@ public class NetCDFImportModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(final @NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     File fileNames[] = parameters.getParameter(NetCDFImportParameters.fileNames).getValue();
 

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_netcdf/NetCDFImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_netcdf/NetCDFImportTask.java
@@ -33,6 +33,7 @@ import io.github.mzmine.util.ExceptionUtils;
 import io.github.mzmine.util.scans.ScanUtils;
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Date;
 import java.util.Hashtable;
 import java.util.logging.Level;
@@ -73,7 +74,7 @@ public class NetCDFImportTask extends AbstractTask {
   private double intensityValueScaleFactor = 1;
 
   public NetCDFImportTask(MZmineProject project, File fileToOpen, RawDataFile newMZmineFile,
-      @NotNull final Class<? extends MZmineModule> module, @NotNull final ParameterSet parameters, @NotNull Date moduleCallDate) {
+      @NotNull final Class<? extends MZmineModule> module, @NotNull final ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // storage in raw data file
     this.project = project;
     this.file = fileToOpen;

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_thermo_raw/ThermoRawImportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_thermo_raw/ThermoRawImportModule.java
@@ -31,9 +31,9 @@ import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.RawDataFileUtils;
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -73,7 +73,7 @@ public class ThermoRawImportModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(final @NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     File fileNames[] = parameters.getParameter(ThermoRawImportParameters.fileNames).getValue();
 

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_thermo_raw/ThermoRawImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_thermo_raw/ThermoRawImportTask.java
@@ -40,6 +40,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.time.Instant;
 import java.util.Date;
 import java.util.logging.Logger;
 import java.util.zip.ZipInputStream;
@@ -79,7 +80,7 @@ public class ThermoRawImportTask extends AbstractTask {
   private MzMLFileImportMethod msdkTask;
 
   public ThermoRawImportTask(MZmineProject project, File fileToOpen, RawDataFile newMZmineFile,
-      @NotNull final Class<? extends MZmineModule> module, @NotNull final ParameterSet parameters, @NotNull Date moduleCallDate) {
+      @NotNull final Class<? extends MZmineModule> module, @NotNull final ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // storage in raw data file
     this.project = project;
     this.fileToOpen = fileToOpen;

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_waters_raw/WatersRawImportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_waters_raw/WatersRawImportModule.java
@@ -31,9 +31,9 @@ import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.RawDataFileUtils;
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -72,7 +72,7 @@ public class WatersRawImportModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(final @NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     File fileNames[] = parameters.getParameter(WatersRawImportParameters.fileNames).getValue();
 

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_waters_raw/WatersRawImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_waters_raw/WatersRawImportTask.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.time.Instant;
 import java.util.Date;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -77,7 +78,7 @@ public class WatersRawImportTask extends AbstractTask {
   private double precursorMZ = 0;
 
   public WatersRawImportTask(MZmineProject project, File fileToOpen, RawDataFile newMZmineFile,
-      @NotNull final Class<? extends MZmineModule> module, @NotNull final ParameterSet parameters, @NotNull Date moduleCallDate) {
+      @NotNull final Class<? extends MZmineModule> module, @NotNull final ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // storage in raw data file
     this.project = project;
     this.file = fileToOpen;

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_zip/ZipImportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_zip/ZipImportModule.java
@@ -34,9 +34,9 @@ import io.github.mzmine.util.RawDataFileTypeDetector;
 import io.github.mzmine.util.RawDataFileUtils;
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -75,7 +75,7 @@ public class ZipImportModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(final @NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     File fileNames[] = parameters.getParameter(ZipImportParameters.fileNames).getValue();
 

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_zip/ZipImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_zip/ZipImportTask.java
@@ -34,6 +34,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -60,7 +61,7 @@ public class ZipImportTask extends AbstractTask {
   private Task decompressedOpeningTask = null;
 
   public ZipImportTask(@NotNull MZmineProject project, File fileToOpen, RawDataFileType fileType,
-      @NotNull final Class<? extends MZmineModule> module, @NotNull final ParameterSet parameters, @NotNull Date moduleCallDate) {
+      @NotNull final Class<? extends MZmineModule> module, @NotNull final ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // storage in raw data file
     this.project = project;
     this.fileToOpen = fileToOpen;

--- a/src/main/java/io/github/mzmine/modules/io/projectload/ProjectLoadModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/projectload/ProjectLoadModule.java
@@ -18,9 +18,9 @@
 
 package io.github.mzmine.modules.io.projectload;
 
+import java.time.Instant;
 import java.util.Collection;
 
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -53,7 +53,7 @@ public class ProjectLoadModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     ProjectOpeningTask newTask = new ProjectOpeningTask(parameters, moduleCallDate);
     tasks.add(newTask);
     return ExitCode.OK;

--- a/src/main/java/io/github/mzmine/modules/io/projectload/ProjectOpeningTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/projectload/ProjectOpeningTask.java
@@ -39,6 +39,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.time.Instant;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -71,12 +72,12 @@ public class ProjectOpeningTask extends AbstractTask {
 //  private final Hashtable<String, RawDataFile> dataFilesIDMap = new Hashtable<>();
 //  private final Hashtable<String, File> scanFilesIDMap = new Hashtable<>();
 
-  public ProjectOpeningTask(ParameterSet parameters, @NotNull Date moduleCallDate) {
+  public ProjectOpeningTask(ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate);
     this.openFile = parameters.getParameter(ProjectLoaderParameters.projectFile).getValue();
   }
 
-  public ProjectOpeningTask(File openFile, @NotNull Date moduleCallDate) {
+  public ProjectOpeningTask(File openFile, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate);
     this.openFile = openFile;
   }

--- a/src/main/java/io/github/mzmine/modules/io/projectload/RawDataFileOpenHandler.java
+++ b/src/main/java/io/github/mzmine/modules/io/projectload/RawDataFileOpenHandler.java
@@ -22,13 +22,14 @@ import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.modules.io.projectload.version_3_0.RawDataFileOpenHandler_3_0;
 import io.github.mzmine.taskcontrol.Task;
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.Date;
 import java.util.zip.ZipFile;
 import org.jetbrains.annotations.NotNull;
 
 public interface RawDataFileOpenHandler extends Task {
 
-  public static RawDataFileOpenHandler forVersion(String versionString, @NotNull Date moduleCallDate) {
+  public static RawDataFileOpenHandler forVersion(String versionString, @NotNull Instant moduleCallDate) {
     return new RawDataFileOpenHandler_3_0(moduleCallDate);
   }
 

--- a/src/main/java/io/github/mzmine/modules/io/projectload/version_3_0/FeatureListLoadTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/projectload/version_3_0/FeatureListLoadTask.java
@@ -41,9 +41,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -89,7 +89,7 @@ public class FeatureListLoadTask extends AbstractTask {
 
   public FeatureListLoadTask(@Nullable MemoryMapStorage storage, @NotNull MZmineProject project,
       ZipFile zip) {
-    super(storage, new Date());
+    super(storage, Instant.now());
     this.project = project;
     this.zip = zip;
   }

--- a/src/main/java/io/github/mzmine/modules/io/projectload/version_3_0/RawDataFileOpenHandler_3_0.java
+++ b/src/main/java/io/github/mzmine/modules/io/projectload/version_3_0/RawDataFileOpenHandler_3_0.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -62,7 +63,7 @@ public class RawDataFileOpenHandler_3_0 extends AbstractTask implements RawDataF
   private AbstractTask currentTask;
   private ZipFile zipFile;
 
-  public RawDataFileOpenHandler_3_0(@NotNull Date moduleCallDate) {
+  public RawDataFileOpenHandler_3_0(@NotNull Instant moduleCallDate) {
     super(null, moduleCallDate);
   }
 
@@ -188,7 +189,7 @@ public class RawDataFileOpenHandler_3_0 extends AbstractTask implements RawDataF
         param.setParameter(BatchModeParameters.batchQueue, batchQueue);
         final BatchModeModule batchModule = MZmineCore.getModuleInstance(BatchModeModule.class);
         final List<Task> tasks = new ArrayList<>();
-        batchModule.runModule(project, param, tasks, new Date());
+        batchModule.runModule(project, param, tasks, Instant.now());
 
         List<AbstractTask> abstractTasks = tasks.stream().filter(t -> t instanceof AbstractTask)
             .map(t -> (AbstractTask) t).toList();

--- a/src/main/java/io/github/mzmine/modules/io/projectsave/FeatureListSaveTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/projectsave/FeatureListSaveTask.java
@@ -40,7 +40,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.logging.Level;
@@ -79,7 +79,7 @@ public class FeatureListSaveTask extends AbstractTask {
   private int processedRows = 0;
 
   public FeatureListSaveTask(ModularFeatureList flist, ZipOutputStream zos) {
-    super(null, new Date());
+    super(null, Instant.now());
     this.flist = flist;
     this.zos = zos;
     rows = flist.getNumberOfRows();

--- a/src/main/java/io/github/mzmine/modules/io/projectsave/ProjectSaveAsModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/projectsave/ProjectSaveAsModule.java
@@ -18,9 +18,9 @@
 
 package io.github.mzmine.modules.io.projectsave;
 
+import java.time.Instant;
 import java.util.Collection;
 
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -48,7 +48,7 @@ public class ProjectSaveAsModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     ProjectSavingTask newTask = new ProjectSavingTask(project, parameters, moduleCallDate);
     tasks.add(newTask);
     return ExitCode.OK;

--- a/src/main/java/io/github/mzmine/modules/io/projectsave/ProjectSaveModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/projectsave/ProjectSaveModule.java
@@ -18,9 +18,9 @@
 
 package io.github.mzmine.modules.io.projectsave;
 
+import java.time.Instant;
 import java.util.Collection;
 
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -48,7 +48,7 @@ public class ProjectSaveModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     ProjectSavingTask newTask = new ProjectSavingTask(project, parameters, moduleCallDate);
     tasks.add(newTask);
     return ExitCode.OK;

--- a/src/main/java/io/github/mzmine/modules/io/projectsave/ProjectSavingTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/projectsave/ProjectSavingTask.java
@@ -34,6 +34,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Date;
 import java.util.Hashtable;
 import java.util.Objects;
@@ -71,7 +72,7 @@ public class ProjectSavingTask extends AbstractTask {
   private Hashtable<RawDataFile, String> dataFilesIDMap;
 
   public ProjectSavingTask(MZmineProject project, ParameterSet parameters,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate);
     this.savedProject = (MZmineProjectImpl) project;
     this.saveFile = parameters.getParameter(ProjectLoaderParameters.projectFile).getValue();

--- a/src/main/java/io/github/mzmine/modules/io/projectsave/RawDataFileSaveHandler.java
+++ b/src/main/java/io/github/mzmine/modules/io/projectsave/RawDataFileSaveHandler.java
@@ -40,6 +40,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -94,7 +95,7 @@ public class RawDataFileSaveHandler extends AbstractTask {
   }
 
   public RawDataFileSaveHandler(MZmineProject project, ZipOutputStream zipOutputStream,
-      boolean saveFilesInProject, @NotNull Date moduleCallDate) {
+      boolean saveFilesInProject, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate);
     this.project = project;
     this.zipStream = zipOutputStream;

--- a/src/main/java/io/github/mzmine/modules/io/projectsave/RawDataSavingUtils.java
+++ b/src/main/java/io/github/mzmine/modules/io/projectsave/RawDataSavingUtils.java
@@ -15,6 +15,7 @@ import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilePlacehold
 import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesSelectionType;
 import java.io.File;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -47,7 +48,7 @@ public class RawDataSavingUtils {
         .sorted(Comparator.comparing(FeatureListAppliedMethod::getModuleCallDate)).toList();
 
     // group applied methods by date
-    final Map<Date, List<FeatureListAppliedMethod>> methodMap = new TreeMap<>();
+    final Map<Instant, List<FeatureListAppliedMethod>> methodMap = new TreeMap<>();
     for (FeatureListAppliedMethod method : appliedMethods) {
       final List<FeatureListAppliedMethod> value = methodMap
           .computeIfAbsent(method.getModuleCallDate(), d -> new ArrayList<>());

--- a/src/main/java/io/github/mzmine/modules/io/spectraldbsubmit/LibrarySubmitTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/spectraldbsubmit/LibrarySubmitTask.java
@@ -47,6 +47,7 @@ import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.files.FileAndPathUtil;
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Date;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -98,7 +99,7 @@ public class LibrarySubmitTask extends AbstractTask {
   private final MSMSLibrarySubmissionWindow window;
 
   public LibrarySubmitTask(MSMSLibrarySubmissionWindow window,
-      Map<LibrarySubmitIonParameters, DataPoint[]> map, @NotNull Date moduleCallDate) {
+      Map<LibrarySubmitIonParameters, DataPoint[]> map, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate);
     this.window = window;
     this.map = map;
@@ -127,7 +128,7 @@ public class LibrarySubmitTask extends AbstractTask {
     }
   }
 
-  public LibrarySubmitTask(Map<LibrarySubmitIonParameters, DataPoint[]> map, @NotNull Date moduleCallDate) {
+  public LibrarySubmitTask(Map<LibrarySubmitIonParameters, DataPoint[]> map, @NotNull Instant moduleCallDate) {
     this(null, map, moduleCallDate);
   }
 

--- a/src/main/java/io/github/mzmine/modules/io/spectraldbsubmit/view/MSMSLibrarySubmissionWindow.java
+++ b/src/main/java/io/github/mzmine/modules/io/spectraldbsubmit/view/MSMSLibrarySubmissionWindow.java
@@ -47,6 +47,7 @@ import io.github.mzmine.util.scans.sorting.ScanSortMode;
 import java.awt.Dimension;
 import java.net.URL;
 import java.text.MessageFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -564,7 +565,7 @@ public class MSMSLibrarySubmissionWindow extends Stage {
           // start task
           logger.info(
               "Added task to export library entries: " + ions + " MS/MS spectra were selected");
-          LibrarySubmitTask task = new LibrarySubmitTask(this, map, new Date());
+          LibrarySubmitTask task = new LibrarySubmitTask(this, map, Instant.now());
           MZmineCore.getTaskController().addTask(task);
         }
       }

--- a/src/main/java/io/github/mzmine/modules/tools/batchwizard/BatchWizardModule.java
+++ b/src/main/java/io/github/mzmine/modules/tools/batchwizard/BatchWizardModule.java
@@ -25,8 +25,8 @@ import io.github.mzmine.modules.MZmineRunnableModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -50,7 +50,7 @@ public class BatchWizardModule implements MZmineRunnableModule {
   @Override
   public @NotNull ExitCode runModule(@NotNull MZmineProject project,
       @NotNull ParameterSet parameters, @NotNull Collection<Task> tasks,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     if (MZmineCore.isHeadLessMode()) {
       return ExitCode.OK;
     }

--- a/src/main/java/io/github/mzmine/modules/tools/isotopepatternpreview/IsotopePatternPreviewModule.java
+++ b/src/main/java/io/github/mzmine/modules/tools/isotopepatternpreview/IsotopePatternPreviewModule.java
@@ -18,9 +18,9 @@
 
 package io.github.mzmine.modules.tools.isotopepatternpreview;
 
+import java.time.Instant;
 import java.util.Collection;
 
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -61,7 +61,7 @@ public class IsotopePatternPreviewModule implements MZmineRunnableModule {
   @Override
   public @NotNull ExitCode runModule(@NotNull MZmineProject project,
       @NotNull ParameterSet parameters, @NotNull Collection<Task> tasks,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
 
     return ExitCode.OK;
   }

--- a/src/main/java/io/github/mzmine/modules/tools/isotopepatternpreview/IsotopePatternPreviewTask.java
+++ b/src/main/java/io/github/mzmine/modules/tools/isotopepatternpreview/IsotopePatternPreviewTask.java
@@ -31,6 +31,7 @@ import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.tools.isotopeprediction.IsotopePatternCalculator;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Objects;
@@ -55,7 +56,7 @@ public class IsotopePatternPreviewTask extends AbstractTask {
   private boolean displayResult;
 
   public IsotopePatternPreviewTask() {
-    super(null, new Date()); // date irrelevant, not in batch mode
+    super(null, Instant.now()); // date irrelevant, not in batch mode
     message = "Wating for parameters";
     parametersChanged = false;
     formula = "";
@@ -67,7 +68,7 @@ public class IsotopePatternPreviewTask extends AbstractTask {
 
   public IsotopePatternPreviewTask(String formula, double minIntensity, double mergeWidth,
       int charge, PolarityType polarity, IsotopePatternPreviewDialog dialog) {
-    super(null, new Date());
+    super(null, Instant.now());
     parametersChanged = false;
     this.minIntensity = minIntensity;
     this.mergeWidth = mergeWidth;

--- a/src/main/java/io/github/mzmine/modules/tools/kovats/KovatsIndexExtractionModule.java
+++ b/src/main/java/io/github/mzmine/modules/tools/kovats/KovatsIndexExtractionModule.java
@@ -18,8 +18,8 @@
 
 package io.github.mzmine.modules.tools.kovats;
 
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -58,7 +58,7 @@ public class KovatsIndexExtractionModule implements MZmineRunnableModule {
   @Override
   public @NotNull ExitCode runModule(@NotNull MZmineProject project,
       @NotNull ParameterSet parameters, @NotNull Collection<Task> tasks,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
 
     return ExitCode.OK;
   }

--- a/src/main/java/io/github/mzmine/modules/tools/qualityparameters/QualityParametersModule.java
+++ b/src/main/java/io/github/mzmine/modules/tools/qualityparameters/QualityParametersModule.java
@@ -26,6 +26,7 @@ import io.github.mzmine.modules.MZmineRunnableModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Date;
 import org.jetbrains.annotations.NotNull;
@@ -45,7 +46,7 @@ public class QualityParametersModule implements MZmineRunnableModule {
   @NotNull
   @Override
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     for (FeatureList featureList : parameters.getParameter(QualityParametersParameters.peakLists)
         .getValue().getMatchingFeatureLists()) {
       runModule(featureList, parameters, moduleCallDate);
@@ -53,14 +54,14 @@ public class QualityParametersModule implements MZmineRunnableModule {
     return ExitCode.OK;
   }
 
-  public ExitCode runModule(FeatureList[] featureLists, ParameterSet parameters, @NotNull Date moduleCallDate) {
+  public ExitCode runModule(FeatureList[] featureLists, ParameterSet parameters, @NotNull Instant moduleCallDate) {
     for(FeatureList featureList : featureLists){
       runModule(featureList, parameters, moduleCallDate);
     }
     return ExitCode.OK;
   }
 
-  public ExitCode runModule(FeatureList featureList, ParameterSet parameters, @NotNull Date moduleCallDate) {
+  public ExitCode runModule(FeatureList featureList, ParameterSet parameters, @NotNull Instant moduleCallDate) {
     MZmineCore.getTaskController().addTask(new QualityParametersTask(featureList, parameters, moduleCallDate));
     return ExitCode.OK;
   }

--- a/src/main/java/io/github/mzmine/modules/tools/qualityparameters/QualityParametersTask.java
+++ b/src/main/java/io/github/mzmine/modules/tools/qualityparameters/QualityParametersTask.java
@@ -23,6 +23,7 @@ import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import java.time.Instant;
 import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
@@ -32,7 +33,7 @@ public class QualityParametersTask extends AbstractTask {
   private final ParameterSet parameterSet;
 
   private double finishedPercentage;
-  public QualityParametersTask(FeatureList featureList, ParameterSet parameterSet, @NotNull Date moduleCallDate) {
+  public QualityParametersTask(FeatureList featureList, ParameterSet parameterSet, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     this.parameterSet = parameterSet;
     this.featureList = featureList;

--- a/src/main/java/io/github/mzmine/modules/tools/rawfilerename/RawDataFileRenameModule.java
+++ b/src/main/java/io/github/mzmine/modules/tools/rawfilerename/RawDataFileRenameModule.java
@@ -29,9 +29,9 @@ import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesSelectio
 import io.github.mzmine.project.impl.MZmineProjectImpl;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -102,23 +102,9 @@ public class RawDataFileRenameModule implements MZmineProcessingModule {
   @Override
   public @NotNull ExitCode runModule(@NotNull MZmineProject project,
       @NotNull ParameterSet parameters, @NotNull Collection<Task> tasks,
-      @NotNull Date moduleCallDate) {
-    final RawDataFile[] matchingRawDataFiles = parameters.getParameter(
-        RawDataFileRenameParameters.files).getValue().getMatchingRawDataFiles();
-    final String newName = parameters.getParameter(RawDataFileRenameParameters.newName).getValue();
-    if (matchingRawDataFiles.length == 0) {
-      return ExitCode.OK;
-    }
+      @NotNull Instant moduleCallDate) {
 
-    RawDataFile file = matchingRawDataFiles[0];
-
-    // set name is now threadsafe and will return the set name after checking for duplicates etc
-    final String realName = file.setName(newName);
-    parameters.setParameter(RawDataFileRenameParameters.newName, realName);
-
-    file.getAppliedMethods()
-        .add(new SimpleFeatureListAppliedMethod(this, parameters, moduleCallDate));
-
+    tasks.add(new RawDataFileRenameTask(null, moduleCallDate, parameters));
     return ExitCode.OK;
   }
 

--- a/src/main/java/io/github/mzmine/modules/tools/rawfilerename/RawDataFileRenameTask.java
+++ b/src/main/java/io/github/mzmine/modules/tools/rawfilerename/RawDataFileRenameTask.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright 2006-2020 The MZmine Development Team
+ *
+ *  This file is part of MZmine.
+ *
+ *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ *  General Public License as published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
+ *
+ *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ *  Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with MZmine; if not,
+ *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ *  USA
+ */
+
+package io.github.mzmine.modules.tools.rawfilerename;
+
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
+import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.taskcontrol.AbstractTask;
+import io.github.mzmine.taskcontrol.TaskStatus;
+import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class RawDataFileRenameTask extends AbstractTask {
+  private final ParameterSet parameters;
+
+  public RawDataFileRenameTask(@Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate,
+      ParameterSet parameters) {
+    super(storage, moduleCallDate);
+    this.parameters = parameters;
+  }
+
+  @Override
+  public String getTaskDescription() {
+    return "Renaming raw data file.";
+  }
+
+  @Override
+  public double getFinishedPercentage() {
+    return 0;
+  }
+
+  @Override
+  public void run() {
+    setStatus(TaskStatus.PROCESSING);
+
+    final RawDataFile[] matchingRawDataFiles = parameters.getParameter(
+        RawDataFileRenameParameters.files).getValue().getMatchingRawDataFiles();
+    final String newName = parameters.getParameter(RawDataFileRenameParameters.newName).getValue();
+
+    if (matchingRawDataFiles.length == 0) {
+      setStatus(TaskStatus.FINISHED);
+    }
+
+    RawDataFile file = matchingRawDataFiles[0];
+
+    // set name is now threadsafe and will return the set name after checking for duplicates etc
+    final String realName = file.setName(newName);
+    parameters.setParameter(RawDataFileRenameParameters.newName, realName);
+
+    file.getAppliedMethods().add(
+        new SimpleFeatureListAppliedMethod(RawDataFileRenameModule.class, parameters,
+            getModuleCallDate()));
+
+    setStatus(TaskStatus.FINISHED);
+  }
+}

--- a/src/main/java/io/github/mzmine/modules/tools/sortdatafiles/SortDataFilesModule.java
+++ b/src/main/java/io/github/mzmine/modules/tools/sortdatafiles/SortDataFilesModule.java
@@ -18,9 +18,9 @@
 
 package io.github.mzmine.modules.tools.sortdatafiles;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 
 import org.jetbrains.annotations.NotNull;
@@ -54,7 +54,7 @@ public class SortDataFilesModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     List<RawDataFile> dataFiles = Arrays.asList(parameters
         .getParameter(SortDataFilesParameters.dataFiles).getValue().getMatchingRawDataFiles());

--- a/src/main/java/io/github/mzmine/modules/tools/sortfeaturelists/SortFeatureListsModule.java
+++ b/src/main/java/io/github/mzmine/modules/tools/sortfeaturelists/SortFeatureListsModule.java
@@ -19,9 +19,9 @@
 package io.github.mzmine.modules.tools.sortfeaturelists;
 
 import io.github.mzmine.datamodel.features.FeatureList;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -58,7 +58,7 @@ public class SortFeatureListsModule implements MZmineProcessingModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     List<FeatureList> featureLists = Arrays.asList(parameters
         .getParameter(SortFeatureListsParameters.featureLists).getValue().getMatchingFeatureLists());

--- a/src/main/java/io/github/mzmine/modules/visualization/chromatogram/ChromatogramVisualizerModule.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/chromatogram/ChromatogramVisualizerModule.java
@@ -34,10 +34,10 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.parametertypes.selectors.ScanSelection;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -96,7 +96,7 @@ public class ChromatogramVisualizerModule implements MZmineRunnableModule {
       }
 
       myInstance.runModule(MZmineCore.getProjectManager().getCurrentProject(), p,
-          new ArrayList<Task>(), new Date()); // date is irrelevant
+          new ArrayList<Task>(), Instant.now()); // date is irrelevant
     }
 
   }
@@ -226,7 +226,7 @@ public class ChromatogramVisualizerModule implements MZmineRunnableModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     final RawDataFile[] dataFiles = parameters.getParameter(TICVisualizerParameters.DATA_FILES)
         .getValue().getMatchingRawDataFiles();
     final Range<Double> mzRange =

--- a/src/main/java/io/github/mzmine/modules/visualization/chromatogram/ExportChromatogramTask.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/chromatogram/ExportChromatogramTask.java
@@ -24,15 +24,15 @@
 
 package io.github.mzmine.modules.visualization.chromatogram;
 
+import io.github.mzmine.taskcontrol.AbstractTask;
+import io.github.mzmine.taskcontrol.TaskStatus;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import io.github.mzmine.taskcontrol.AbstractTask;
-import io.github.mzmine.taskcontrol.TaskStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -58,7 +58,7 @@ public class ExportChromatogramTask extends AbstractTask {
    * @param data data set to export.
    * @param file file to write to.
    */
-  public ExportChromatogramTask(final TICDataSet data, final File file, @NotNull Date moduleCallDate) {
+  public ExportChromatogramTask(final TICDataSet data, final File file, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate);
 
     dataSet = data;

--- a/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICVisualizerTab.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICVisualizerTab.java
@@ -41,6 +41,7 @@ import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.io.File;
 import java.text.NumberFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -487,7 +488,8 @@ public class TICVisualizerTab extends MZmineTab {
       final File exportFile = exportChooser.showSaveDialog(getTabPane().getScene().getWindow());
       if (exportFile != null) {
 
-        MZmineCore.getTaskController().addTask(new ExportChromatogramTask(dataSet, exportFile, new Date()));
+        MZmineCore.getTaskController().addTask(new ExportChromatogramTask(dataSet, exportFile,
+            Instant.now()));
       }
     }
   }

--- a/src/main/java/io/github/mzmine/modules/visualization/chromatogramandspectra/FeatureDataSetCalc.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/chromatogramandspectra/FeatureDataSetCalc.java
@@ -18,13 +18,6 @@
 
 package io.github.mzmine.modules.visualization.chromatogramandspectra;
 
-import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.logging.Logger;
 import com.google.common.collect.Range;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.features.ModularFeature;
@@ -39,6 +32,13 @@ import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.FeatureConvertors;
 import io.github.mzmine.util.ManualFeatureUtils;
+import java.text.NumberFormat;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.logging.Logger;
 import javafx.application.Platform;
 
 /**
@@ -60,7 +60,7 @@ public class FeatureDataSetCalc extends AbstractTask {
 
   public FeatureDataSetCalc(final Collection<RawDataFile> rawDataFiles, final Range<Double> mzRange,
       ScanSelection scanSelection, TICPlot chromPlot) {
-    super(null, new Date()); // no new data stored -> null, date irrelevant (not used in batch)
+    super(null, Instant.now()); // no new data stored -> null, date irrelevant (not used in batch)
     this.rawDataFiles = rawDataFiles;
     this.mzRange = mzRange;
     this.chromPlot = chromPlot;

--- a/src/main/java/io/github/mzmine/modules/visualization/chromatogramandspectra/SpectraDataSetCalc.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/chromatogramandspectra/SpectraDataSetCalc.java
@@ -28,6 +28,7 @@ import io.github.mzmine.modules.visualization.spectra.simplespectra.datasets.Sca
 import io.github.mzmine.parameters.parametertypes.selectors.ScanSelection;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -49,7 +50,7 @@ public class SpectraDataSetCalc extends AbstractTask {
       final ChromatogramCursorPosition pos, final ScanSelection scanSelection,
       boolean showSpectraOfEveryRawFile, SpectraPlot spectrumPlot,
       BooleanProperty showMassListProperty) {
-    super(null, new Date());
+    super(null, Instant.now());
     filesAndDataSets = new HashMap<>();
     this.rawDataFiles = rawDataFiles;
     this.pos = pos;

--- a/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableContextMenu.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableContextMenu.java
@@ -65,9 +65,9 @@ import io.github.mzmine.util.SortingDirection;
 import io.github.mzmine.util.SortingProperty;
 import io.github.mzmine.util.components.ConditionalMenuItem;
 import io.github.mzmine.util.scans.SpectraMerging;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -171,7 +171,7 @@ public class FeatureTableContextMenu extends ContextMenu {
     final MenuItem exportToSirius =
         new ConditionalMenuItem("Export to Sirius", () -> !selectedRows.isEmpty());
     exportToSirius.setOnAction(e -> SiriusExportModule
-        .exportSingleRows(selectedRows.toArray(new ModularFeatureListRow[0]), new Date()));
+        .exportSingleRows(selectedRows.toArray(new ModularFeatureListRow[0]), Instant.now()));
 
     final MenuItem exportMS1Library =
         new ConditionalMenuItem("Export to MS1 library", () -> !selectedRows.isEmpty());
@@ -194,7 +194,7 @@ public class FeatureTableContextMenu extends ContextMenu {
     final MenuItem exportImageToCsv = new ConditionalMenuItem("Export image to .csv",
         () -> !selectedRows.isEmpty() && selectedRows.get(0).hasFeatureType(ImageType.class));
     exportImageToCsv
-        .setOnAction(e -> ImageToCsvExportModule.showExportDialog(selectedRows, new Date()));
+        .setOnAction(e -> ImageToCsvExportModule.showExportDialog(selectedRows, Instant.now()));
 
     // export menu
     exportMenu.getItems().addAll(exportIsotopesItem, exportMSMSItem, exportToSirius,
@@ -207,13 +207,13 @@ public class FeatureTableContextMenu extends ContextMenu {
         new ConditionalMenuItem("Online compound database search", () -> selectedRows.size() == 1);
     onlineDbSearchItem.setOnAction(
         e -> OnlineDBSearchModule
-            .showSingleRowIdentificationDialog(selectedRows.get(0), new Date()));
+            .showSingleRowIdentificationDialog(selectedRows.get(0), Instant.now()));
 
     final MenuItem spectralDbSearchItem =
         new ConditionalMenuItem("Local spectral database search", () -> selectedRows.size() >= 1);
     spectralDbSearchItem
         .setOnAction(e -> LocalSpectralDBSearchModule.showSelectedRowsIdentificationDialog(
-            selectedRows.toArray(new ModularFeatureListRow[0]), table, new Date()));
+            selectedRows.toArray(new ModularFeatureListRow[0]), table, Instant.now()));
 
     final MenuItem nistSearchItem =
         new ConditionalMenuItem("NIST MS search", () -> selectedRows.size() == 1);
@@ -227,7 +227,7 @@ public class FeatureTableContextMenu extends ContextMenu {
         new ConditionalMenuItem("Sirius structure prediction", () -> selectedRows.size() == 1);
     siriusItem.setOnAction(
         e -> SiriusIdentificationModule
-            .showSingleRowIdentificationDialog(selectedRows.get(0), new Date()));
+            .showSingleRowIdentificationDialog(selectedRows.get(0), Instant.now()));
 
     final MenuItem formulaPredictionItem =
         new ConditionalMenuItem("Predict molecular formula", () -> selectedRows.size() == 1);

--- a/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableDoubleClickTask.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableDoubleClickTask.java
@@ -22,7 +22,7 @@ import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.datamodel.features.types.DataType;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
-import java.util.Date;
+import java.time.Instant;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -37,7 +37,7 @@ public class FeatureTableDoubleClickTask extends AbstractTask {
 
   protected FeatureTableDoubleClickTask(final Runnable runnable, final ModularFeatureList flist,
       final DataType<?> dataType) {
-    super(null, new Date()); // date is irrelevant
+    super(null, Instant.now()); // date is irrelevant
 
     this.runnable = runnable;
     this.flist = flist;

--- a/src/main/java/io/github/mzmine/modules/visualization/fx3d/Fx3DSamplingTask.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/fx3d/Fx3DSamplingTask.java
@@ -30,7 +30,7 @@ import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.ExceptionUtils;
 import io.github.mzmine.util.scans.ScanUtils;
 import io.github.mzmine.util.scans.ScanUtils.BinningType;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Random;
 import java.util.logging.Logger;
 import javafx.application.Platform;
@@ -73,7 +73,7 @@ class Fx3DSamplingTask extends AbstractTask {
    */
   Fx3DSamplingTask(RawDataFile dataFile, ScanSelection scanSel, Range<Double> mzRange,
       int rtResolution, int mzResolution, Fx3DBorderPaneController controller) {
-    super(null, new Date()); // no new data stored -> null, date is irrelevant
+    super(null, Instant.now()); // no new data stored -> null, date is irrelevant
 
     this.dataFile = dataFile;
     this.scans = scanSel.getMatchingScans(dataFile);

--- a/src/main/java/io/github/mzmine/modules/visualization/fx3d/Fx3DVisualizerModule.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/fx3d/Fx3DVisualizerModule.java
@@ -18,17 +18,10 @@
 
 package io.github.mzmine.modules.visualization.fx3d;
 
-import io.github.mzmine.datamodel.features.Feature;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.logging.Logger;
-import org.jetbrains.annotations.NotNull;
 import com.google.common.collect.Range;
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.MZmineRunnableModule;
@@ -38,8 +31,15 @@ import io.github.mzmine.parameters.parametertypes.selectors.ScanSelection;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.scans.ScanUtils;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
 import javafx.application.ConditionalFeature;
 import javafx.application.Platform;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * @author akshaj This class represents the module class of the Fx3DVisualizer.
@@ -64,7 +64,7 @@ public class Fx3DVisualizerModule implements MZmineRunnableModule {
   @Override
   public @NotNull ExitCode runModule(@NotNull MZmineProject project,
       @NotNull ParameterSet parameters, @NotNull Collection<Task> tasks,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
 
     final RawDataFile[] currentDataFiles = parameters
         .getParameter(Fx3DVisualizerParameters.dataFiles).getValue().getMatchingRawDataFiles();
@@ -125,7 +125,7 @@ public class Fx3DVisualizerModule implements MZmineRunnableModule {
 
     if (myParameters.showSetupDialog(true) == ExitCode.OK) {
       myInstance.runModule(MZmineCore.getProjectManager().getCurrentProject(),
-          myParameters.cloneParameterSet(), new ArrayList<Task>(), new Date());
+          myParameters.cloneParameterSet(), new ArrayList<Task>(), Instant.now());
     }
   }
 

--- a/src/main/java/io/github/mzmine/modules/visualization/histo_feature_correlation/FeatureCorrelationHistogramModule.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/histo_feature_correlation/FeatureCorrelationHistogramModule.java
@@ -24,8 +24,8 @@ import io.github.mzmine.modules.MZmineRunnableModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public class FeatureCorrelationHistogramModule implements MZmineRunnableModule {
@@ -47,7 +47,7 @@ public class FeatureCorrelationHistogramModule implements MZmineRunnableModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     ModularFeatureList[] flists = parameters
         .getParameter(FeatureCorrelationHistogramParameters.featureLists)

--- a/src/main/java/io/github/mzmine/modules/visualization/histo_feature_correlation/FeatureCorrelationHistogramTask.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/histo_feature_correlation/FeatureCorrelationHistogramTask.java
@@ -29,7 +29,7 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
-import java.util.Date;
+import java.time.Instant;
 import java.util.logging.Logger;
 import javafx.application.Platform;
 import org.jetbrains.annotations.NotNull;
@@ -43,7 +43,7 @@ public class FeatureCorrelationHistogramTask extends AbstractTask {
   private FeatureCorrelationHistogramTab tab;
 
   public FeatureCorrelationHistogramTask(ModularFeatureList flist, ParameterSet parameters,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     this.flist = flist;
     startBinWidth = parameters.getParameter(FeatureCorrelationHistogramParameters.binWidth)

--- a/src/main/java/io/github/mzmine/modules/visualization/histogram/HistogramVisualizerModule.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/histogram/HistogramVisualizerModule.java
@@ -19,8 +19,8 @@
 package io.github.mzmine.modules.visualization.histogram;
 
 import io.github.mzmine.main.MZmineCore;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.modules.MZmineModuleCategory;
@@ -47,7 +47,7 @@ public class HistogramVisualizerModule implements MZmineRunnableModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     HistogramTab newTab = new HistogramTab(parameters);
     //newTab.show();
     MZmineCore.getDesktop().addTab(newTab);

--- a/src/main/java/io/github/mzmine/modules/visualization/image/ImageVisualizerModule.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/image/ImageVisualizerModule.java
@@ -18,8 +18,8 @@
 
 package io.github.mzmine.modules.visualization.image;
 
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import io.github.mzmine.datamodel.ImagingRawDataFile;
@@ -53,7 +53,7 @@ public class ImageVisualizerModule implements MZmineRunnableModule {
   @NotNull
   @Override
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     RawDataFile[] files = parameters.getParameter(ImageVisualizerParameters.rawDataFiles).getValue()
         .getMatchingRawDataFiles();

--- a/src/main/java/io/github/mzmine/modules/visualization/image/ImageVisualizerTask.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/image/ImageVisualizerTask.java
@@ -35,6 +35,7 @@ import io.github.mzmine.parameters.parametertypes.selectors.ScanSelection;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.scans.ScanUtils;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -67,7 +68,7 @@ public class ImageVisualizerTask extends AbstractTask {
 
 
   public ImageVisualizerTask(RawDataFile rawDataFile, ParameterSet parameters) {
-    super(null, new Date());// date irrelevant
+    super(null, Instant.now());// date irrelevant
     this.parameters = parameters;
     this.rawDataFile = (ImagingRawDataFile) rawDataFile;
     this.imagingParameters = ((ImagingRawDataFile) rawDataFile).getImagingParam();

--- a/src/main/java/io/github/mzmine/modules/visualization/ims_mobilitymzplot/CalculateDatasetsTask.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/ims_mobilitymzplot/CalculateDatasetsTask.java
@@ -41,8 +41,8 @@ import io.github.mzmine.gui.chartbasics.simplechart.renderers.ColoredXYZPieRende
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -65,7 +65,7 @@ public class CalculateDatasetsTask extends AbstractTask {
 
   public CalculateDatasetsTask(Collection<ModularFeatureListRow> rows,
       PlotType plotType, boolean useMobilograms) {
-    super(null, new Date()); // no new data stored -> null, date is irrelevant (not used in batch)
+    super(null, Instant.now()); // no new data stored -> null, date is irrelevant (not used in batch)
     this.rows = rows;
     this.plotType = plotType;
     this.useMobilograms = useMobilograms;

--- a/src/main/java/io/github/mzmine/modules/visualization/intensityplot/IntensityPlotModule.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/intensityplot/IntensityPlotModule.java
@@ -21,8 +21,8 @@ package io.github.mzmine.modules.visualization.intensityplot;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsSelectionType;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.datamodel.RawDataFile;
@@ -55,7 +55,7 @@ public class IntensityPlotModule implements MZmineRunnableModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     IntensityPlotTab newTab = new IntensityPlotTab(parameters);
     //newFrame.show();
     MZmineCore.getDesktop().addTab(newTab);

--- a/src/main/java/io/github/mzmine/modules/visualization/kendrickmassplot/KendrickMassPlotModule.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/kendrickmassplot/KendrickMassPlotModule.java
@@ -18,8 +18,8 @@
 
 package io.github.mzmine.modules.visualization.kendrickmassplot;
 
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.modules.MZmineModuleCategory;
@@ -51,7 +51,7 @@ public class KendrickMassPlotModule implements MZmineRunnableModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     Task newTask = new KendrickMassPlotTask(parameters, moduleCallDate);
     tasks.add(newTask);

--- a/src/main/java/io/github/mzmine/modules/visualization/kendrickmassplot/KendrickMassPlotTask.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/kendrickmassplot/KendrickMassPlotTask.java
@@ -21,6 +21,7 @@ package io.github.mzmine.modules.visualization.kendrickmassplot;
 import java.awt.Color;
 import java.awt.Font;
 import java.awt.Paint;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.logging.Logger;
@@ -90,7 +91,7 @@ public class KendrickMassPlotTask extends AbstractTask {
   private FeatureListRow[] rows;
   private int totalSteps = 3, appliedSteps = 0;
 
-  public KendrickMassPlotTask(ParameterSet parameters, @NotNull Date moduleCallDate) {
+  public KendrickMassPlotTask(ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate);
     featureList = parameters.getParameter(KendrickMassPlotParameters.featureList).getValue()
         .getMatchingFeatureLists()[0];

--- a/src/main/java/io/github/mzmine/modules/visualization/msms/MsMsVisualizerModule.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/msms/MsMsVisualizerModule.java
@@ -25,8 +25,8 @@ import io.github.mzmine.modules.MZmineRunnableModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public class MsMsVisualizerModule implements MZmineRunnableModule {
@@ -50,7 +50,7 @@ public class MsMsVisualizerModule implements MZmineRunnableModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     assert MZmineCore.getDesktop() != null;
 
     MsMsVisualizerTab newTab = new MsMsVisualizerTab(parameters);

--- a/src/main/java/io/github/mzmine/modules/visualization/mzhistogram/CorrelatedFeaturesMzHistogramModule.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/mzhistogram/CorrelatedFeaturesMzHistogramModule.java
@@ -24,8 +24,8 @@ import io.github.mzmine.modules.MZmineRunnableModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public class CorrelatedFeaturesMzHistogramModule implements MZmineRunnableModule {
@@ -47,7 +47,7 @@ public class CorrelatedFeaturesMzHistogramModule implements MZmineRunnableModule
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     ModularFeatureList[] flists = parameters
         .getParameter(CorrelatedFeaturesMzHistogramParameters.featureLists)

--- a/src/main/java/io/github/mzmine/modules/visualization/mzhistogram/CorrelatedFeaturesMzHistogramTask.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/mzhistogram/CorrelatedFeaturesMzHistogramTask.java
@@ -35,8 +35,8 @@ import io.github.mzmine.util.files.FileAndPathUtil;
 import io.github.mzmine.util.io.TxtWriter;
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import java.io.File;
+import java.time.Instant;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javafx.application.Platform;
@@ -57,7 +57,7 @@ public class CorrelatedFeaturesMzHistogramTask extends AbstractTask {
   private MzDeltaCorrelationHistogramTab tab;
   private final ParameterSet parameters;
 
-  public CorrelatedFeaturesMzHistogramTask(ModularFeatureList flist, ParameterSet parameters, @NotNull Date moduleCallDate) {
+  public CorrelatedFeaturesMzHistogramTask(ModularFeatureList flist, ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     this.flist = flist;
     this.parameters = parameters;

--- a/src/main/java/io/github/mzmine/modules/visualization/mzhistogram/ScanMzHistogramModule.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/mzhistogram/ScanMzHistogramModule.java
@@ -18,9 +18,9 @@
 
 package io.github.mzmine.modules.visualization.mzhistogram;
 
+import java.time.Instant;
 import java.util.Collection;
 
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -50,7 +50,7 @@ public class ScanMzHistogramModule implements MZmineRunnableModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     RawDataFile[] dataFiles = parameters.getParameter(ScanMzHistogramParameters.dataFiles)
         .getValue().getMatchingRawDataFiles();

--- a/src/main/java/io/github/mzmine/modules/visualization/mzhistogram/ScanMzHistogramTask.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/mzhistogram/ScanMzHistogramTask.java
@@ -19,6 +19,7 @@
 package io.github.mzmine.modules.visualization.mzhistogram;
 
 import io.github.mzmine.main.MZmineCore;
+import java.time.Instant;
 import java.util.Date;
 import java.util.logging.Logger;
 import io.github.mzmine.datamodel.MZmineProject;
@@ -45,7 +46,7 @@ public class ScanMzHistogramTask extends AbstractTask {
    * @param parameters
    */
   public ScanMzHistogramTask(MZmineProject project, RawDataFile dataFile,
-      ParameterSet parameters, @NotNull Date moduleCallDate) {
+      ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     this.project = project;
     this.dataFile = dataFile;

--- a/src/main/java/io/github/mzmine/modules/visualization/networking/AnnotationNetworkModule.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/networking/AnnotationNetworkModule.java
@@ -27,8 +27,8 @@ import io.github.mzmine.modules.visualization.networking.visual.FeatureNetworkTa
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 public class AnnotationNetworkModule implements MZmineRunnableModule {
@@ -52,7 +52,7 @@ public class AnnotationNetworkModule implements MZmineRunnableModule {
   @NotNull
   @Override
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     ModularFeatureList[] pkls = parameters.getParameter(AnnotationNetworkParameters.PEAK_LISTS)
         .getValue().getMatchingFeatureLists();
     boolean connectByNetRelations =

--- a/src/main/java/io/github/mzmine/modules/visualization/rawdataoverview/RawDataOverviewModule.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/rawdataoverview/RawDataOverviewModule.java
@@ -18,8 +18,8 @@
 
 package io.github.mzmine.modules.visualization.rawdataoverview;
 
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.modules.MZmineModuleCategory;
@@ -55,7 +55,7 @@ public class RawDataOverviewModule implements MZmineRunnableModule {
 
   @Override
   public ExitCode runModule(MZmineProject project, ParameterSet parameters, Collection<Task> tasks,
-      @NotNull Date moduleCallDate) {
+      @NotNull Instant moduleCallDate) {
 
     Task newTask = new RawDataOverviewTask(parameters, moduleCallDate);
     tasks.add(newTask);

--- a/src/main/java/io/github/mzmine/modules/visualization/rawdataoverview/RawDataOverviewTask.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/rawdataoverview/RawDataOverviewTask.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.modules.visualization.rawdataoverview;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.logging.Logger;
@@ -43,7 +44,7 @@ public class RawDataOverviewTask extends AbstractTask {
   private int totalSteps = 0;
   private int appliedSteps = 0;
 
-  public RawDataOverviewTask(ParameterSet parameters, @NotNull Date moduleCallDate) {
+  public RawDataOverviewTask(ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
 
     this.rawDataFiles = parameters.getParameter(RawDataOverviewParameters.rawDataFiles).getValue()

--- a/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/IMSRawDataOverviewModule.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/IMSRawDataOverviewModule.java
@@ -35,8 +35,8 @@ import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesSelectio
 import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -110,7 +110,7 @@ public class IMSRawDataOverviewModule implements MZmineRunnableModule {
   @NotNull
   @Override
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     RawDataFilesParameter param = parameters
         .getParameter(IMSRawDataOverviewParameters.rawDataFiles);
     RawDataFilesSelection selection = param.getValue();

--- a/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/threads/BuildMultipleMobilogramRanges.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/threads/BuildMultipleMobilogramRanges.java
@@ -35,6 +35,7 @@ import io.github.mzmine.util.IonMobilityUtils;
 import io.github.mzmine.util.IonMobilityUtils.MobilogramType;
 import io.github.mzmine.util.color.SimpleColorPalette;
 import java.text.NumberFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -55,7 +56,7 @@ public class BuildMultipleMobilogramRanges extends AbstractTask {
   public BuildMultipleMobilogramRanges(@NotNull List<Range<Double>> mzRanges,
       @NotNull Set<Frame> frames, @NotNull IMSRawDataFile file,
       @NotNull IMSRawDataOverviewPane pane, @NotNull BinningMobilogramDataAccess binning, @NotNull Date moduleCallDate) {
-    super(null, new Date()); // no new data stored -> null, date is irrelevant (not used in batch mode)
+    super(null, Instant.now()); // no new data stored -> null, date is irrelevant (not used in batch mode)
     this.binning = binning;
     finishedPercentage = 0d;
     this.mzRanges = mzRanges;

--- a/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/threads/BuildMultipleTICRanges.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/rawdataoverviewims/threads/BuildMultipleTICRanges.java
@@ -29,8 +29,8 @@ import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.color.SimpleColorPalette;
 import java.awt.Color;
 import java.text.NumberFormat;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import javafx.application.Platform;
 import org.jetbrains.annotations.NotNull;
@@ -46,7 +46,7 @@ public class BuildMultipleTICRanges extends AbstractTask {
   public BuildMultipleTICRanges(@NotNull List<Range<Double>> mzRanges, @NotNull IMSRawDataFile file,
       @NotNull ScanSelection scanSelection,
       @NotNull IMSRawDataOverviewPane pane) {
-    super(null, new Date()); // no new data stored -> null, date is irrelevant (not used in batch mode)
+    super(null, Instant.now()); // no new data stored -> null, date is irrelevant (not used in batch mode)
     finishedPercentage = 0d;
     this.mzRanges = mzRanges;
     this.pane = pane;

--- a/src/main/java/io/github/mzmine/modules/visualization/scatterplot/ScatterPlotVisualizerModule.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/scatterplot/ScatterPlotVisualizerModule.java
@@ -19,8 +19,8 @@
 package io.github.mzmine.modules.visualization.scatterplot;
 
 import io.github.mzmine.datamodel.features.FeatureList;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.main.MZmineCore;
@@ -48,7 +48,7 @@ public class ScatterPlotVisualizerModule implements MZmineRunnableModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     FeatureList featureLists[] =
         parameters.getParameter(ScatterPlotParameters.featureLists).getValue().getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/SpectraVisualizerModule.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/SpectraVisualizerModule.java
@@ -18,8 +18,8 @@
 
 package io.github.mzmine.modules.visualization.spectra.simplespectra;
 
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 import io.github.mzmine.datamodel.IsotopePattern;
 import io.github.mzmine.datamodel.MZmineProject;
@@ -55,7 +55,7 @@ public class SpectraVisualizerModule implements MZmineRunnableModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     RawDataFile dataFile = parameters.getParameter(SpectraVisualizerParameters.dataFiles)
         .getValue().getMatchingRawDataFiles()[0];
 

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/SpectraVisualizerTab.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/SpectraVisualizerTab.java
@@ -54,6 +54,7 @@ import io.github.mzmine.util.scans.ScanUtils;
 import java.awt.Color;
 import java.io.File;
 import java.text.NumberFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -218,32 +219,32 @@ public class SpectraVisualizerTab extends MZmineTab {
     dbOnlineButton = new Button(null, new ImageView(dbOnlineIcon));
     dbOnlineButton.setTooltip(new Tooltip("Select online database for annotation"));
     dbOnlineButton.setOnAction(e -> {
-      OnlineDBSpectraSearchModule.showSpectraIdentificationDialog(currentScan, spectrumPlot, new Date());
+      OnlineDBSpectraSearchModule.showSpectraIdentificationDialog(currentScan, spectrumPlot, Instant.now());
     });
 
     dbCustomButton = new Button(null, new ImageView(dbCustomIcon));
     dbCustomButton.setTooltip(new Tooltip("Select custom database for annotation"));
     dbCustomButton.setOnAction(e -> {
-      CustomDBSpectraSearchModule.showSpectraIdentificationDialog(currentScan, spectrumPlot, new Date());
+      CustomDBSpectraSearchModule.showSpectraIdentificationDialog(currentScan, spectrumPlot, Instant.now());
     });
 
     dbLipidsButton = new Button(null, new ImageView(dbLipidsIcon));
     dbLipidsButton.setTooltip(new Tooltip("Select target lipid classes for annotation"));
     dbLipidsButton.setOnAction(e -> {
-      LipidSpectraSearchModule.showSpectraIdentificationDialog(currentScan, spectrumPlot, new Date());
+      LipidSpectraSearchModule.showSpectraIdentificationDialog(currentScan, spectrumPlot, Instant.now());
     });
 
     dbSpectraButton = new Button(null, new ImageView(dbSpectraIcon));
     dbSpectraButton.setTooltip(new Tooltip("Compare spectrum with spectral database"));
     dbSpectraButton.setOnAction(e -> {
       SpectraIdentificationSpectralDatabaseModule.showSpectraIdentificationDialog(currentScan,
-          spectrumPlot, new Date());
+          spectrumPlot, Instant.now());
     });
 
     sumFormulaButton = new Button(null, new ImageView(sumFormulaIcon));
     sumFormulaButton.setTooltip(new Tooltip("Predict sum formulas for annotation"));
     sumFormulaButton.setOnAction(e -> {
-      SumFormulaSpectraSearchModule.showSpectraIdentificationDialog(currentScan, spectrumPlot, new Date());
+      SumFormulaSpectraSearchModule.showSpectraIdentificationDialog(currentScan, spectrumPlot, Instant.now());
     });
 
     toolBar.getItems().addAll(centroidContinuousButton, dataPointsButton, annotationsButton,

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/datapointprocessing/DataPointProcessingTask.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/datapointprocessing/DataPointProcessingTask.java
@@ -26,8 +26,8 @@ import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.taskcontrol.TaskStatusListener;
 import java.awt.Color;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -76,7 +76,7 @@ public abstract class DataPointProcessingTask extends AbstractTask {
   public DataPointProcessingTask(@NotNull MassSpectrum dataPoints, @NotNull SpectraPlot plot,
       @NotNull ParameterSet parameterSet, @NotNull DataPointProcessingController controller,
       @NotNull TaskStatusListener listener) {
-    super(null, new Date()); // no new data stored -> null, date irrelevant (not executed in batch)
+    super(null, Instant.now()); // no new data stored -> null, date irrelevant (not executed in batch)
     logger.warning("Rethink storage creation when re-implementing data point processing");
 
     setDataPoints(dataPoints);

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/customdatabase/CustomDBSpectraSearchModule.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/customdatabase/CustomDBSpectraSearchModule.java
@@ -18,15 +18,14 @@
 
 package io.github.mzmine.modules.visualization.spectra.simplespectra.spectraidentification.customdatabase;
 
-import java.util.Date;
-import org.jetbrains.annotations.NotNull;
-
 import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.MZmineModule;
 import io.github.mzmine.modules.visualization.spectra.simplespectra.SpectraPlot;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Module for identifying peaks by searching custom databases file.
@@ -53,7 +52,7 @@ public class CustomDBSpectraSearchModule implements MZmineModule {
    * 
    */
   public static void showSpectraIdentificationDialog(final Scan scan,
-      final SpectraPlot spectraPlot, @NotNull Date moduleCallDate) {
+      final SpectraPlot spectraPlot, @NotNull Instant moduleCallDate) {
 
     final SpectraIdentificationCustomDatabaseParameters parameters =
         (SpectraIdentificationCustomDatabaseParameters) MZmineCore.getConfiguration()

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/customdatabase/SpectraIdentificationCustomDatabaseTask.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/customdatabase/SpectraIdentificationCustomDatabaseTask.java
@@ -23,6 +23,7 @@ import java.awt.Color;
 import java.io.File;
 import java.io.FileReader;
 import java.text.NumberFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.logging.Level;
@@ -82,7 +83,7 @@ public class SpectraIdentificationCustomDatabaseTask extends AbstractTask {
    * @param parameters task parameters.
    */
   public SpectraIdentificationCustomDatabaseTask(ParameterSet parameters, Scan currentScan,
-      SpectraPlot spectraPlot, @NotNull Date moduleCallDate) {
+      SpectraPlot spectraPlot, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
 
     this.currentScan = currentScan;

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/lipidsearch/LipidSpectraSearchModule.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/lipidsearch/LipidSpectraSearchModule.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.modules.visualization.spectra.simplespectra.spectraidentification.lipidsearch;
 
+import java.time.Instant;
 import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
@@ -53,7 +54,7 @@ public class LipidSpectraSearchModule implements MZmineModule {
    * 
    */
   public static void showSpectraIdentificationDialog(final Scan scan,
-      final SpectraPlot spectraPlot, @NotNull Date moduleCallDate) {
+      final SpectraPlot spectraPlot, @NotNull Instant moduleCallDate) {
 
     final SpectraIdentificationLipidSearchParameters parameters =
         (SpectraIdentificationLipidSearchParameters) MZmineCore.getConfiguration()

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/lipidsearch/SpectraIdentificationLipidSearchTask.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/lipidsearch/SpectraIdentificationLipidSearchTask.java
@@ -20,6 +20,7 @@ package io.github.mzmine.modules.visualization.spectra.simplespectra.spectraiden
 
 import java.awt.Color;
 import java.text.NumberFormat;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
@@ -92,7 +93,7 @@ public class SpectraIdentificationLipidSearchTask extends AbstractTask {
    * @param parameters task parameters.
    */
   public SpectraIdentificationLipidSearchTask(ParameterSet parameters, Scan currentScan,
-      SpectraPlot spectraPlot, @NotNull Date moduleCallDate) {
+      SpectraPlot spectraPlot, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate);
     this.currentScan = currentScan;
     this.spectraPlot = spectraPlot;

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/onlinedatabase/OnlineDBSpectraSearchModule.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/onlinedatabase/OnlineDBSpectraSearchModule.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.modules.visualization.spectra.simplespectra.spectraidentification.onlinedatabase;
 
+import java.time.Instant;
 import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
@@ -54,7 +55,7 @@ public class OnlineDBSpectraSearchModule implements MZmineModule {
    * @param row the feature list row.
    */
   public static void showSpectraIdentificationDialog(final Scan scan,
-      final SpectraPlot spectraPlot, @NotNull Date moduleCallDate) {
+      final SpectraPlot spectraPlot, @NotNull Instant moduleCallDate) {
 
     final SpectraIdentificationOnlineDatabaseParameters parameters =
         (SpectraIdentificationOnlineDatabaseParameters) MZmineCore.getConfiguration()

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/onlinedatabase/SpectraIdentificationOnlineDatabaseTask.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/onlinedatabase/SpectraIdentificationOnlineDatabaseTask.java
@@ -23,6 +23,7 @@ import static io.github.mzmine.modules.dataprocessing.id_onlinecompounddb.Single
 import io.github.mzmine.datamodel.impl.SimpleDataPoint;
 import java.awt.Color;
 import java.text.NumberFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.logging.Level;
@@ -82,7 +83,7 @@ public class SpectraIdentificationOnlineDatabaseTask extends AbstractTask {
    * @param parameters task parameters.
    */
   public SpectraIdentificationOnlineDatabaseTask(ParameterSet parameters, Scan currentScan,
-      SpectraPlot spectraPlot, @NotNull Date moduleCallDate) {
+      SpectraPlot spectraPlot, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate);
 
     this.currentScan = currentScan;

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationSpectralDatabaseModule.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationSpectralDatabaseModule.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.modules.visualization.spectra.simplespectra.spectraidentification.spectraldatabase;
 
+import java.time.Instant;
 import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
@@ -53,7 +54,7 @@ public class SpectraIdentificationSpectralDatabaseModule implements MZmineModule
    * 
    */
   public static void showSpectraIdentificationDialog(final Scan scan,
-      final SpectraPlot spectraPlot, @NotNull Date moduleCallDate) {
+      final SpectraPlot spectraPlot, @NotNull Instant moduleCallDate) {
 
     final SpectraIdentificationSpectralDatabaseParameters parameters =
         (SpectraIdentificationSpectralDatabaseParameters) MZmineCore.getConfiguration()

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationSpectralDatabaseTask.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectraIdentificationSpectralDatabaseTask.java
@@ -31,6 +31,7 @@ import io.github.mzmine.util.spectraldb.parser.LibraryEntryProcessor;
 import io.github.mzmine.util.spectraldb.parser.UnsupportedFormatException;
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -62,7 +63,7 @@ class SpectraIdentificationSpectralDatabaseTask extends AbstractTask {
   private int totalTasks;
 
   SpectraIdentificationSpectralDatabaseTask(ParameterSet parameters, Scan currentScan,
-      SpectraPlot spectraPlot, @NotNull Date moduleCallDate) {
+      SpectraPlot spectraPlot, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
 
     this.parameters = parameters;

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectralMatchTask.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SpectralMatchTask.java
@@ -44,6 +44,7 @@ import java.awt.Color;
 import java.io.File;
 import java.text.DecimalFormat;
 import java.text.MessageFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -111,7 +112,7 @@ public class SpectralMatchTask extends AbstractTask {
 
   public SpectralMatchTask(ParameterSet parameters, int startEntry, List<SpectralDBEntry> list,
       SpectraPlot spectraPlot, Scan currentScan,
-      SpectraIdentificationResultsWindowFX resultWindow, @NotNull Date moduleCallDate) {
+      SpectraIdentificationResultsWindowFX resultWindow, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
 
     this.startEntry = startEntry;

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/sumformula/SpectraIdentificationSumFormulaTask.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/sumformula/SpectraIdentificationSumFormulaTask.java
@@ -42,6 +42,7 @@ import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.FormulaUtils;
 import java.awt.Color;
 import java.text.NumberFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
@@ -94,7 +95,7 @@ public class SpectraIdentificationSumFormulaTask extends AbstractTask {
    * @param parameters task parameters.
    */
   public SpectraIdentificationSumFormulaTask(ParameterSet parameters, Scan currentScan,
-      SpectraPlot spectraPlot, @NotNull Date moduleCallDate) {
+      SpectraPlot spectraPlot, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate);
 
     this.currentScan = currentScan;

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/sumformula/SumFormulaSpectraSearchModule.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/sumformula/SumFormulaSpectraSearchModule.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.modules.visualization.spectra.simplespectra.spectraidentification.sumformula;
 
+import java.time.Instant;
 import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
@@ -49,7 +50,7 @@ public class SumFormulaSpectraSearchModule implements MZmineModule {
   }
 
   public static void showSpectraIdentificationDialog(final Scan scan,
-      final SpectraPlot spectraPlot, @NotNull Date moduleCallDate) {
+      final SpectraPlot spectraPlot, @NotNull Instant moduleCallDate) {
 
     final SpectraIdentificationSumFormulaParameters parameters =
         (SpectraIdentificationSumFormulaParameters) MZmineCore.getConfiguration()

--- a/src/main/java/io/github/mzmine/modules/visualization/twod/TwoDVisualizerModule.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/twod/TwoDVisualizerModule.java
@@ -18,8 +18,8 @@
 
 package io.github.mzmine.modules.visualization.twod;
 
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 import com.google.common.collect.Range;
 import io.github.mzmine.datamodel.MZmineProject;
@@ -56,7 +56,7 @@ public class TwoDVisualizerModule implements MZmineRunnableModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
     RawDataFile dataFiles[] = parameters.getParameter(TwoDVisualizerParameters.dataFiles).getValue()
         .getMatchingRawDataFiles();
     ScanSelection scanSel =

--- a/src/main/java/io/github/mzmine/modules/visualization/vankrevelendiagram/VanKrevelenDiagramModule.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/vankrevelendiagram/VanKrevelenDiagramModule.java
@@ -18,9 +18,9 @@
 
 package io.github.mzmine.modules.visualization.vankrevelendiagram;
 
+import java.time.Instant;
 import java.util.Collection;
 
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -53,7 +53,7 @@ public class VanKrevelenDiagramModule implements MZmineRunnableModule {
   @Override
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
-      @NotNull Collection<Task> tasks, @NotNull Date moduleCallDate) {
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
 
     Task newTask = new VanKrevelenDiagramTask(parameters, moduleCallDate);
     tasks.add(newTask);

--- a/src/main/java/io/github/mzmine/modules/visualization/vankrevelendiagram/VanKrevelenDiagramTask.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/vankrevelendiagram/VanKrevelenDiagramTask.java
@@ -20,6 +20,7 @@ package io.github.mzmine.modules.visualization.vankrevelendiagram;
 
 import java.awt.Color;
 import java.awt.Font;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -86,7 +87,7 @@ public class VanKrevelenDiagramTask extends AbstractTask {
   private int totalSteps = 3, appliedSteps = 0;
   private ParameterSet parameters;
 
-  public VanKrevelenDiagramTask(ParameterSet parameters, @NotNull Date moduleCallDate) {
+  public VanKrevelenDiagramTask(ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     this.parameters = parameters;
     featureList = parameters.getParameter(VanKrevelenDiagramParameters.featureList).getValue()

--- a/src/main/java/io/github/mzmine/taskcontrol/AbstractTask.java
+++ b/src/main/java/io/github/mzmine/taskcontrol/AbstractTask.java
@@ -21,9 +21,9 @@ package io.github.mzmine.taskcontrol;
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
@@ -37,7 +37,7 @@ import org.jetbrains.annotations.Nullable;
 public abstract class AbstractTask implements Task {
 
   protected final MemoryMapStorage storage;
-  protected final Date moduleCallDate;
+  protected final Instant moduleCallDate;
 
   private TaskStatus status = TaskStatus.WAITING;
 
@@ -59,14 +59,13 @@ public abstract class AbstractTask implements Task {
   }
 
   /**
-   *
-   * @param storage The {@link MemoryMapStorage} used to store results of this task (e.g.
+   *  @param storage The {@link MemoryMapStorage} used to store results of this task (e.g.
    *                RawDataFiles, MassLists, FeatureLists). May be null if results shall be stored
    *                in ram. For now, one storage should be created per module call in {@link
-   *                io.github.mzmine.modules.MZmineRunnableModule#runModule(MZmineProject, ParameterSet, Collection, Date)}.
+   *                io.github.mzmine.modules.MZmineRunnableModule#runModule(MZmineProject, ParameterSet, Collection, Instant)}.
    * @param moduleCallDate
    */
-  protected AbstractTask(@Nullable MemoryMapStorage storage, @NotNull Date moduleCallDate) {
+  protected AbstractTask(@Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     this.storage = storage;
     this.moduleCallDate = moduleCallDate;
   }
@@ -165,7 +164,7 @@ public abstract class AbstractTask implements Task {
       listener.clear();
   }
 
-  public Date getModuleCallDate() {
+  public Instant getModuleCallDate() {
     return moduleCallDate;
   }
 }

--- a/src/main/java/io/github/mzmine/taskcontrol/impl/FinishedTask.java
+++ b/src/main/java/io/github/mzmine/taskcontrol/impl/FinishedTask.java
@@ -20,7 +20,7 @@ package io.github.mzmine.taskcontrol.impl;
 
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.Task;
-import java.util.Date;
+import java.time.Instant;
 
 /**
  * This class serves as a replacement for Task within the task controller queue, after the Task is
@@ -33,7 +33,7 @@ public class FinishedTask extends AbstractTask {
   private double finishedPercentage;
 
   public FinishedTask(Task task) {
-    super(null, new Date()); // date is irrelevant
+    super(null, Instant.now()); // date is irrelevant
     setStatus(task.getStatus());
     setErrorMessage(task.getErrorMessage());
     description = task.getTaskDescription();

--- a/src/main/java/io/github/mzmine/util/RawDataFileUtils.java
+++ b/src/main/java/io/github/mzmine/util/RawDataFileUtils.java
@@ -41,6 +41,7 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -65,7 +66,7 @@ public class RawDataFileUtils {
 
   public static void createRawDataImportTasks(MZmineProject project, List<Task> taskList,
       @NotNull final Class<? extends MZmineModule> module, @NotNull final ParameterSet parameters,
-      @NotNull Date moduleCallDate, File... fileNames) throws IOException {
+      @NotNull Instant moduleCallDate, File... fileNames) throws IOException {
 
     // one storage for all files imported in the same task as they are typically analyzed together
     final MemoryMapStorage storage = MemoryMapStorage.forRawDataFile();

--- a/src/test/java/tdfimportest/BrukerTdfTest.java
+++ b/src/test/java/tdfimportest/BrukerTdfTest.java
@@ -40,6 +40,7 @@ import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.exceptions.MissingMassListException;
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -68,7 +69,7 @@ public class BrukerTdfTest {
     AtomicReference<TaskStatus> status = new AtomicReference<>(TaskStatus.WAITING);
 
     AbstractTask importTask = new TDFImportTask(project, file, rawDataFile, TDFImportModule.class,
-        new TDFImportParameters(), new Date());
+        new TDFImportParameters(), Instant.now());
     importTask.addTaskStatusListener((task, newStatus, oldStatus) -> {
       status.set(newStatus);
     });


### PR DESCRIPTION
Projects could not be safed because Date did only have second accuracy, therefore grouping by date lead to grouping of different module calls.

- move from java.util.Date to java.time.instant for microsecond accuracy
- make raw data file rename a task to not get same microsecond time for individual calls (still occured at some point, so adding the task is the cleanest solution, because it waits 300 ms every loop step)