### PR TITLE
Fix "Add new" on list types

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureListRow.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureListRow.java
@@ -693,6 +693,6 @@ public class ModularFeatureListRow implements FeatureListRow {
 
   @Override
   public String toString() {
-    return FeatureUtils.rowToString();
+    return FeatureUtils.rowToString(this);
   }
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/DataType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/DataType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2020 The MZmine Development Team
+ * Copyright 2006-2021 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -8,11 +8,12 @@
  * License, or (at your option) any later version.
  *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
- * Public License for more details.
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
  */
 
 package io.github.mzmine.datamodel.features.types;
@@ -93,27 +94,29 @@ public abstract class DataType<T> {
 
           // if parent type is different than type - parent type will handle the value change
           // e.g. see io.github.mzmine.datamodel.features.types.ListWithSubsType
-          if (parentType != null && !parentType.equals(type)) {
+          if (type instanceof ListDataType && type instanceof AddElementDialog addDialog
+              && data instanceof String && AddElementDialog.BUTTON_TEXT.equals(data)) {
+            addDialog.createNewElementDialog(model, parentType, type, subColumnIndex,
+                (newElement) -> { // refresh table due to change
+                  col.getTreeTableView().refresh();
+                });
+          } else if (parentType != null && !parentType.equals(type)) {
             parentType.valueChanged(model, (DataType) type, subColumnIndex, data);
+            col.getTreeTableView().refresh();
           } else {
             if (type instanceof ListDataType) {
-              if (type instanceof AddElementDialog addDialog && data instanceof String
-                  && AddElementDialog.BUTTON_TEXT.equals(data)) {
-                addDialog.createNewElementDialog(model, type);
-              } else {
-                try {
-                  List list = (List) model.get(type);
-                  if (list != null) {
-                    list = new ArrayList<>(list);
-                    list.remove(data);
-                    list.add(0, (T) data);
-                    model.set((DataType) type, list);
-                  }
-                } catch (Exception ex) {
-                  logger.log(Level.SEVERE,
-                      "Cannot set value from table cell to data type: " + type.getHeaderString());
-                  logger.log(Level.SEVERE, ex.getMessage(), ex);
+              try {
+                List list = (List) model.get(type);
+                if (list != null) {
+                  list = new ArrayList<>(list);
+                  list.remove(data);
+                  list.add(0, (T) data);
+                  model.set((DataType) type, list);
                 }
+              } catch (Exception ex) {
+                logger.log(Level.SEVERE,
+                    "Cannot set value from table cell to data type: " + type.getHeaderString());
+                logger.log(Level.SEVERE, ex.getMessage(), ex);
               }
             } else {
               // TODO check if this cast is safe

--- a/src/main/java/io/github/mzmine/datamodel/features/types/annotations/ManualAnnotationType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/annotations/ManualAnnotationType.java
@@ -193,6 +193,8 @@ public class ManualAnnotationType extends DataType<ManualAnnotation> implements 
       } else if (subType.getClass().equals(CompoundNameType.class)) {
         manual.setCompoundName((String) newValue);
       }
+      // finally set annotation
+      model.set(ManualAnnotationType.class, manual);
     } catch (Exception ex) {
       logger.log(Level.WARNING, () -> String.format(
           "Cannot handle change in subtype %s at index %d in parent type %s with new value %s",

--- a/src/main/java/io/github/mzmine/datamodel/features/types/fx/EditComboCellFactory.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/fx/EditComboCellFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2020 The MZmine Development Team
+ * Copyright 2006-2021 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -8,11 +8,12 @@
  * License, or (at your option) any later version.
  *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
- * Public License for more details.
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
  */
 
 package io.github.mzmine.datamodel.features.types.fx;
@@ -66,7 +67,9 @@ public class EditComboCellFactory implements
       public void startEdit() {
         List list = getTypeList();
         getItems().clear();
-        getItems().addAll(list);
+        if (list != null) {
+          getItems().addAll(list);
+        }
         // create element that triggers the add element dialog on selection
         if (type instanceof AddElementDialog) {
           getItems().add(AddElementDialog.BUTTON_TEXT);
@@ -110,15 +113,6 @@ public class EditComboCellFactory implements
             }
           }
 
-          // sub columns provide values
-//          if (parentType != null) {
-//            // get sub column value
-//            Node n = parentType.getSubColNode(subcolumn, this, param, list, raw);
-//            setGraphic(n);
-//            String formattedSubVal = parentType.getFormattedSubColValue(subcolumn, list);
-//            setText(n != null ? null : formattedSubVal);
-//            setTooltip(new Tooltip(formattedSubVal));
-//          } else
           if (type instanceof GraphicalColumType graphType) {
             Node node = graphType.getCellNode(this, param, list, raw);
             getTableColumn().setMinWidth(graphType.getColumnWidth());

--- a/src/main/java/io/github/mzmine/datamodel/features/types/modifiers/AddElementDialog.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/modifiers/AddElementDialog.java
@@ -22,9 +22,10 @@ import io.github.mzmine.datamodel.features.ModularDataModel;
 import io.github.mzmine.datamodel.features.types.DataType;
 import io.github.mzmine.datamodel.features.types.numbers.abstr.ListDataType;
 import java.util.Optional;
+import java.util.function.Consumer;
 import javafx.beans.property.ListProperty;
-import javafx.beans.property.Property;
 import javafx.scene.control.TextInputDialog;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * @author Robin Schmid (https://github.com/robinschmid)
@@ -35,17 +36,30 @@ public interface AddElementDialog {
 
   /**
    * Shows a dialog to create a new element. e.g., to add an element to a {@link ListDataType}
+   *
    * @param model
+   * @param parentType
    * @param type
+   * @param subColumnIndex
    */
-  default void createNewElementDialog(ModularDataModel model, DataType type) {
+  default void createNewElementDialog(ModularDataModel model,
+      @Nullable SubColumnsFactory parentType, DataType type, int subColumnIndex,
+      Consumer<Object> newElementConsumer) {
     assert type instanceof StringParser : "Cannot use the default dialog without a StringParser type";
     assert type instanceof ListDataType : "Cannot use the default dialog for a non ListDataType";
     TextInputDialog dialog = new TextInputDialog("Enter new element");
     Optional<String> result = dialog.showAndWait();
-    if(result.isPresent()) {
+    if (result.isPresent()) {
       Object newElement = ((StringParser) type).fromString(result.get());
-      ((ListProperty)model.get(type)).add(0, newElement);
+      // set via parent if available
+      if (parentType != null) {
+        parentType.valueChanged(model, (DataType) type, subColumnIndex, newElement);
+      } else {
+        ((ListProperty) model.get(type)).add(0, newElement);
+      }
+      if (newElementConsumer != null) {
+        newElementConsumer.accept(newElement);
+      }
     }
   }
 }


### PR DESCRIPTION
The Add new button on list types (e.g., the IdentityType) work now. It also updates the FeatureListFX. 

Changes tested on Identity, Formula, Ion identity (latter two only for selecting new elements)