### PR TITLE
Speed up isotope grouper with indexes, test 45s to 2s

### DIFF
--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_isotopegrouper/IsotopeGrouperTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_isotopegrouper/IsotopeGrouperTask.java
@@ -35,6 +35,7 @@ import io.github.mzmine.parameters.parametertypes.tolerances.RTTolerance;
 import io.github.mzmine.parameters.parametertypes.tolerances.mobilitytolerance.MobilityTolerance;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import io.github.mzmine.util.DataPointSorter;
 import io.github.mzmine.util.DataTypeUtils;
 import io.github.mzmine.util.FeatureListRowSorter;
 import io.github.mzmine.util.MemoryMapStorage;
@@ -209,6 +210,7 @@ class IsotopeGrouperTask extends AbstractTask {
       // Convert the peak pattern to array
       final DataPoint[] isotopes = bestFitRows.stream()
           .map(r -> new SimpleDataPoint(r.getAverageMZ(), r.getAverageHeight()))
+          .sorted(new DataPointSorter(SortingProperty.MZ, SortingDirection.Ascending))
           .toArray(DataPoint[]::new);
       SimpleIsotopePattern newPattern = new SimpleIsotopePattern(isotopes,
           IsotopePatternStatus.DETECTED, mostIntenseRow.toString());

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_isotopegrouper/IsotopeGrouperTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_isotopegrouper/IsotopeGrouperTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2020 The MZmine Development Team
+ * Copyright 2006-2021 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -8,11 +8,12 @@
  * License, or (at your option) any later version.
  *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
- * Public License for more details.
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
  */
 
 package io.github.mzmine.modules.dataprocessing.filter_isotopegrouper;
@@ -41,8 +42,6 @@ import io.github.mzmine.util.SortingDirection;
 import io.github.mzmine.util.SortingProperty;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.logging.Logger;
@@ -97,27 +96,20 @@ class IsotopeGrouperTask extends AbstractTask {
     monotonicShape = parameters.getParameter(IsotopeGrouperParameters.monotonicShape).getValue();
     maximumCharge = parameters.getParameter(IsotopeGrouperParameters.maximumCharge).getValue();
     chooseMostIntense = (Objects
-        .equals(parameters.getParameter(IsotopeGrouperParameters.representativeIsotope)
-            .getValue(), IsotopeGrouperParameters.ChooseTopIntensity));
+        .equals(parameters.getParameter(IsotopeGrouperParameters.representativeIsotope).getValue(),
+            IsotopeGrouperParameters.ChooseTopIntensity));
     removeOriginal = parameters.getParameter(IsotopeGrouperParameters.autoRemove).getValue();
     useMobilityTolerance = parameters.getParameter(IsotopeGrouperParameters.mobilityTolerace)
         .getValue();
     mobilityTolerance = parameters.getParameter(IsotopeGrouperParameters.mobilityTolerace)
-        .getEmbeddedParameter()
-        .getValue();
+        .getEmbeddedParameter().getValue();
   }
 
-  /**
-   * @see io.github.mzmine.taskcontrol.Task#getTaskDescription()
-   */
   @Override
   public String getTaskDescription() {
     return "Isotopic peaks grouper on " + featureList;
   }
 
