### PR TITLE
add tooltips to labels only

### DIFF
--- a/src/main/java/io/github/mzmine/parameters/dialogs/ParameterSetupDialog.java
+++ b/src/main/java/io/github/mzmine/parameters/dialogs/ParameterSetupDialog.java
@@ -178,7 +178,7 @@ public class ParameterSetupDialog extends Stage {
       UserParameter up = (UserParameter) p;
 
       Node comp = up.createEditingComponent();
-      addToolTipToControls(comp, up.getDescription());
+//      addToolTipToControls(comp, up.getDescription());
       if (comp instanceof Region) {
         double minWidth = ((Region) comp).getMinWidth();
         // if (minWidth > column2.getMinWidth()) column2.setMinWidth(minWidth);
@@ -203,6 +203,7 @@ public class ParameterSetupDialog extends Stage {
       Label label = new Label(p.getName());
       label.minWidthProperty().bind(label.widthProperty());
       label.setPadding(new Insets(0.0, 10.0, 0.0, 0.0));
+      label.setTooltip(new Tooltip(up.getDescription()));
 
       label.setStyle("-fx-font-weight: bold");
       paramsPane.add(label, 0, rowCounter);


### PR DESCRIPTION
It's so annoying that tooltips of background windows hide the current on-top window. Most of the time it's due to big components of the parameters (e.g., batch queue). Therefore i add the tooltip to the label instead of the component.

Any objections?