-  /**
-   * @see io.github.mzmine.taskcontrol.Task#getFinishedPercentage()
-   */
   @Override
   public double getFinishedPercentage() {
     if (totalRows == 0) {
@@ -126,9 +118,6 @@ class IsotopeGrouperTask extends AbstractTask {
     return (double) processedRows / (double) totalRows;
   }
 
-  /**
-   * @see Runnable#run()
-   */
   @Override
   public void run() {
 
@@ -145,9 +134,8 @@ class IsotopeGrouperTask extends AbstractTask {
     // Create a new deisotoped peakList
     ModularFeatureList deisotopedFeatureList = new ModularFeatureList(featureList + " " + suffix,
         getMemoryMapStorage(), featureList.getRawDataFiles());
-    deisotopedFeatureList
-        .setSelectedScans(featureList.getRawDataFile(0), featureList.getSeletedScans(
-            featureList.getRawDataFile(0)));
+    deisotopedFeatureList.setSelectedScans(featureList.getRawDataFile(0),
+        featureList.getSeletedScans(featureList.getRawDataFile(0)));
     DataTypeUtils.copyTypes(featureList, deisotopedFeatureList, true, true);
 
     // Collect all selected charge states
@@ -157,25 +145,34 @@ class IsotopeGrouperTask extends AbstractTask {
     }
 
     // Sort peaks by descending height
-    List<FeatureListRow> sortedRows = new ArrayList<>(featureList.getRows());
-    sortedRows.sort(new FeatureListRowSorter(SortingProperty.Height, SortingDirection.Descending));
+    List<FeatureListRow> rowsSortedByHeight = new ArrayList<>(featureList.getRows());
+    rowsSortedByHeight
+        .sort(new FeatureListRowSorter(SortingProperty.Height, SortingDirection.Descending));
+
+    // use a second sorted list to limit the number of comparisons
+    List<FeatureListRow> rowsSortedByMz = new ArrayList<>(featureList.getRows());
+    rowsSortedByMz.sort(new FeatureListRowSorter(SortingProperty.MZ, SortingDirection.Ascending));
 
     // Loop through all peaks
-    totalRows = sortedRows.size();
+    totalRows = rowsSortedByHeight.size();
 
-    while (!sortedRows.isEmpty()) {
+    while (!rowsSortedByHeight.isEmpty()) {
 
       if (isCanceled()) {
         return;
       }
 
-      ModularFeatureListRow row = (ModularFeatureListRow) sortedRows.get(0);
+      ModularFeatureListRow mostIntenseRow = (ModularFeatureListRow) rowsSortedByHeight.remove(0);
 
       // Check if peak was already deleted
-      if (row == null) {
+      if (mostIntenseRow == null) {
         processedRows++;
         continue;
       }
+
+      // find index in mz sorted list
+      int indexMzSorted = rowsSortedByMz.indexOf(mostIntenseRow);
+      rowsSortedByMz.remove(indexMzSorted);
 
       // Check which charge state fits best around this peak
       int bestFitCharge = 0;
@@ -184,8 +181,9 @@ class IsotopeGrouperTask extends AbstractTask {
       for (int charge : charges) {
 
         List<FeatureListRow> fittedRows = new ArrayList<>();
-        fittedRows.add(row);
-        fitPattern(fittedRows, row, charge, sortedRows);
+        fittedRows.add(mostIntenseRow);
+        // use rows sorted by mz
+        fitPattern(fittedRows, mostIntenseRow, charge, rowsSortedByMz, indexMzSorted);
 
         int score = fittedRows.size();
         if ((score > bestFitScore) || ((score == bestFitScore) && (bestFitCharge > charge))) {
@@ -201,39 +199,32 @@ class IsotopeGrouperTask extends AbstractTask {
       // Verify the number of detected isotopes. If there is only one
       // isotope, we skip this left the original peak in the feature list.
       if (bestFitRows.size() == 1) {
-        deisotopedFeatureList
-            .addRow(new ModularFeatureListRow(deisotopedFeatureList, row.getID(), row, true));
-        sortedRows.remove(bestFitRows.get(0));
+        deisotopedFeatureList.addRow(
+            new ModularFeatureListRow(deisotopedFeatureList, mostIntenseRow.getID(), mostIntenseRow,
+                true));
         processedRows++;
         continue;
       }
 
       // Convert the peak pattern to array
-      FeatureListRow[] originalRows = bestFitRows.toArray(new FeatureListRow[0]);
-
-      // Create a new SimpleIsotopePattern
-      DataPoint[] isotopes = new DataPoint[bestFitRows.size()];
-      for (int i = 0; i < isotopes.length; i++) {
-        FeatureListRow p = originalRows[i];
-        isotopes[i] = new SimpleDataPoint(p.getAverageMZ(), p.getAverageHeight());
-      }
-      SimpleIsotopePattern newPattern =
-          new SimpleIsotopePattern(isotopes, IsotopePatternStatus.DETECTED, row.toString());
+      final DataPoint[] isotopes = bestFitRows.stream()
+          .map(r -> new SimpleDataPoint(r.getAverageMZ(), r.getAverageHeight()))
+          .toArray(DataPoint[]::new);
+      SimpleIsotopePattern newPattern = new SimpleIsotopePattern(isotopes,
+          IsotopePatternStatus.DETECTED, mostIntenseRow.toString());
 
       // Depending on user's choice, we leave either the most intense, or
       // the lowest m/z peak
       if (chooseMostIntense) {
-        Arrays.sort(originalRows,
-            new FeatureListRowSorter(SortingProperty.Height, SortingDirection.Descending));
+        bestFitRows
+            .sort(new FeatureListRowSorter(SortingProperty.Height, SortingDirection.Descending));
       } else {
-        Arrays
-            .sort(originalRows,
-                new FeatureListRowSorter(SortingProperty.MZ, SortingDirection.Ascending));
+        bestFitRows.sort(new FeatureListRowSorter(SortingProperty.MZ, SortingDirection.Ascending));
       }
 
       // copy row
       FeatureListRow newRow = new ModularFeatureListRow(deisotopedFeatureList,
-          originalRows[0].getID(), (ModularFeatureListRow) originalRows[0], true);
+          bestFitRows.get(0).getID(), (ModularFeatureListRow) bestFitRows.get(0), true);
       deisotopedFeatureList.addRow(newRow);
       // set isotope pattern
       Feature feature = newRow.getFeatures().get(0);
@@ -241,8 +232,11 @@ class IsotopeGrouperTask extends AbstractTask {
       feature.setCharge(bestFitCharge);
 
       // Remove all peaks already assigned to isotope pattern
-      for (FeatureListRow fit : bestFitRows) {
-        sortedRows.remove(fit);
+      // first is already removed
+      for (int r = 1; r < bestFitRows.size(); r++) {
+        FeatureListRow fit = bestFitRows.get(r);
+        rowsSortedByHeight.remove(fit);
+        rowsSortedByMz.remove(fit);
       }
 
       // Update completion rate
@@ -259,8 +253,8 @@ class IsotopeGrouperTask extends AbstractTask {
 
     // Add task description to peakList
     deisotopedFeatureList.addDescriptionOfAppliedTask(
-        new SimpleFeatureListAppliedMethod("Isotopic peaks grouper",
-            IsotopeGrouperModule.class, parameters, getModuleCallDate()));
+        new SimpleFeatureListAppliedMethod("Isotopic peaks grouper", IsotopeGrouperModule.class,
+            parameters, getModuleCallDate()));
 
     // Remove the original peakList if requested
     if (removeOriginal) {
@@ -274,11 +268,13 @@ class IsotopeGrouperTask extends AbstractTask {
   /**
    * Fits isotope pattern around one peak.
    *
-   * @param row    Pattern is fitted around this peak
-   * @param charge Charge state of the fitted pattern
+   * @param row            Pattern is fitted around this peak
+   * @param charge         Charge state of the fitted pattern
+   * @param rowsSortedByMz rows sorted by mz
+   * @param startRowIndex  index to start with in mz sorted list
    */
   private void fitPattern(List<FeatureListRow> fittedRows, ModularFeatureListRow row, int charge,
-      List<FeatureListRow> sortedRows) {
+      List<FeatureListRow> rowsSortedByMz, int startRowIndex) {
 
     if (charge == 0) {
       return;
@@ -286,36 +282,41 @@ class IsotopeGrouperTask extends AbstractTask {
 
     // Search for peaks before the start peak
     if (!monotonicShape) {
-      fitHalfPattern(row, charge, -1, fittedRows, sortedRows);
+      fitHalfPattern(row, charge, -1, fittedRows, rowsSortedByMz, startRowIndex);
     }
 
     // Search for peaks after the start peak
-    fitHalfPattern(row, charge, 1, fittedRows, sortedRows);
+    fitHalfPattern(row, charge, 1, fittedRows, rowsSortedByMz, startRowIndex);
   }
 
   /**
    * Helper method for fitPattern. Fits only one half of the pattern.
    *
-   * @param row        Pattern is fitted around this peak
-   * @param charge     Charge state of the fitted pattern
-   * @param direction  Defines which half to fit: -1=fit to peaks before start M/Z, +1=fit to peaks
-   *                   after start M/Z
-   * @param fittedRows All matching peaks will be added to this set
+   * @param row            Pattern is fitted around this peak
+   * @param charge         Charge state of the fitted pattern
+   * @param direction      Defines which half to fit: -1=fit to peaks before start M/Z, +1=fit to
+   *                       peaks after start M/Z
+   * @param fittedRows     All matching peaks will be added to this set
+   * @param rowsSortedByMz rows sorted by mz
+   * @param startRowIndex  index to start with in mz sorted list
    */
   private void fitHalfPattern(ModularFeatureListRow row, int charge, int direction,
-      List<FeatureListRow> fittedRows,
-      List<FeatureListRow> sortedRows) {
+      List<FeatureListRow> fittedRows, List<FeatureListRow> rowsSortedByMz, int startRowIndex) {
 
     // Use M/Z and RT of the strongest peak of the pattern (row)
     double mainMZ = row.getAverageMZ();
     float mainRT = row.getAverageRT();
     Float mainMobility = row.getAverageMobility();
 
+    final double absoluteMzTolerance = mzTolerance.getMzToleranceForMass(mainMZ);
+
     // Variable n is the number of peak we are currently searching. 1=first
     // peak before/after start peak, 2=peak before/after previous, 3=...
     boolean followingPeakFound;
     int n = 1;
     do {
+      // start at start row index in mz sorted list
+      int ind = startRowIndex;
 
       // Assume we don't find match for n:th peak in the pattern (which
       // will end the loop)
@@ -324,9 +325,9 @@ class IsotopeGrouperTask extends AbstractTask {
       // Loop through all peaks, and collect candidates for the n:th peak
       // in the pattern
       List<FeatureListRow> goodCandidates = new ArrayList<>();
-      for (int ind = 0; ind < sortedRows.size(); ind++) {
+      for (; ind < rowsSortedByMz.size() && ind >= 0; ind += direction) {
 
-        ModularFeatureListRow candidatePeak = (ModularFeatureListRow) sortedRows.get(ind);
+        ModularFeatureListRow candidatePeak = (ModularFeatureListRow) rowsSortedByMz.get(ind);
 
         if (candidatePeak == null) {
           continue;
@@ -334,23 +335,24 @@ class IsotopeGrouperTask extends AbstractTask {
 
         // Get properties of the candidate peak
         double candidatePeakMZ = candidatePeak.getAverageMZ();
-        float candidatePeakRT = candidatePeak.getAverageRT();
-        Float candidateMobility = candidatePeak.getAverageMobility();
 
         // Does this peak fill all requirements of a candidate?
         // - within tolerances from the expected location (M/Z and RT)
         // - not already a fitted peak (only necessary to avoid
         // conflicts when parameters are set too wide)
         double isotopeMZ = candidatePeakMZ - isotopeDistance * direction * n / charge;
+        double deltaMZ = isotopeMZ - mainMZ;
 
-        if (mzTolerance.checkWithinTolerance(isotopeMZ, mainMZ)
-            && rtTolerance.checkWithinTolerance(candidatePeakRT, mainRT)) {
+        // break the loop if deltaMZ reaches out of the maximum allowed mz tolerance (one sided check)
+        if (deltaMZ * direction > absoluteMzTolerance) {
+          break;
+        }
 
-          if (useMobilityTolerance && mainMobility != null && candidateMobility != null) {
-            if (mobilityTolerance.checkWithinTolerance(mainMobility, candidateMobility)) {
-              goodCandidates.add(candidatePeak);
-            }
-          } else {
+        // check if in range
+        if (Math.abs(deltaMZ) <= absoluteMzTolerance && rtTolerance
+            .checkWithinTolerance(candidatePeak.getAverageRT(), mainRT)) {
+          if (!useMobilityTolerance || mainMobility == null || checkCandidateMobility(mainMobility,
+              candidatePeak)) {
             goodCandidates.add(candidatePeak);
           }
 
@@ -370,6 +372,12 @@ class IsotopeGrouperTask extends AbstractTask {
       }
 
     } while (followingPeakFound);
+  }
+
+  private boolean checkCandidateMobility(Float mainMobility, FeatureListRow row) {
+    Float candidateMobility = row.getAverageMobility();
+    return candidateMobility == null || mobilityTolerance
+        .checkWithinTolerance(mainMobility, candidateMobility);
   }
 
 }


### PR DESCRIPTION
Speeds up the isotope grouper in my test from 45 s -> 2 s
when run on 7208 rows which are reduced to 5483 rows.

Uses two lists. One sorted by intensity for the order of main features. One sorted by m/z to only consider rows in the range and limit the number of rows accessed in the fitPattern method.

The results on my test dataset were the same rows.