### PR TITLE
Add options to handle original feature lists

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/features/FeatureList.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/FeatureList.java
@@ -161,6 +161,15 @@ public interface FeatureList {
   void setRows(FeatureListRow... rows);
 
   /**
+   * Clear all rows and set new rows
+   *
+   * @param rows new rows to set
+   */
+  default void setRows(List<FeatureListRow> rows) {
+    setRows(rows.toArray(FeatureListRow[]::new));
+  }
+
+  /**
    * Creates a stream of FeatureListRows
    *
    * @return

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_join/JoinAlignerParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_join/JoinAlignerParameters.java
@@ -25,6 +25,7 @@ import io.github.mzmine.parameters.impl.SimpleParameterSet;
 import io.github.mzmine.parameters.parametertypes.BooleanParameter;
 import io.github.mzmine.parameters.parametertypes.DoubleParameter;
 import io.github.mzmine.parameters.parametertypes.OptionalParameter;
+import io.github.mzmine.parameters.parametertypes.OriginalFeatureListHandlingParameter;
 import io.github.mzmine.parameters.parametertypes.StringParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
 import io.github.mzmine.parameters.parametertypes.submodules.OptionalModuleParameter;
@@ -76,10 +77,13 @@ public class JoinAlignerParameters extends SimpleParameterSet {
       "Compare spectra similarity", "Compare MS1 or MS2 spectra similarity",
       new JoinAlignerSpectraSimilarityScoreParameters(), false);
 
+  public static final OriginalFeatureListHandlingParameter handleOriginal = new OriginalFeatureListHandlingParameter(
+      false);
+
   public JoinAlignerParameters() {
     super(new Parameter[]{peakLists, peakListName, MZTolerance, MZWeight, RTTolerance, RTWeight,
         mobilityTolerance, mobilityWeight, SameChargeRequired, SameIDRequired,
-        compareIsotopePattern, compareSpectraSimilarity});
+        compareIsotopePattern, compareSpectraSimilarity, handleOriginal});
   }
 
   @NotNull

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_join/JoinAlignerTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_join/JoinAlignerTask.java
@@ -35,6 +35,7 @@ import io.github.mzmine.modules.MZmineProcessingStep;
 import io.github.mzmine.modules.tools.isotopepatternscore.IsotopePatternScoreCalculator;
 import io.github.mzmine.modules.tools.isotopepatternscore.IsotopePatternScoreParameters;
 import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.parameters.parametertypes.OriginalFeatureListHandlingParameter.OriginalFeatureListOption;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.parameters.parametertypes.tolerances.RTTolerance;
 import io.github.mzmine.parameters.parametertypes.tolerances.mobilitytolerance.MobilityTolerance;
@@ -270,6 +271,11 @@ public class JoinAlignerTask extends AbstractTask {
             getModuleCallDate()));
     // Add new aligned feature list to the project {
     project.addFeatureList(alignedFeatureList);
+
+    if (parameters.getValue(JoinAlignerParameters.handleOriginal)
+        == OriginalFeatureListOption.REMOVE) {
+      project.removeFeatureLists(featureLists);
+    }
 
     logger.info("Finished join aligner");
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/ADAPpeakpicking/ADAPResolverParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/ADAPpeakpicking/ADAPResolverParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 The du-lab Development Team
+ * Copyright 2006-2021 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -8,12 +8,12 @@
  * License, or (at your option) any later version.
  *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
- * Public License for more details.
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
- * USA
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
  */
 /*
  * author Owen Myers (Oweenm@gmail.com)
@@ -24,9 +24,9 @@ package io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolutio
 import com.google.common.collect.Range;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.FeatureResolver;
 import io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.FeatureResolverSetupDialog;
 import io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.GeneralResolverParameters;
-import io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.FeatureResolver;
 import io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.Resolver;
 import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.ParameterSet;
@@ -78,7 +78,7 @@ public class ADAPResolverParameters extends GeneralResolverParameters {
           + "set in the chromatogram building.", NumberFormat.getNumberInstance(), 10.0, 0.0, null);
 
   public ADAPResolverParameters() {
-    super(new Parameter[]{PEAK_LISTS, SUFFIX, AUTO_REMOVE, groupMS2Parameters, dimension,
+    super(new Parameter[]{PEAK_LISTS, SUFFIX, handleOriginal, groupMS2Parameters, dimension,
         SN_THRESHOLD, SN_ESTIMATORS, MIN_FEAT_HEIGHT, COEF_AREA_THRESHOLD, PEAK_DURATION,
         RT_FOR_CWT_SCALES_DURATION});
   }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/FeatureResolverTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/FeatureResolverTask.java
@@ -124,16 +124,16 @@ public class FeatureResolverTask extends AbstractTask {
             "Feature resolving can only be performed on feature lists with a single raw data file");
       } else {
         try {
-          if (((GeneralResolverParameters) parameters)
-                  .getResolver(parameters, (ModularFeatureList) originalPeakList) != null) {
+          if (((GeneralResolverParameters) parameters).getResolver(parameters,
+              (ModularFeatureList) originalPeakList) != null) {
             dimensionIndependentResolve((ModularFeatureList) originalPeakList);
           } else {
             legacyResolve();
           }
 
           if (parameters.getParameter(GeneralResolverParameters.groupMS2Parameters).getValue()) {
-            GroupMS2SubParameters ms2params = parameters
-                .getParameter(GeneralResolverParameters.groupMS2Parameters).getEmbeddedParameters();
+            GroupMS2SubParameters ms2params = parameters.getParameter(
+                GeneralResolverParameters.groupMS2Parameters).getEmbeddedParameters();
             GroupMS2Task task = new GroupMS2Task(project, newPeakList, ms2params, moduleCallDate);
             // restart progress
             processedRows = 0;
@@ -146,16 +146,12 @@ public class FeatureResolverTask extends AbstractTask {
           }
 
           if (!isCanceled()) {
-            // Add new featurelist to the project.
-            project.addFeatureList(newPeakList);
-
-            // Add quality parameters to features
-            //QualityParameters.calculateQualityParameters(newPeakList);
-
-            // Remove the original feature list if requested.
-            if (parameters.getParameter(GeneralResolverParameters.AUTO_REMOVE).getValue()) {
-              project.removeFeatureList(originalPeakList);
-            }
+            // add new list and remove old if requested
+            final var handleOriginal = parameters.getValue(
+                GeneralResolverParameters.handleOriginal);
+            final String suffix = parameters.getValue(GeneralResolverParameters.SUFFIX);
+            handleOriginal.reflectNewFeatureListToProject(suffix, project, newPeakList,
+                originalPeakList);
 
             setStatus(TaskStatus.FINISHED);
             logger.info("Finished feature resolving on " + originalPeakList);
@@ -336,8 +332,8 @@ public class FeatureResolverTask extends AbstractTask {
   }
 
   private void dimensionIndependentResolve(ModularFeatureList originalFeatureList) {
-    final Resolver resolver = ((GeneralResolverParameters) parameters)
-        .getResolver(parameters, originalFeatureList);
+    final Resolver resolver = ((GeneralResolverParameters) parameters).getResolver(parameters,
+        originalFeatureList);
     if (resolver == null) {
       setErrorMessage("Resolver could not be initialised.");
       setStatus(TaskStatus.ERROR);
@@ -347,8 +343,8 @@ public class FeatureResolverTask extends AbstractTask {
     final RawDataFile dataFile = originalFeatureList.getRawDataFile(0);
     final ModularFeatureList resolvedFeatureList = createNewFeatureList(originalFeatureList);
 
-    final FeatureDataAccess access = EfficientDataAccess
-        .of(originalFeatureList, EfficientDataAccess.FeatureDataType.INCLUDE_ZEROS, dataFile);
+    final FeatureDataAccess access = EfficientDataAccess.of(originalFeatureList,
+        EfficientDataAccess.FeatureDataType.INCLUDE_ZEROS, dataFile);
 
     processedRows = 0;
     totalRows = originalFeatureList.getNumberOfRows();
@@ -358,8 +354,8 @@ public class FeatureResolverTask extends AbstractTask {
 
     while (access.hasNextFeature()) {
       final ModularFeature originalFeature = (ModularFeature) access.nextFeature();
-      final List<IonTimeSeries<? extends Scan>> resolvedSeries = resolver
-          .resolve(access, getMemoryMapStorage());
+      final List<IonTimeSeries<? extends Scan>> resolvedSeries = resolver.resolve(access,
+          getMemoryMapStorage());
 
       for (IonTimeSeries<? extends Scan> resolved : resolvedSeries) {
         final ModularFeatureListRow newRow = new ModularFeatureListRow(resolvedFeatureList,
@@ -383,7 +379,7 @@ public class FeatureResolverTask extends AbstractTask {
     }
     logger.info(c + "/" + resolvedFeatureList.getNumberOfRows()
                 + " have less than 4 scans (frames for IMS data)");
-//    QualityParameters.calculateAndSetModularQualityParameters(resolvedFeatureList);
+    //    QualityParameters.calculateAndSetModularQualityParameters(resolvedFeatureList);
 
     resolvedFeatureList.addDescriptionOfAppliedTask(
         new SimpleFeatureListAppliedMethod(resolver.getModuleClass(), parameters,
@@ -424,21 +420,19 @@ public class FeatureResolverTask extends AbstractTask {
     int peakId = 1;
 
     for (int i = 0; i < totalRows; i++) {
-      final ModularFeatureListRow originalRow = (ModularFeatureListRow) originalFeatureList
-          .getRow(i);
+      final ModularFeatureListRow originalRow = (ModularFeatureListRow) originalFeatureList.getRow(
+          i);
       final ModularFeature originalFeature = originalRow.getFeature(dataFile);
 
-      final ResolvedPeak[] peaks = resolver
-          .resolvePeaks(originalFeature, parameters, rSession, mzCenterFunction, msmsRange,
-              RTRangeMSMS);
+      final ResolvedPeak[] peaks = resolver.resolvePeaks(originalFeature, parameters, rSession,
+          mzCenterFunction, msmsRange, RTRangeMSMS);
 
       for (final ResolvedPeak peak : peaks) {
         peak.setParentChromatogramRowID(originalRow.getID());
         final ModularFeatureListRow newRow = new ModularFeatureListRow(resolvedFeatureList,
             peakId++);
-        final ModularFeature newFeature = FeatureConvertors
-            .ResolvedPeakToMoularFeature(resolvedFeatureList, peak,
-                originalFeature.getFeatureData());
+        final ModularFeature newFeature = FeatureConvertors.ResolvedPeakToMoularFeature(
+            resolvedFeatureList, peak, originalFeature.getFeatureData());
         if (originalFeature.getMobilityUnit() != null) {
           newFeature.set(MobilityUnitType.class, originalFeature.getMobilityUnit());
         }
@@ -466,10 +460,10 @@ public class FeatureResolverTask extends AbstractTask {
     // create a new feature list and don't copy. Previous annotations of features are invalidated
     // during resolution
     final ModularFeatureList resolvedFeatureList = new ModularFeatureList(
-        originalFeatureList.getName() + " " + parameters
-            .getParameter(GeneralResolverParameters.SUFFIX).getValue(), storage, dataFile);
+        originalFeatureList.getName() + " " + parameters.getParameter(
+            GeneralResolverParameters.SUFFIX).getValue(), storage, dataFile);
 
-//    DataTypeUtils.addDefaultChromatographicTypeColumns(resolvedFeatureList);
+    //    DataTypeUtils.addDefaultChromatographicTypeColumns(resolvedFeatureList);
     resolvedFeatureList.setSelectedScans(dataFile, originalFeatureList.getSeletedScans(dataFile));
 
     // since we dont create a copy, we have to copy manually
@@ -478,8 +472,8 @@ public class FeatureResolverTask extends AbstractTask {
     // the new method is added later, since we don't know here which resolver module is used.
 
     // check the actual feature data. IMSRawDataFiles can also be built as classic lc-ms features
-    ModularFeature exampleFeature = originalFeatureList
-        .getFeature(0, originalFeatureList.getRawDataFile(0));
+    ModularFeature exampleFeature = originalFeatureList.getFeature(0,
+        originalFeatureList.getRawDataFile(0));
 
     boolean isImagingFile = (originalFeatureList.getRawDataFile(0) instanceof ImagingRawDataFile);
     if (exampleFeature.getFeatureData() instanceof IonMobilogramTimeSeries) {

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/GeneralResolverParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/GeneralResolverParameters.java
@@ -23,8 +23,8 @@ import io.github.mzmine.modules.dataprocessing.filter_groupms2.GroupMS2SubParame
 import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
-import io.github.mzmine.parameters.parametertypes.BooleanParameter;
 import io.github.mzmine.parameters.parametertypes.ComboParameter;
+import io.github.mzmine.parameters.parametertypes.OriginalFeatureListHandlingParameter;
 import io.github.mzmine.parameters.parametertypes.StringParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
 import io.github.mzmine.parameters.parametertypes.submodules.OptionalModuleParameter;
@@ -39,9 +39,8 @@ public abstract class GeneralResolverParameters extends SimpleParameterSet {
   public static final StringParameter SUFFIX = new StringParameter("Suffix",
       "This string is added to feature list name as suffix", "resolved");
 
-  public static final BooleanParameter AUTO_REMOVE = new BooleanParameter(
-      "Remove original feature list",
-      "If checked, original chromatogram will be removed and only the deconvolved version remains");
+  public static final OriginalFeatureListHandlingParameter handleOriginal = //
+      new OriginalFeatureListHandlingParameter(true);
 
   public static final OptionalModuleParameter<GroupMS2SubParameters> groupMS2Parameters = new OptionalModuleParameter<>(
       "MS/MS scan pairing", "Set MS/MS scan pairing parameters.", new GroupMS2SubParameters());

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/baseline/BaselineFeatureResolverParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/baseline/BaselineFeatureResolverParameters.java
@@ -20,9 +20,9 @@ package io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolutio
 
 import com.google.common.collect.Range;
 import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.FeatureResolver;
 import io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.FeatureResolverSetupDialog;
 import io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.GeneralResolverParameters;
-import io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.FeatureResolver;
 import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.parametertypes.DoubleParameter;
 import io.github.mzmine.parameters.parametertypes.ranges.DoubleRangeParameter;
@@ -43,7 +43,7 @@ public class BaselineFeatureResolverParameters extends GeneralResolverParameters
       MZmineCore.getConfiguration().getIntensityFormat());
 
   public BaselineFeatureResolverParameters() {
-    super(new Parameter[]{PEAK_LISTS, SUFFIX, AUTO_REMOVE, groupMS2Parameters, MIN_PEAK_HEIGHT,
+    super(new Parameter[]{PEAK_LISTS, SUFFIX, handleOriginal, groupMS2Parameters, MIN_PEAK_HEIGHT,
         PEAK_DURATION, BASELINE_LEVEL});
   }
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/centwave/CentWaveResolverParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/centwave/CentWaveResolverParameters.java
@@ -16,19 +16,13 @@
  *
  */
 
-/*
- * Code created was by or on behalf of Syngenta and is released under the open source license in use
- * for the pre-existing code or project. Syngenta does not assert ownership or copyright any over
- * pre-existing work.
- */
-
 package io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.centwave;
 
 import com.google.common.collect.Range;
 import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.FeatureResolver;
 import io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.FeatureResolverSetupDialog;
 import io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.GeneralResolverParameters;
-import io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.FeatureResolver;
 import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.parametertypes.ComboParameter;
 import io.github.mzmine.parameters.parametertypes.DoubleParameter;
@@ -93,7 +87,7 @@ public class CentWaveResolverParameters extends GeneralResolverParameters {
 
   public CentWaveResolverParameters() {
 
-    super(new Parameter[]{PEAK_LISTS, SUFFIX, AUTO_REMOVE, groupMS2Parameters, SN_THRESHOLD,
+    super(new Parameter[]{PEAK_LISTS, SUFFIX, handleOriginal, groupMS2Parameters, SN_THRESHOLD,
         PEAK_SCALES, PEAK_DURATION, INTEGRATION_METHOD, RENGINE_TYPE});
   }
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/minimumsearch/MinimumSearchFeatureResolverParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/minimumsearch/MinimumSearchFeatureResolverParameters.java
@@ -71,7 +71,7 @@ public class MinimumSearchFeatureResolverParameters extends GeneralResolverParam
 
 
   public MinimumSearchFeatureResolverParameters() {
-    super(new Parameter[]{PEAK_LISTS, SUFFIX, AUTO_REMOVE, groupMS2Parameters, dimension,
+    super(new Parameter[]{PEAK_LISTS, SUFFIX, handleOriginal, groupMS2Parameters, dimension,
         CHROMATOGRAPHIC_THRESHOLD_LEVEL, SEARCH_RT_RANGE, MIN_RELATIVE_HEIGHT, MIN_ABSOLUTE_HEIGHT,
         MIN_RATIO, PEAK_DURATION, MIN_NUMBER_OF_DATAPOINTS});
   }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/noiseamplitude/NoiseAmplitudeFeatureResolverParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/noiseamplitude/NoiseAmplitudeFeatureResolverParameters.java
@@ -20,9 +20,9 @@ package io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolutio
 
 import com.google.common.collect.Range;
 import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.FeatureResolver;
 import io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.FeatureResolverSetupDialog;
 import io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.GeneralResolverParameters;
-import io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.FeatureResolver;
 import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.parametertypes.DoubleParameter;
 import io.github.mzmine.parameters.parametertypes.ranges.DoubleRangeParameter;
@@ -43,7 +43,7 @@ public class NoiseAmplitudeFeatureResolverParameters extends GeneralResolverPara
       MZmineCore.getConfiguration().getIntensityFormat());
 
   public NoiseAmplitudeFeatureResolverParameters() {
-    super(new Parameter[]{PEAK_LISTS, SUFFIX, AUTO_REMOVE, groupMS2Parameters, MIN_PEAK_HEIGHT,
+    super(new Parameter[]{PEAK_LISTS, SUFFIX, handleOriginal, groupMS2Parameters, MIN_PEAK_HEIGHT,
         PEAK_DURATION, NOISE_AMPLITUDE});
   }
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/savitzkygolay/SavitzkyGolayFeatureResolverParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/savitzkygolay/SavitzkyGolayFeatureResolverParameters.java
@@ -20,9 +20,9 @@ package io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolutio
 
 import com.google.common.collect.Range;
 import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.FeatureResolver;
 import io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.FeatureResolverSetupDialog;
 import io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.GeneralResolverParameters;
-import io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution.FeatureResolver;
 import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.parametertypes.DoubleParameter;
 import io.github.mzmine.parameters.parametertypes.PercentParameter;
@@ -44,7 +44,7 @@ public class SavitzkyGolayFeatureResolverParameters extends GeneralResolverParam
       "Minimum acceptable intensity in the 2nd derivative for peak recognition");
 
   public SavitzkyGolayFeatureResolverParameters() {
-    super(new Parameter[]{PEAK_LISTS, SUFFIX, AUTO_REMOVE, groupMS2Parameters, MIN_PEAK_HEIGHT,
+    super(new Parameter[]{PEAK_LISTS, SUFFIX, handleOriginal, groupMS2Parameters, MIN_PEAK_HEIGHT,
         PEAK_DURATION, DERIVATIVE_THRESHOLD_LEVEL, RENGINE_TYPE});
   }
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_imsexpander/ImsExpanderParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_imsexpander/ImsExpanderParameters.java
@@ -25,10 +25,10 @@ import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.impl.IonMobilitySupport;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
-import io.github.mzmine.parameters.parametertypes.BooleanParameter;
 import io.github.mzmine.parameters.parametertypes.DoubleParameter;
 import io.github.mzmine.parameters.parametertypes.IntegerParameter;
 import io.github.mzmine.parameters.parametertypes.OptionalParameter;
+import io.github.mzmine.parameters.parametertypes.OriginalFeatureListHandlingParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZToleranceParameter;
 import java.util.Collection;
@@ -47,23 +47,25 @@ public class ImsExpanderParameters extends SimpleParameterSet {
   public static final OptionalParameter<DoubleParameter> useRawData = new OptionalParameter<>(
       new DoubleParameter("Raw data instead of thresholded",
           "If checked, the raw data can be used to expand the chromatograms into mobility dimension.\n"
-              + "This can increase sensitivity but will also increase RAM demands and computation time.\n"
-              + "A new noise level can be given or every data point can be used (0E0)",
-          MZmineCore.getConfiguration().getIntensityFormat(), 1E1, 0d, Double.POSITIVE_INFINITY), true);
+          + "This can increase sensitivity but will also increase RAM demands and computation time.\n"
+          + "A new noise level can be given or every data point can be used (0E0)",
+          MZmineCore.getConfiguration().getIntensityFormat(), 1E1, 0d, Double.POSITIVE_INFINITY),
+      true);
 
   public static final OptionalParameter<IntegerParameter> mobilogramBinWidth = new OptionalParameter<>(
       new IntegerParameter("Override default mobility bin witdh (scans)",
           "If checked, the default recommended bin width for the raw data file will be overridden with the given value.\n"
-              + "The mobility binning width in scans. (high mobility resolutions "
-              + "in TIMS might require a higher bin width to achieve a constant ion current for a "
-              + "mobilogram.", 1, true), false);
+          + "The mobility binning width in scans. (high mobility resolutions "
+          + "in TIMS might require a higher bin width to achieve a constant ion current for a "
+          + "mobilogram.", 1, true), false);
 
-  public static final BooleanParameter removeOriginalFeatureList = new BooleanParameter(
-      "Remove original feature list",
-      "If checked, the original feature list will be removed.\nUseful to minimize ram consumption.", false);
+
+  public static final OriginalFeatureListHandlingParameter handleOriginal = //
+      new OriginalFeatureListHandlingParameter(false);
 
   public ImsExpanderParameters() {
-    super(new Parameter[]{featureLists, mzTolerance, useRawData, mobilogramBinWidth, removeOriginalFeatureList});
+    super(
+        new Parameter[]{featureLists, mzTolerance, useRawData, mobilogramBinWidth, handleOriginal});
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_smoothing/SmoothingParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_smoothing/SmoothingParameters.java
@@ -25,8 +25,8 @@ import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.dialogs.ParameterSetupDialog;
 import io.github.mzmine.parameters.impl.IonMobilitySupport;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
-import io.github.mzmine.parameters.parametertypes.BooleanParameter;
 import io.github.mzmine.parameters.parametertypes.ModuleComboParameter;
+import io.github.mzmine.parameters.parametertypes.OriginalFeatureListHandlingParameter;
 import io.github.mzmine.parameters.parametertypes.StringParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
 import io.github.mzmine.util.ExitCode;
@@ -37,8 +37,8 @@ public class SmoothingParameters extends SimpleParameterSet {
   public static final SmoothingAlgorithm sgSmoothing = MZmineCore
       .getModuleInstance(SavitzkyGolaySmoothing.class);
 
-  public static final SmoothingAlgorithm loessSmoothing = MZmineCore
-      .getModuleInstance(LoessSmoothing.class);
+  public static final SmoothingAlgorithm loessSmoothing = MZmineCore.getModuleInstance(
+      LoessSmoothing.class);
 
   public static final SmoothingAlgorithm[] smoothingAlgorithms = new SmoothingAlgorithm[]{
       sgSmoothing, loessSmoothing};
@@ -46,17 +46,17 @@ public class SmoothingParameters extends SimpleParameterSet {
   public static final FeatureListsParameter featureLists = new FeatureListsParameter();
 
   public static final ModuleComboParameter<SmoothingAlgorithm> smoothingAlgorithm = new ModuleComboParameter<SmoothingAlgorithm>(
-      "Smoothing algorithm", "Please select a smoothing algorithm.", smoothingAlgorithms, sgSmoothing);
+      "Smoothing algorithm", "Please select a smoothing algorithm.", smoothingAlgorithms,
+      sgSmoothing);
 
-  public static final BooleanParameter removeOriginal = new BooleanParameter(
-      "Remove original feature list",
-      "The original feature list is removed after the processing has finished");
+  public static final OriginalFeatureListHandlingParameter handleOriginal = //
+      new OriginalFeatureListHandlingParameter(false);
 
   public static final StringParameter suffix = new StringParameter("Suffix",
       "The suffix to be added to processed feature lists.", " sm");
 
   public SmoothingParameters() {
-    super(new Parameter[]{featureLists, smoothingAlgorithm, removeOriginal, suffix});
+    super(new Parameter[]{featureLists, smoothingAlgorithm, handleOriginal, suffix});
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_isotopegrouper/IsotopeGrouperParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_isotopegrouper/IsotopeGrouperParameters.java
@@ -24,6 +24,7 @@ import io.github.mzmine.parameters.parametertypes.BooleanParameter;
 import io.github.mzmine.parameters.parametertypes.ComboParameter;
 import io.github.mzmine.parameters.parametertypes.IntegerParameter;
 import io.github.mzmine.parameters.parametertypes.OptionalParameter;
+import io.github.mzmine.parameters.parametertypes.OriginalFeatureListHandlingParameter;
 import io.github.mzmine.parameters.parametertypes.StringParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZToleranceParameter;
@@ -65,12 +66,12 @@ public class IsotopeGrouperParameters extends SimpleParameterSet {
           + "peptides, the lowest m/z isotope may be the representative.",
       representativeIsotopeValues);
 
-  public static final BooleanParameter autoRemove = new BooleanParameter("Remove original peaklist",
-      "If checked, original peaklist will be removed and only deisotoped version remains");
+  public static final OriginalFeatureListHandlingParameter handleOriginal = new OriginalFeatureListHandlingParameter(
+      true);
 
   public IsotopeGrouperParameters() {
     super(new Parameter[]{peakLists, suffix, mzTolerance, rtTolerance, mobilityTolerace,
-        monotonicShape, maximumCharge, representativeIsotope, autoRemove});
+        monotonicShape, maximumCharge, representativeIsotope, handleOriginal});
   }
 
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_isotopegrouper/IsotopeGrouperTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_isotopegrouper/IsotopeGrouperTask.java
@@ -207,9 +207,7 @@ class IsotopeGrouperTask extends AbstractTask {
       // Verify the number of detected isotopes. If there is only one
       // isotope, we skip this left the original peak in the feature list.
       if (bestFitRows.size() == 1) {
-        deisotopedFeatureList.addRow(
-            new ModularFeatureListRow(deisotopedFeatureList, mostIntenseRow.getID(), mostIntenseRow,
-                true));
+        finalRows.add(mostIntenseRow);
         processedRows++;
         continue;
       }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_isotopegrouper/IsotopeGrouperTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_isotopegrouper/IsotopeGrouperTask.java
@@ -99,7 +99,7 @@ class IsotopeGrouperTask extends AbstractTask {
     chooseMostIntense = (Objects.equals(
         parameters.getParameter(IsotopeGrouperParameters.representativeIsotope).getValue(),
         IsotopeGrouperParameters.ChooseTopIntensity));
-    handleOriginal = parameters.getParameter(IsotopeGrouperParameters.handleOriginal).getValue();
+    handleOriginal = parameters.getValue(IsotopeGrouperParameters.handleOriginal);
     useMobilityTolerance = parameters.getParameter(IsotopeGrouperParameters.mobilityTolerace)
         .getValue();
     mobilityTolerance = parameters.getParameter(IsotopeGrouperParameters.mobilityTolerace)

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_isotopegrouper/IsotopeGrouperTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_isotopegrouper/IsotopeGrouperTask.java
@@ -22,7 +22,6 @@ import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.IsotopePattern.IsotopePatternStatus;
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.datamodel.features.Feature;
-import io.github.mzmine.datamodel.features.FeatureList.FeatureListAppliedMethod;
 import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
@@ -30,19 +29,20 @@ import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
 import io.github.mzmine.datamodel.impl.SimpleDataPoint;
 import io.github.mzmine.datamodel.impl.SimpleIsotopePattern;
 import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.parameters.parametertypes.OriginalFeatureListHandlingParameter.OriginalFeatureListOption;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.parameters.parametertypes.tolerances.RTTolerance;
 import io.github.mzmine.parameters.parametertypes.tolerances.mobilitytolerance.MobilityTolerance;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.DataPointSorter;
-import io.github.mzmine.util.DataTypeUtils;
 import io.github.mzmine.util.FeatureListRowSorter;
 import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.SortingDirection;
 import io.github.mzmine.util.SortingProperty;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.logging.Logger;
@@ -72,10 +72,10 @@ class IsotopeGrouperTask extends AbstractTask {
   private final boolean useMobilityTolerance;
   private final MobilityTolerance mobilityTolerance;
   private final boolean monotonicShape;
-  private final boolean removeOriginal;
   private final boolean chooseMostIntense;
   private final int maximumCharge;
   private final ParameterSet parameters;
+  private final OriginalFeatureListOption handleOriginal;
   // peaks counter
   private int processedRows, totalRows;
 
@@ -96,10 +96,10 @@ class IsotopeGrouperTask extends AbstractTask {
     rtTolerance = parameters.getParameter(IsotopeGrouperParameters.rtTolerance).getValue();
     monotonicShape = parameters.getParameter(IsotopeGrouperParameters.monotonicShape).getValue();
     maximumCharge = parameters.getParameter(IsotopeGrouperParameters.maximumCharge).getValue();
-    chooseMostIntense = (Objects
-        .equals(parameters.getParameter(IsotopeGrouperParameters.representativeIsotope).getValue(),
-            IsotopeGrouperParameters.ChooseTopIntensity));
-    removeOriginal = parameters.getParameter(IsotopeGrouperParameters.autoRemove).getValue();
+    chooseMostIntense = (Objects.equals(
+        parameters.getParameter(IsotopeGrouperParameters.representativeIsotope).getValue(),
+        IsotopeGrouperParameters.ChooseTopIntensity));
+    handleOriginal = parameters.getParameter(IsotopeGrouperParameters.handleOriginal).getValue();
     useMobilityTolerance = parameters.getParameter(IsotopeGrouperParameters.mobilityTolerace)
         .getValue();
     mobilityTolerance = parameters.getParameter(IsotopeGrouperParameters.mobilityTolerace)
@@ -132,12 +132,13 @@ class IsotopeGrouperTask extends AbstractTask {
       return;
     }
 
-    // Create a new deisotoped peakList
-    ModularFeatureList deisotopedFeatureList = new ModularFeatureList(featureList + " " + suffix,
-        getMemoryMapStorage(), featureList.getRawDataFiles());
-    deisotopedFeatureList.setSelectedScans(featureList.getRawDataFile(0),
-        featureList.getSeletedScans(featureList.getRawDataFile(0)));
-    DataTypeUtils.copyTypes(featureList, deisotopedFeatureList, true, true);
+    // create copy or work on same list
+    ModularFeatureList deisotopedFeatureList = switch (handleOriginal) {
+      case KEEP, REMOVE -> featureList.createCopy(featureList.getName() + " " + suffix,
+          getMemoryMapStorage(), false);
+      case PROCESS_IN_PLACE -> featureList;
+    };
+    //    DataTypeUtils.copyTypes(featureList, deisotopedFeatureList, true, true);
 
     // Collect all selected charge states
     int[] charges = new int[maximumCharge];
@@ -145,17 +146,24 @@ class IsotopeGrouperTask extends AbstractTask {
       charges[i] = i + 1;
     }
 
+    final FeatureListRowSorter rowsHeightSorter = new FeatureListRowSorter(SortingProperty.Height,
+        SortingDirection.Descending);
+    final FeatureListRowSorter rowsMzSorter = new FeatureListRowSorter(SortingProperty.MZ,
+        SortingDirection.Ascending);
+
     // Sort peaks by descending height
-    List<FeatureListRow> rowsSortedByHeight = new ArrayList<>(featureList.getRows());
-    rowsSortedByHeight
-        .sort(new FeatureListRowSorter(SortingProperty.Height, SortingDirection.Descending));
+    List<FeatureListRow> rowsSortedByHeight = new ArrayList<>(deisotopedFeatureList.getRows());
+    rowsSortedByHeight.sort(rowsHeightSorter);
 
     // use a second sorted list to limit the number of comparisons
-    List<FeatureListRow> rowsSortedByMz = new ArrayList<>(featureList.getRows());
-    rowsSortedByMz.sort(new FeatureListRowSorter(SortingProperty.MZ, SortingDirection.Ascending));
+    List<FeatureListRow> rowsSortedByMz = new ArrayList<>(deisotopedFeatureList.getRows());
+    rowsSortedByMz.sort(rowsMzSorter);
 
     // Loop through all peaks
     totalRows = rowsSortedByHeight.size();
+
+    // list of final rows (size is usually similar)
+    List<FeatureListRow> finalRows = new ArrayList<>((int) (totalRows * 0.9));
 
     while (!rowsSortedByHeight.isEmpty()) {
 
@@ -170,9 +178,8 @@ class IsotopeGrouperTask extends AbstractTask {
         processedRows++;
         continue;
       }
-
       // find index in mz sorted list
-      int indexMzSorted = rowsSortedByMz.indexOf(mostIntenseRow);
+      int indexMzSorted = Collections.binarySearch(rowsSortedByMz, mostIntenseRow, rowsMzSorter);
       rowsSortedByMz.remove(indexMzSorted);
 
       // Check which charge state fits best around this peak
@@ -218,39 +225,27 @@ class IsotopeGrouperTask extends AbstractTask {
       // Depending on user's choice, we leave either the most intense, or
       // the lowest m/z peak
       if (chooseMostIntense) {
-        bestFitRows
-            .sort(new FeatureListRowSorter(SortingProperty.Height, SortingDirection.Descending));
+        bestFitRows.sort(rowsHeightSorter);
       } else {
-        bestFitRows.sort(new FeatureListRowSorter(SortingProperty.MZ, SortingDirection.Ascending));
+        bestFitRows.sort(rowsMzSorter);
       }
 
-      // copy row
-      FeatureListRow newRow = new ModularFeatureListRow(deisotopedFeatureList,
-          bestFitRows.get(0).getID(), (ModularFeatureListRow) bestFitRows.get(0), true);
-      deisotopedFeatureList.addRow(newRow);
+      // add to final rows
+      final FeatureListRow mainRow = bestFitRows.get(0);
+      finalRows.add(mainRow);
       // set isotope pattern
-      Feature feature = newRow.getFeatures().get(0);
+      Feature feature = mainRow.getFeatures().get(0);
       feature.setIsotopePattern(newPattern);
       feature.setCharge(bestFitCharge);
 
       // Remove all peaks already assigned to isotope pattern
       // first is already removed
-      for (int r = 1; r < bestFitRows.size(); r++) {
-        FeatureListRow fit = bestFitRows.get(r);
-        rowsSortedByHeight.remove(fit);
-        rowsSortedByMz.remove(fit);
-      }
+      bestFitRows.remove(0);
+      rowsSortedByHeight.removeAll(bestFitRows);
+      rowsSortedByMz.removeAll(bestFitRows);
 
       // Update completion rate
       processedRows += bestFitRows.size();
-    }
-
-    // Add new feature list to the project
-    project.addFeatureList(deisotopedFeatureList);
-
-    // Load previous applied methods
-    for (FeatureListAppliedMethod proc : featureList.getAppliedMethods()) {
-      deisotopedFeatureList.addDescriptionOfAppliedTask(proc);
     }
 
     // Add task description to peakList
@@ -258,10 +253,12 @@ class IsotopeGrouperTask extends AbstractTask {
         new SimpleFeatureListAppliedMethod("Isotopic peaks grouper", IsotopeGrouperModule.class,
             parameters, getModuleCallDate()));
 
-    // Remove the original peakList if requested
-    if (removeOriginal) {
-      project.removeFeatureList(featureList);
-    }
+    // replace rows in list
+    deisotopedFeatureList.setRows(finalRows);
+
+    // Remove the original peakList if requested, or add, or work in place
+    handleOriginal.reflectNewFeatureListToProject(suffix, project, deisotopedFeatureList,
+        featureList);
 
     logger.info("Finished isotopic peak grouper on " + featureList);
     setStatus(TaskStatus.FINISHED);
@@ -351,8 +348,8 @@ class IsotopeGrouperTask extends AbstractTask {
         }
 
         // check if in range
-        if (Math.abs(deltaMZ) <= absoluteMzTolerance && rtTolerance
-            .checkWithinTolerance(candidatePeak.getAverageRT(), mainRT)) {
+        if (Math.abs(deltaMZ) <= absoluteMzTolerance && rtTolerance.checkWithinTolerance(
+            candidatePeak.getAverageRT(), mainRT)) {
           if (!useMobilityTolerance || mainMobility == null || checkCandidateMobility(mainMobility,
               candidatePeak)) {
             goodCandidates.add(candidatePeak);
@@ -378,8 +375,8 @@ class IsotopeGrouperTask extends AbstractTask {
 
   private boolean checkCandidateMobility(Float mainMobility, FeatureListRow row) {
     Float candidateMobility = row.getAverageMobility();
-    return candidateMobility == null || mobilityTolerance
-        .checkWithinTolerance(mainMobility, candidateMobility);
+    return candidateMobility == null || mobilityTolerance.checkWithinTolerance(mainMobility,
+        candidateMobility);
   }
 
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/PeakFinderParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/PeakFinderParameters.java
@@ -22,6 +22,7 @@ import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.impl.IonMobilitySupport;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
 import io.github.mzmine.parameters.parametertypes.BooleanParameter;
+import io.github.mzmine.parameters.parametertypes.OriginalFeatureListHandlingParameter;
 import io.github.mzmine.parameters.parametertypes.PercentParameter;
 import io.github.mzmine.parameters.parametertypes.StringParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
@@ -33,8 +34,8 @@ public class PeakFinderParameters extends SimpleParameterSet {
 
   public static final FeatureListsParameter peakLists = new FeatureListsParameter();
 
-  public static final StringParameter suffix =
-      new StringParameter("Name suffix", "Suffix to be added to feature list name", "gap-filled");
+  public static final StringParameter suffix = new StringParameter("Name suffix",
+      "Suffix to be added to feature list name", "gap-filled");
 
   public static final PercentParameter intTolerance = new PercentParameter("Intensity tolerance",
       "Maximum allowed deviation from expected /\\ shape of a peak in chromatographic direction");
@@ -45,18 +46,18 @@ public class PeakFinderParameters extends SimpleParameterSet {
 
   public static final BooleanParameter RTCorrection = new BooleanParameter("RT correction",
       "If checked, correction of the retention time will be applied to avoid the"
-          + "\nproblems caused by the deviation of the retention time between the samples.");
+      + "\nproblems caused by the deviation of the retention time between the samples.");
 
-  public static final BooleanParameter useParallel =
-      new BooleanParameter("Parallel (never combined with RT correction)",
-          "Parallel processing of gaps (RT correction is always on a single thread)");
+  public static final BooleanParameter useParallel = new BooleanParameter(
+      "Parallel (never combined with RT correction)",
+      "Parallel processing of gaps (RT correction is always on a single thread)");
 
-  public static final BooleanParameter autoRemove = new BooleanParameter(
-      "Remove original feature list", "If checked, the original feature list will be removed");
+  public static final OriginalFeatureListHandlingParameter handleOriginal = //
+      new OriginalFeatureListHandlingParameter(false);
 
   public PeakFinderParameters() {
-    super(new Parameter[] {peakLists, suffix, intTolerance, MZTolerance, RTTolerance, RTCorrection,
-        useParallel, autoRemove});
+    super(new Parameter[]{peakLists, suffix, intTolerance, MZTolerance, RTTolerance, RTCorrection,
+        useParallel, handleOriginal});
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_samerange/SameRangeGapFillerParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_samerange/SameRangeGapFillerParameters.java
@@ -20,7 +20,7 @@ package io.github.mzmine.modules.dataprocessing.gapfill_samerange;
 
 import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
-import io.github.mzmine.parameters.parametertypes.BooleanParameter;
+import io.github.mzmine.parameters.parametertypes.OriginalFeatureListHandlingParameter;
 import io.github.mzmine.parameters.parametertypes.StringParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZToleranceParameter;
@@ -29,16 +29,16 @@ public class SameRangeGapFillerParameters extends SimpleParameterSet {
 
   public static final FeatureListsParameter peakLists = new FeatureListsParameter();
 
-  public static final StringParameter suffix =
-      new StringParameter("Name suffix", "Suffix to be added to feature list name", "gap-filled");
+  public static final StringParameter suffix = new StringParameter("Name suffix",
+      "Suffix to be added to feature list name", "gap-filled");
 
   public static final MZToleranceParameter mzTolerance = new MZToleranceParameter();
 
-  public static final BooleanParameter autoRemove = new BooleanParameter(
-      "Remove original feature list", "If checked, the original feature list will be removed");
+  public static final OriginalFeatureListHandlingParameter handleOriginal = //
+      new OriginalFeatureListHandlingParameter(false);
 
   public SameRangeGapFillerParameters() {
-    super(new Parameter[] {peakLists, suffix, mzTolerance, autoRemove});
+    super(new Parameter[]{peakLists, suffix, mzTolerance, handleOriginal});
   }
 
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/norm_linear/LinearNormalizerParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/norm_linear/LinearNormalizerParameters.java
@@ -20,8 +20,8 @@ package io.github.mzmine.modules.dataprocessing.norm_linear;
 
 import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
-import io.github.mzmine.parameters.parametertypes.BooleanParameter;
 import io.github.mzmine.parameters.parametertypes.ComboParameter;
+import io.github.mzmine.parameters.parametertypes.OriginalFeatureListHandlingParameter;
 import io.github.mzmine.parameters.parametertypes.StringParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
 import io.github.mzmine.util.FeatureMeasurementType;
@@ -30,23 +30,21 @@ public class LinearNormalizerParameters extends SimpleParameterSet {
 
   public static final FeatureListsParameter featureLists = new FeatureListsParameter();
 
-  public static final StringParameter suffix =
-      new StringParameter("Name suffix", "Suffix to be added to feature list name", "normalized");
+  public static final StringParameter suffix = new StringParameter("Name suffix",
+      "Suffix to be added to feature list name", "normalized");
 
-  public static final ComboParameter<NormalizationType> normalizationType =
-      new ComboParameter<NormalizationType>("Normalization type", "Normalize intensities by...",
-          NormalizationType.values());
+  public static final ComboParameter<NormalizationType> normalizationType = new ComboParameter<NormalizationType>(
+      "Normalization type", "Normalize intensities by...", NormalizationType.values());
 
-  public static final ComboParameter<FeatureMeasurementType> featureMeasurementType =
-      new ComboParameter<FeatureMeasurementType>("Feature measurement type", "Measure features using",
-          FeatureMeasurementType.values());
+  public static final ComboParameter<FeatureMeasurementType> featureMeasurementType = new ComboParameter<FeatureMeasurementType>(
+      "Feature measurement type", "Measure features using", FeatureMeasurementType.values());
 
-  public static final BooleanParameter autoRemove =
-      new BooleanParameter("Remove original feature list",
-          "If checked, original feature list will be removed and only normalized version remains");
+  public static final OriginalFeatureListHandlingParameter handleOriginal = //
+      new OriginalFeatureListHandlingParameter(false);
 
   public LinearNormalizerParameters() {
-    super(new Parameter[] {featureLists, suffix, normalizationType, featureMeasurementType, autoRemove});
+    super(new Parameter[]{featureLists, suffix, normalizationType, featureMeasurementType,
+        handleOriginal});
   }
 
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/norm_rtcalibration/RTCalibrationParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/norm_rtcalibration/RTCalibrationParameters.java
@@ -22,8 +22,8 @@ package io.github.mzmine.modules.dataprocessing.norm_rtcalibration;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
-import io.github.mzmine.parameters.parametertypes.BooleanParameter;
 import io.github.mzmine.parameters.parametertypes.DoubleParameter;
+import io.github.mzmine.parameters.parametertypes.OriginalFeatureListHandlingParameter;
 import io.github.mzmine.parameters.parametertypes.StringParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZToleranceParameter;
@@ -33,8 +33,8 @@ public class RTCalibrationParameters extends SimpleParameterSet {
 
   public static final FeatureListsParameter featureLists = new FeatureListsParameter(2);
 
-  public static final StringParameter suffix =
-      new StringParameter("Name suffix", "Suffix to be added to feature list name", "normalized");
+  public static final StringParameter suffix = new StringParameter("Name suffix",
+      "Suffix to be added to feature list name", "normalized");
 
   public static final MZToleranceParameter MZTolerance = new MZToleranceParameter();
 
@@ -44,12 +44,12 @@ public class RTCalibrationParameters extends SimpleParameterSet {
       "Minimum height of a feature to be selected as normalization standard",
       MZmineCore.getConfiguration().getIntensityFormat());
 
-  public static final BooleanParameter autoRemove =
-      new BooleanParameter("Remove original feature list",
-          "If checked, original feature list will be removed and only normalized version remains");
+  public static final OriginalFeatureListHandlingParameter handleOriginal = //
+      new OriginalFeatureListHandlingParameter(false);
 
   public RTCalibrationParameters() {
-    super(new Parameter[] {featureLists, suffix, MZTolerance, RTTolerance, minHeight, autoRemove});
+    super(
+        new Parameter[]{featureLists, suffix, MZTolerance, RTTolerance, minHeight, handleOriginal});
   }
 
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/norm_standardcompound/StandardCompoundNormalizerParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/norm_standardcompound/StandardCompoundNormalizerParameters.java
@@ -20,9 +20,9 @@ package io.github.mzmine.modules.dataprocessing.norm_standardcompound;
 
 import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
-import io.github.mzmine.parameters.parametertypes.BooleanParameter;
 import io.github.mzmine.parameters.parametertypes.ComboParameter;
 import io.github.mzmine.parameters.parametertypes.DoubleParameter;
+import io.github.mzmine.parameters.parametertypes.OriginalFeatureListHandlingParameter;
 import io.github.mzmine.parameters.parametertypes.StringParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.FeatureSelectionParameter;
@@ -32,29 +32,27 @@ public class StandardCompoundNormalizerParameters extends SimpleParameterSet {
 
   public static final FeatureListsParameter featureList = new FeatureListsParameter(1, 1);
 
-  public static final StringParameter suffix =
-      new StringParameter("Name suffix", "Suffix to be added to feature list name", "normalized");
+  public static final StringParameter suffix = new StringParameter("Name suffix",
+      "Suffix to be added to feature list name", "normalized");
 
-  public static final ComboParameter<StandardUsageType> standardUsageType =
-      new ComboParameter<StandardUsageType>("Normalization type", "Normalize intensities using ",
-          StandardUsageType.values());
+  public static final ComboParameter<StandardUsageType> standardUsageType = new ComboParameter<StandardUsageType>(
+      "Normalization type", "Normalize intensities using ", StandardUsageType.values());
 
-  public static final ComboParameter<FeatureMeasurementType> featureMeasurementType =
-      new ComboParameter<FeatureMeasurementType>("Feature measurement type", "Measure features using ",
-          FeatureMeasurementType.values());
+  public static final ComboParameter<FeatureMeasurementType> featureMeasurementType = new ComboParameter<FeatureMeasurementType>(
+      "Feature measurement type", "Measure features using ", FeatureMeasurementType.values());
 
   public static final DoubleParameter MZvsRTBalance = new DoubleParameter("m/z vs RT balance",
       "Used in distance measuring as multiplier of m/z difference");
 
-  public static final BooleanParameter autoRemove = new BooleanParameter(
-      "Remove original feature list", "If checked, the original feature list will be removed");
+  public static final OriginalFeatureListHandlingParameter handleOriginal = //
+      new OriginalFeatureListHandlingParameter(false);
 
   public static final FeatureSelectionParameter standardCompounds = new FeatureSelectionParameter(
       "Standard compounds", "List of features for choosing the normalization standards", null);
 
   public StandardCompoundNormalizerParameters() {
-    super(new Parameter[] {featureList, suffix, standardUsageType, featureMeasurementType, MZvsRTBalance,
-        standardCompounds, autoRemove});
+    super(new Parameter[]{featureList, suffix, standardUsageType, featureMeasurementType,
+        MZvsRTBalance, standardCompounds, handleOriginal});
   }
 
 }

--- a/src/main/java/io/github/mzmine/modules/example/FeatureLearnerTask.java
+++ b/src/main/java/io/github/mzmine/modules/example/FeatureLearnerTask.java
@@ -27,6 +27,7 @@ import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
 import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.parameters.parametertypes.OriginalFeatureListHandlingParameter.OriginalFeatureListOption;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.parameters.parametertypes.tolerances.RTTolerance;
 import io.github.mzmine.taskcontrol.AbstractTask;
@@ -46,6 +47,7 @@ class FeatureLearnerTask extends AbstractTask {
   private static final Logger logger = Logger.getLogger(FeatureLearnerTask.class.getName());
 
   private final MZmineProject project;
+  private final OriginalFeatureListOption handleOriginal;
   private ModularFeatureList featureList;
   private ModularFeatureList resultFeatureList;
 
@@ -57,7 +59,6 @@ class FeatureLearnerTask extends AbstractTask {
   private String suffix;
   private MZTolerance mzTolerance;
   private RTTolerance rtTolerance;
-  private boolean removeOriginal;
   private ParameterSet parameters;
 
   /**
@@ -65,8 +66,8 @@ class FeatureLearnerTask extends AbstractTask {
    *
    * @param parameters
    */
-  public FeatureLearnerTask(MZmineProject project, FeatureList featureList, ParameterSet parameters, @Nullable
-      MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
+  public FeatureLearnerTask(MZmineProject project, FeatureList featureList, ParameterSet parameters,
+      @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
     this.project = project;
     this.featureList = (ModularFeatureList) featureList;
@@ -75,24 +76,19 @@ class FeatureLearnerTask extends AbstractTask {
     suffix = parameters.getParameter(LearnerParameters.suffix).getValue();
     mzTolerance = parameters.getParameter(LearnerParameters.mzTolerance).getValue();
     rtTolerance = parameters.getParameter(LearnerParameters.rtTolerance).getValue();
-    removeOriginal = parameters.getParameter(LearnerParameters.autoRemove).getValue();
+    handleOriginal = parameters.getValue(LearnerParameters.handleOriginal);
   }
 
-  /**
-   * @see io.github.mzmine.taskcontrol.Task#getTaskDescription()
-   */
   @Override
   public String getTaskDescription() {
     return "Learner task on " + featureList;
   }
 
-  /**
-   * @see io.github.mzmine.taskcontrol.Task#getFinishedPercentage()
-   */
   @Override
   public double getFinishedPercentage() {
-    if (totalFeatures == 0)
+    if (totalFeatures == 0) {
       return 0;
+    }
     return (double) processedFeatures / (double) totalFeatures;
   }
 
@@ -105,7 +101,8 @@ class FeatureLearnerTask extends AbstractTask {
     logger.info("Running learner task on " + featureList);
 
     // Create a new results feature list which is added at the end
-    resultFeatureList = new ModularFeatureList(featureList + " " + suffix, getMemoryMapStorage(), featureList.getRawDataFiles());
+    resultFeatureList = new ModularFeatureList(featureList + " " + suffix, getMemoryMapStorage(),
+        featureList.getRawDataFiles());
 
     /**
      * - A FeatureList is a list of Features (feature in retention time dimension with accurate m/z)<br>
@@ -128,8 +125,9 @@ class FeatureLearnerTask extends AbstractTask {
     totalFeatures = sortedFeatures.length;
     for (int i = 0; i < totalFeatures; i++) {
       // check for cancelled state and stop
-      if (isCanceled())
+      if (isCanceled()) {
         return;
+      }
 
       // current features
       Feature aFeature = sortedFeatures[i];
@@ -157,8 +155,8 @@ class FeatureLearnerTask extends AbstractTask {
    * Add feature list to project, delete old if requested, add description to result
    */
   public void addResultToProject() {
-    // Add new feature list to the project
-    project.addFeatureList(resultFeatureList);
+    // add results and maybe remove old lists
+    handleOriginal.reflectNewFeatureListToProject(suffix, project, resultFeatureList, featureList);
 
     // Load previous applied methods
     for (FeatureListAppliedMethod proc : featureList.getAppliedMethods()) {
@@ -166,12 +164,9 @@ class FeatureLearnerTask extends AbstractTask {
     }
 
     // Add task description to feature list
-    resultFeatureList
-        .addDescriptionOfAppliedTask(new SimpleFeatureListAppliedMethod(LearnerModule.class, parameters, getModuleCallDate()));
+    resultFeatureList.addDescriptionOfAppliedTask(
+        new SimpleFeatureListAppliedMethod(LearnerModule.class, parameters, getModuleCallDate()));
 
-    // Remove the original feature list if requested
-    if (removeOriginal)
-      project.removeFeatureList(featureList);
   }
 
 }

--- a/src/main/java/io/github/mzmine/modules/example/LearnerParameters.java
+++ b/src/main/java/io/github/mzmine/modules/example/LearnerParameters.java
@@ -20,8 +20,8 @@ package io.github.mzmine.modules.example;
 
 import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
-import io.github.mzmine.parameters.parametertypes.BooleanParameter;
 import io.github.mzmine.parameters.parametertypes.IntegerParameter;
+import io.github.mzmine.parameters.parametertypes.OriginalFeatureListHandlingParameter;
 import io.github.mzmine.parameters.parametertypes.StringParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZToleranceParameter;
@@ -43,8 +43,8 @@ public class LearnerParameters extends SimpleParameterSet {
   public static final IntegerParameter maximumCharge = new IntegerParameter("Maximum charge",
       "Maximum charge to consider for detecting the isotope patterns");
 
-  public static final BooleanParameter autoRemove = new BooleanParameter("Remove original feature list",
-      "If checked, original feature list will be removed and only deisotoped version remains");
+  public static final OriginalFeatureListHandlingParameter handleOriginal = new OriginalFeatureListHandlingParameter(
+      false);
 
   /**
    * Create a new parameterset
@@ -53,7 +53,8 @@ public class LearnerParameters extends SimpleParameterSet {
     /*
      * The order of the parameters is used to construct the parameter dialog automatically
      */
-    super(new Parameter[] {featureLists, suffix, mzTolerance, rtTolerance, maximumCharge, autoRemove});
+    super(new Parameter[]{featureLists, suffix, mzTolerance, rtTolerance, maximumCharge,
+        handleOriginal});
   }
 
 }

--- a/src/main/java/io/github/mzmine/modules/example/MultiRawDataLearnerTask.java
+++ b/src/main/java/io/github/mzmine/modules/example/MultiRawDataLearnerTask.java
@@ -27,6 +27,7 @@ import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
 import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.parameters.parametertypes.OriginalFeatureListHandlingParameter.OriginalFeatureListOption;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.parameters.parametertypes.tolerances.RTTolerance;
 import io.github.mzmine.taskcontrol.AbstractTask;
@@ -37,7 +38,6 @@ import io.github.mzmine.util.SortingDirection;
 import io.github.mzmine.util.SortingProperty;
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -47,6 +47,7 @@ class MultiRawDataLearnerTask extends AbstractTask {
   private static final Logger logger = Logger.getLogger(MultiRawDataLearnerTask.class.getName());
 
   private final MZmineProject project;
+  private final OriginalFeatureListOption handleOriginal;
   private FeatureList featureList;
   private FeatureList resultFeatureList;
 
@@ -58,7 +59,6 @@ class MultiRawDataLearnerTask extends AbstractTask {
   private String suffix;
   private MZTolerance mzTolerance;
   private RTTolerance rtTolerance;
-  private boolean removeOriginal;
   private ParameterSet parameters;
 
   /**
@@ -74,7 +74,7 @@ class MultiRawDataLearnerTask extends AbstractTask {
     suffix = parameters.getParameter(LearnerParameters.suffix).getValue();
     mzTolerance = parameters.getParameter(LearnerParameters.mzTolerance).getValue();
     rtTolerance = parameters.getParameter(LearnerParameters.rtTolerance).getValue();
-    removeOriginal = parameters.getParameter(LearnerParameters.autoRemove).getValue();
+    handleOriginal = parameters.getValue(LearnerParameters.handleOriginal);
   }
 
   /**
@@ -163,7 +163,7 @@ class MultiRawDataLearnerTask extends AbstractTask {
    */
   public void addResultToProject() {
     // Add new feature list to the project
-    project.addFeatureList(resultFeatureList);
+    handleOriginal.reflectNewFeatureListToProject(suffix, project, resultFeatureList, featureList);
 
     // Load previous applied methods
     for (FeatureListAppliedMethod proc : featureList.getAppliedMethods()) {
@@ -175,10 +175,6 @@ class MultiRawDataLearnerTask extends AbstractTask {
         .addDescriptionOfAppliedTask(
             new SimpleFeatureListAppliedMethod(LearnerModule.class, parameters, getModuleCallDate()));
 
-    // Remove the original feature list if requested
-    if (removeOriginal) {
-      project.removeFeatureList(featureList);
-    }
   }
 
 }

--- a/src/main/java/io/github/mzmine/modules/tools/batchwizard/BatchWizardController.java
+++ b/src/main/java/io/github/mzmine/modules/tools/batchwizard/BatchWizardController.java
@@ -526,7 +526,8 @@ public class BatchWizardController {
     param.setParameter(MinimumSearchFeatureResolverParameters.PEAK_LISTS,
         new FeatureListsSelection(FeatureListsSelectionType.BATCH_LAST_FEATURELISTS));
     param.setParameter(MinimumSearchFeatureResolverParameters.SUFFIX, "r");
-    param.setParameter(MinimumSearchFeatureResolverParameters.handleOriginal, true);
+    param.setParameter(MinimumSearchFeatureResolverParameters.handleOriginal,
+        OriginalFeatureListOption.KEEP);
 
     param.setParameter(MinimumSearchFeatureResolverParameters.groupMS2Parameters, true);
     final GroupMS2SubParameters groupParam = param.getParameter(
@@ -574,7 +575,8 @@ public class BatchWizardController {
     param.setParameter(MinimumSearchFeatureResolverParameters.PEAK_LISTS,
         new FeatureListsSelection(FeatureListsSelectionType.BATCH_LAST_FEATURELISTS));
     param.setParameter(MinimumSearchFeatureResolverParameters.SUFFIX, "r");
-    param.setParameter(MinimumSearchFeatureResolverParameters.handleOriginal, true);
+    param.setParameter(MinimumSearchFeatureResolverParameters.handleOriginal,
+        OriginalFeatureListOption.KEEP);
 
     param.setParameter(MinimumSearchFeatureResolverParameters.groupMS2Parameters, true);
     param.getParameter(MinimumSearchFeatureResolverParameters.groupMS2Parameters)

--- a/src/main/java/io/github/mzmine/modules/tools/batchwizard/BatchWizardController.java
+++ b/src/main/java/io/github/mzmine/modules/tools/batchwizard/BatchWizardController.java
@@ -468,7 +468,7 @@ public class BatchWizardController {
     ParameterSet param = MZmineCore.getConfiguration().getModuleParameters(ImsExpanderModule.class)
         .cloneParameterSet();
 
-    param.setParameter(ImsExpanderParameters.removeOriginalFeatureList, true);
+    param.setParameter(ImsExpanderParameters.handleOriginal, OriginalFeatureListOption.REMOVE);
     param.setParameter(ImsExpanderParameters.featureLists,
         new FeatureListsSelection(FeatureListsSelectionType.BATCH_LAST_FEATURELISTS));
     param.setParameter(ImsExpanderParameters.useRawData, true);
@@ -503,7 +503,7 @@ public class BatchWizardController {
     param.getParameter(SmoothingParameters.smoothingAlgorithm).setValue(
         new MZmineProcessingStepImpl<>(MZmineCore.getModuleInstance(SavitzkyGolaySmoothing.class),
             sgParam));
-    param.setParameter(SmoothingParameters.removeOriginal, true);
+    param.setParameter(SmoothingParameters.handleOriginal, OriginalFeatureListOption.REMOVE);
     param.setParameter(SmoothingParameters.suffix, "sm");
 
     return new MZmineProcessingStepImpl<>(MZmineCore.getModuleInstance(SmoothingModule.class),
@@ -638,7 +638,7 @@ public class BatchWizardController {
     param.setParameter(IsotopeGrouperParameters.maximumCharge, 2);
     param.setParameter(IsotopeGrouperParameters.representativeIsotope,
         IsotopeGrouperParameters.ChooseTopIntensity);
-    param.setParameter(IsotopeGrouperParameters.autoRemove, true);
+    param.setParameter(IsotopeGrouperParameters.handleOriginal, OriginalFeatureListOption.REMOVE);
 
     return new MZmineProcessingStepImpl<>(MZmineCore.getModuleInstance(IsotopeGrouperModule.class),
         param);
@@ -687,6 +687,7 @@ public class BatchWizardController {
     param.setParameter(JoinAlignerParameters.SameIDRequired, false);
     param.setParameter(JoinAlignerParameters.compareIsotopePattern, false);
     param.setParameter(JoinAlignerParameters.compareSpectraSimilarity, false);
+    param.setParameter(JoinAlignerParameters.handleOriginal, OriginalFeatureListOption.KEEP);
 
     return new MZmineProcessingStepImpl<>(MZmineCore.getModuleInstance(JoinAlignerModule.class),
         param);

--- a/src/main/java/io/github/mzmine/modules/tools/batchwizard/BatchWizardController.java
+++ b/src/main/java/io/github/mzmine/modules/tools/batchwizard/BatchWizardController.java
@@ -526,7 +526,7 @@ public class BatchWizardController {
     param.setParameter(MinimumSearchFeatureResolverParameters.PEAK_LISTS,
         new FeatureListsSelection(FeatureListsSelectionType.BATCH_LAST_FEATURELISTS));
     param.setParameter(MinimumSearchFeatureResolverParameters.SUFFIX, "r");
-    param.setParameter(MinimumSearchFeatureResolverParameters.AUTO_REMOVE, true);
+    param.setParameter(MinimumSearchFeatureResolverParameters.handleOriginal, true);
 
     param.setParameter(MinimumSearchFeatureResolverParameters.groupMS2Parameters, true);
     final GroupMS2SubParameters groupParam = param.getParameter(
@@ -574,7 +574,7 @@ public class BatchWizardController {
     param.setParameter(MinimumSearchFeatureResolverParameters.PEAK_LISTS,
         new FeatureListsSelection(FeatureListsSelectionType.BATCH_LAST_FEATURELISTS));
     param.setParameter(MinimumSearchFeatureResolverParameters.SUFFIX, "r");
-    param.setParameter(MinimumSearchFeatureResolverParameters.AUTO_REMOVE, true);
+    param.setParameter(MinimumSearchFeatureResolverParameters.handleOriginal, true);
 
     param.setParameter(MinimumSearchFeatureResolverParameters.groupMS2Parameters, true);
     param.getParameter(MinimumSearchFeatureResolverParameters.groupMS2Parameters)

--- a/src/main/java/io/github/mzmine/modules/tools/batchwizard/BatchWizardHPLCParameters.java
+++ b/src/main/java/io/github/mzmine/modules/tools/batchwizard/BatchWizardHPLCParameters.java
@@ -23,6 +23,8 @@ import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
 import io.github.mzmine.parameters.parametertypes.BooleanParameter;
 import io.github.mzmine.parameters.parametertypes.IntegerParameter;
+import io.github.mzmine.parameters.parametertypes.OriginalFeatureListHandlingParameter;
+import io.github.mzmine.parameters.parametertypes.OriginalFeatureListHandlingParameter.OriginalFeatureListOption;
 import io.github.mzmine.parameters.parametertypes.ranges.RTRangeParameter;
 import io.github.mzmine.parameters.parametertypes.tolerances.RTToleranceParameter;
 
@@ -69,9 +71,12 @@ public class BatchWizardHPLCParameters extends SimpleParameterSet {
       + "Uncheck for varying salt content or variations in ionization conditions.\n"
       + "Used in feature grouping.", true);
 
+  public static final OriginalFeatureListHandlingParameter handleOriginalFeatureLists = new OriginalFeatureListHandlingParameter(
+      false, OriginalFeatureListOption.REMOVE);
+
   public BatchWizardHPLCParameters() {
     super(new Parameter[]{stableIonizationAcrossSamples, cropRtRange, maximumIsomersInChromatogram,
         minNumberOfSamples, minNumberOfDataPoints, approximateChromatographicFWHM,
-        intraSampleRTTolerance, interSampleRTTolerance});
+        intraSampleRTTolerance, interSampleRTTolerance, handleOriginalFeatureLists});
   }
 }

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/OriginalFeatureListHandlingParameter.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/OriginalFeatureListHandlingParameter.java
@@ -30,7 +30,8 @@ import io.github.mzmine.parameters.parametertypes.OriginalFeatureListHandlingPar
 public class OriginalFeatureListHandlingParameter extends
     ComboParameter<OriginalFeatureListOption> {
 
-  public OriginalFeatureListHandlingParameter(boolean includeProcessInPlace) {
+  public OriginalFeatureListHandlingParameter(boolean includeProcessInPlace,
+      OriginalFeatureListOption startValue) {
     super("Original feature list",
         "Defines the processing. Standard is to keep the original feature list and create a new "
         + "processed list. REMOVE saves memory. PROCESS IN PLACE is an advanced option to process "
@@ -38,7 +39,11 @@ public class OriginalFeatureListHandlingParameter extends
         + "side effects, apply with caution.",
         includeProcessInPlace ? OriginalFeatureListOption.values()
             : new OriginalFeatureListOption[]{OriginalFeatureListOption.KEEP,
-                OriginalFeatureListOption.REMOVE}, OriginalFeatureListOption.KEEP);
+                OriginalFeatureListOption.REMOVE}, startValue);
+  }
+
+  public OriginalFeatureListHandlingParameter(boolean includeProcessInPlace) {
+    this(includeProcessInPlace, OriginalFeatureListOption.KEEP);
   }
 
   public enum OriginalFeatureListOption {

--- a/src/test/java/FeatureFindingTest.java
+++ b/src/test/java/FeatureFindingTest.java
@@ -109,8 +109,8 @@ public class FeatureFindingTest {
    */
   @BeforeAll
   public void init() {
-//    logger.info("Running MZmine");
-//    MZmineCore.main(new String[]{"-r", "-m", "all"});
+    //    logger.info("Running MZmine");
+    //    MZmineCore.main(new String[]{"-r", "-m", "all"});
     logger.info("Getting project");
     project = MZmineCore.getProjectManager().getCurrentProject();
   }
@@ -126,16 +126,16 @@ public class FeatureFindingTest {
   @Order(1)
   @DisplayName("Test advanced data import of mzML and mzXML with mass detection")
   void dataImportTest() throws InterruptedException {
-    File[] files = new File[]{new File(FeatureFindingTest.class.getClassLoader()
-        .getResource("rawdatafiles/DOM_a.mzML").getFile()),
-        new File(FeatureFindingTest.class.getClassLoader()
-            .getResource("rawdatafiles/DOM_b.mzXML").getFile())};
+    File[] files = new File[]{new File(
+        FeatureFindingTest.class.getClassLoader().getResource("rawdatafiles/DOM_a.mzML").getFile()),
+        new File(FeatureFindingTest.class.getClassLoader().getResource("rawdatafiles/DOM_b.mzXML")
+            .getFile())};
 
     AllSpectralDataImportParameters paramDataImport = new AllSpectralDataImportParameters();
     paramDataImport.setParameter(AllSpectralDataImportParameters.fileNames, files);
     paramDataImport.setParameter(AllSpectralDataImportParameters.advancedImport, true);
-    AdvancedSpectraImportParameters advancedImport = paramDataImport
-        .getParameter(AllSpectralDataImportParameters.advancedImport).getEmbeddedParameters();
+    AdvancedSpectraImportParameters advancedImport = paramDataImport.getParameter(
+        AllSpectralDataImportParameters.advancedImport).getEmbeddedParameters();
     advancedImport.setParameter(AdvancedSpectraImportParameters.msMassDetection, true);
     advancedImport.setParameter(AdvancedSpectraImportParameters.ms2MassDetection, true);
     // create centroid mass detectors
@@ -145,8 +145,8 @@ public class FeatureFindingTest {
         .getEmbeddedParameter().setValue(createCentroidMassDetector(0));
 
     logger.info("Testing advanced data import of mzML and mzXML with direct mass detection");
-    TaskResult finished = MZmineTestUtil
-        .callModuleWithTimeout(30, AllSpectralDataImportModule.class, paramDataImport);
+    TaskResult finished = MZmineTestUtil.callModuleWithTimeout(30,
+        AllSpectralDataImportModule.class, paramDataImport);
 
     // should have finished by now
     assertEquals(TaskResult.FINISHED, finished, () -> switch (finished) {
@@ -220,19 +220,19 @@ public class FeatureFindingTest {
   void chromatogramBuilderTest() throws InterruptedException {
 
     ADAPChromatogramBuilderParameters paramChrom = new ADAPChromatogramBuilderParameters();
-    paramChrom.getParameter(ADAPChromatogramBuilderParameters.dataFiles).setValue(
-        RawDataFilesSelectionType.ALL_FILES);
+    paramChrom.getParameter(ADAPChromatogramBuilderParameters.dataFiles)
+        .setValue(RawDataFilesSelectionType.ALL_FILES);
     paramChrom.setParameter(ADAPChromatogramBuilderParameters.scanSelection, new ScanSelection(1));
     paramChrom.setParameter(ADAPChromatogramBuilderParameters.minimumScanSpan, 4);
-    paramChrom
-        .setParameter(ADAPChromatogramBuilderParameters.mzTolerance, new MZTolerance(0.002, 10));
+    paramChrom.setParameter(ADAPChromatogramBuilderParameters.mzTolerance,
+        new MZTolerance(0.002, 10));
     paramChrom.setParameter(ADAPChromatogramBuilderParameters.startIntensity, 3E5);
     paramChrom.setParameter(ADAPChromatogramBuilderParameters.IntensityThresh2, 1E5);
     paramChrom.setParameter(ADAPChromatogramBuilderParameters.suffix, chromSuffix);
 
     logger.info("Testing ADAPChromatogramBuilder");
-    TaskResult finished = MZmineTestUtil
-        .callModuleWithTimeout(30, ModularADAPChromatogramBuilderModule.class, paramChrom);
+    TaskResult finished = MZmineTestUtil.callModuleWithTimeout(30,
+        ModularADAPChromatogramBuilderModule.class, paramChrom);
 
     // should have finished by now
     assertEquals(TaskResult.FINISHED, finished, () -> switch (finished) {
@@ -280,10 +280,8 @@ public class FeatureFindingTest {
     // both files tested
     assertEquals(2, filesTested);
 
-    lastFlistA = (ModularFeatureList) project
-        .getFeatureList(getName(sample1, chromSuffix));
-    lastFlistB = (ModularFeatureList) project
-        .getFeatureList(getName(sample2, chromSuffix));
+    lastFlistA = (ModularFeatureList) project.getFeatureList(getName(sample1, chromSuffix));
+    lastFlistB = (ModularFeatureList) project.getFeatureList(getName(sample2, chromSuffix));
   }
 
   @Test
@@ -309,8 +307,8 @@ public class FeatureFindingTest {
     paramSmooth.setParameter(SmoothingParameters.suffix, smoothSuffix);
 
     logger.info("Testing chromatogram smoothing (RT, 5 dp)");
-    TaskResult finished = MZmineTestUtil
-        .callModuleWithTimeout(30, SmoothingModule.class, paramSmooth);
+    TaskResult finished = MZmineTestUtil.callModuleWithTimeout(30, SmoothingModule.class,
+        paramSmooth);
 
     // should have finished by now
     assertEquals(TaskResult.FINISHED, finished, () -> switch (finished) {
@@ -321,10 +319,10 @@ public class FeatureFindingTest {
 
     assertEquals(4, project.getCurrentFeatureLists().size());
     // test feature lists
-    ModularFeatureList processed1 = (ModularFeatureList) project
-        .getFeatureList(getName(sample1, chromSuffix, smoothSuffix));
-    ModularFeatureList processed2 = (ModularFeatureList) project
-        .getFeatureList(getName(sample2, chromSuffix, smoothSuffix));
+    ModularFeatureList processed1 = (ModularFeatureList) project.getFeatureList(
+        getName(sample1, chromSuffix, smoothSuffix));
+    ModularFeatureList processed2 = (ModularFeatureList) project.getFeatureList(
+        getName(sample2, chromSuffix, smoothSuffix));
 
     // already save feature lists to last for next steps
     ModularFeatureList lastFlistA = this.lastFlistA;
@@ -339,10 +337,8 @@ public class FeatureFindingTest {
     // same size
     assertEquals(lastFlistA.getNumberOfRows(), processed1.getNumberOfRows());
     assertEquals(lastFlistB.getNumberOfRows(), processed2.getNumberOfRows());
-    assertEquals(lastFlistA.getAppliedMethods().size() + 1,
-        processed1.getAppliedMethods().size());
-    assertEquals(lastFlistB.getAppliedMethods().size() + 1,
-        processed2.getAppliedMethods().size());
+    assertEquals(lastFlistA.getAppliedMethods().size() + 1, processed1.getAppliedMethods().size());
+    assertEquals(lastFlistB.getAppliedMethods().size() + 1, processed2.getAppliedMethods().size());
 
     for (int i = 0; i < lastFlistA.getNumberOfRows(); i++) {
       // same order and number of data points after smoothing
@@ -356,10 +352,10 @@ public class FeatureFindingTest {
       assertEquals(a.getAverageMZ(), b.getAverageMZ(), 0.005, "mz change to high");
 
       // area change is greater than 25 % for some features
-//      assertTrue(Precision.equals(a.getAverageArea(), b.getAverageArea(), 0, maxRelAreaChange),
-//          () -> MessageFormat.format(
-//              "area change is too high (more then {4}) for IDs: {0} and {1} with areas: {2}, {3}",
-//              a.getID(), b.getID(), a.getAverageArea(), b.getAverageArea(), maxRelAreaChange));
+      //      assertTrue(Precision.equals(a.getAverageArea(), b.getAverageArea(), 0, maxRelAreaChange),
+      //          () -> MessageFormat.format(
+      //              "area change is too high (more then {4}) for IDs: {0} and {1} with areas: {2}, {3}",
+      //              a.getID(), b.getID(), a.getAverageArea(), b.getAverageArea(), maxRelAreaChange));
     }
 
     for (int i = 0; i < lastFlistB.getNumberOfRows(); i++) {
@@ -374,10 +370,10 @@ public class FeatureFindingTest {
       assertEquals(a.getAverageMZ(), b.getAverageMZ(), 0.005, "mz change to high");
 
       // area change is greater than 25 % for some features
-//      assertTrue(Precision.equals(a.getAverageArea(), b.getAverageArea(), 0, maxRelAreaChange),
-//          () -> MessageFormat.format(
-//              "area change is too high (more then {4}) for IDs: {0} and {1} with areas: {2}, {3}",
-//              a.getID(), b.getID(), a.getAverageArea(), b.getAverageArea(), maxRelAreaChange));
+      //      assertTrue(Precision.equals(a.getAverageArea(), b.getAverageArea(), 0, maxRelAreaChange),
+      //          () -> MessageFormat.format(
+      //              "area change is too high (more then {4}) for IDs: {0} and {1} with areas: {2}, {3}",
+      //              a.getID(), b.getID(), a.getAverageArea(), b.getAverageArea(), maxRelAreaChange));
     }
   }
 
@@ -393,12 +389,12 @@ public class FeatureFindingTest {
     MinimumSearchFeatureResolverParameters generalParam = new MinimumSearchFeatureResolverParameters();
     generalParam.getParameter(MinimumSearchFeatureResolverParameters.PEAK_LISTS)
         .setValue(new FeatureListsSelection(lastFlistA, lastFlistB));
-    generalParam.setParameter(MinimumSearchFeatureResolverParameters.AUTO_REMOVE, false);
-    generalParam
-        .setParameter(MinimumSearchFeatureResolverParameters.CHROMATOGRAPHIC_THRESHOLD_LEVEL, 0.8);
-    generalParam
-        .setParameter(MinimumSearchFeatureResolverParameters.dimension,
-            ResolvingDimension.RETENTION_TIME);
+    generalParam.setParameter(MinimumSearchFeatureResolverParameters.handleOriginal,
+        OriginalFeatureListOption.KEEP);
+    generalParam.setParameter(
+        MinimumSearchFeatureResolverParameters.CHROMATOGRAPHIC_THRESHOLD_LEVEL, 0.8);
+    generalParam.setParameter(MinimumSearchFeatureResolverParameters.dimension,
+        ResolvingDimension.RETENTION_TIME);
     generalParam.setParameter(MinimumSearchFeatureResolverParameters.MIN_ABSOLUTE_HEIGHT, 1E5);
     generalParam.setParameter(MinimumSearchFeatureResolverParameters.MIN_NUMBER_OF_DATAPOINTS, 4);
     generalParam.setParameter(MinimumSearchFeatureResolverParameters.MIN_RATIO, 1.8);
@@ -410,17 +406,16 @@ public class FeatureFindingTest {
 
     // group ms2
     generalParam.setParameter(MinimumSearchFeatureResolverParameters.groupMS2Parameters, true);
-    GroupMS2SubParameters groupMS2SubParameters = generalParam
-        .getParameter(MinimumSearchFeatureResolverParameters.groupMS2Parameters)
-        .getEmbeddedParameters();
+    GroupMS2SubParameters groupMS2SubParameters = generalParam.getParameter(
+        MinimumSearchFeatureResolverParameters.groupMS2Parameters).getEmbeddedParameters();
     groupMS2SubParameters.setParameter(GroupMS2SubParameters.limitRTByFeature, false);
     groupMS2SubParameters.setParameter(GroupMS2SubParameters.mzTol, new MZTolerance(0.05, 10));
-    groupMS2SubParameters
-        .setParameter(GroupMS2SubParameters.rtTol, new RTTolerance(0.15f, Unit.MINUTES));
+    groupMS2SubParameters.setParameter(GroupMS2SubParameters.rtTol,
+        new RTTolerance(0.15f, Unit.MINUTES));
 
     logger.info("Testing chromatogram deconvolution");
-    TaskResult finished = MZmineTestUtil
-        .callModuleWithTimeout(45, MinimumSearchFeatureResolverModule.class, generalParam);
+    TaskResult finished = MZmineTestUtil.callModuleWithTimeout(45,
+        MinimumSearchFeatureResolverModule.class, generalParam);
 
     // should have finished by now
     assertEquals(TaskResult.FINISHED, finished, () -> switch (finished) {
@@ -433,10 +428,10 @@ public class FeatureFindingTest {
         .map(FeatureList::getName).collect(Collectors.joining(", ")));
     assertEquals(6, project.getCurrentFeatureLists().size());
     // test feature lists
-    ModularFeatureList processed1 = (ModularFeatureList) project
-        .getFeatureList(getName(sample1, chromSuffix, smoothSuffix, deconSuffix));
-    ModularFeatureList processed2 = (ModularFeatureList) project
-        .getFeatureList(getName(sample2, chromSuffix, smoothSuffix, deconSuffix));
+    ModularFeatureList processed1 = (ModularFeatureList) project.getFeatureList(
+        getName(sample1, chromSuffix, smoothSuffix, deconSuffix));
+    ModularFeatureList processed2 = (ModularFeatureList) project.getFeatureList(
+        getName(sample2, chromSuffix, smoothSuffix, deconSuffix));
 
     // already save feature lists to last for next steps
     ModularFeatureList lastFlistA = this.lastFlistA;
@@ -449,10 +444,8 @@ public class FeatureFindingTest {
     assertNotNull(processed2);
 
     // methods +1
-    assertEquals(lastFlistA.getAppliedMethods().size() + 1,
-        processed1.getAppliedMethods().size());
-    assertEquals(lastFlistB.getAppliedMethods().size() + 1,
-        processed2.getAppliedMethods().size());
+    assertEquals(lastFlistA.getAppliedMethods().size() + 1, processed1.getAppliedMethods().size());
+    assertEquals(lastFlistB.getAppliedMethods().size() + 1, processed2.getAppliedMethods().size());
 
     assertEquals(158, processed1.getNumberOfRows());
     assertEquals(169, processed2.getNumberOfRows());
@@ -476,15 +469,15 @@ public class FeatureFindingTest {
     generalParam.setParameter(IsotopeGrouperParameters.mobilityTolerace, false);
     generalParam.setParameter(IsotopeGrouperParameters.monotonicShape, true);
     generalParam.setParameter(IsotopeGrouperParameters.mzTolerance, new MZTolerance(0.003, 10));
-    generalParam
-        .setParameter(IsotopeGrouperParameters.rtTolerance, new RTTolerance(0.1f, Unit.MINUTES));
+    generalParam.setParameter(IsotopeGrouperParameters.rtTolerance,
+        new RTTolerance(0.1f, Unit.MINUTES));
     generalParam.setParameter(IsotopeGrouperParameters.representativeIsotope,
         IsotopeGrouperParameters.ChooseTopIntensity);
     generalParam.setParameter(IsotopeGrouperParameters.suffix, deisotopeSuffix);
 
     logger.info("Testing deisotoping");
-    TaskResult finished = MZmineTestUtil
-        .callModuleWithTimeout(30, IsotopeGrouperModule.class, generalParam);
+    TaskResult finished = MZmineTestUtil.callModuleWithTimeout(30, IsotopeGrouperModule.class,
+        generalParam);
 
     // should have finished by now
     assertEquals(TaskResult.FINISHED, finished, () -> switch (finished) {
@@ -495,10 +488,10 @@ public class FeatureFindingTest {
 
     assertEquals(8, project.getCurrentFeatureLists().size());
     // test feature lists
-    ModularFeatureList processed1 = (ModularFeatureList) project
-        .getFeatureList(getName(sample1, chromSuffix, smoothSuffix, deconSuffix, deisotopeSuffix));
-    ModularFeatureList processed2 = (ModularFeatureList) project
-        .getFeatureList(getName(sample2, chromSuffix, smoothSuffix, deconSuffix, deisotopeSuffix));
+    ModularFeatureList processed1 = (ModularFeatureList) project.getFeatureList(
+        getName(sample1, chromSuffix, smoothSuffix, deconSuffix, deisotopeSuffix));
+    ModularFeatureList processed2 = (ModularFeatureList) project.getFeatureList(
+        getName(sample2, chromSuffix, smoothSuffix, deconSuffix, deisotopeSuffix));
 
     // already save feature lists to last for next steps
     ModularFeatureList lastFlistA = this.lastFlistA;
@@ -510,10 +503,8 @@ public class FeatureFindingTest {
     assertNotNull(processed2);
 
     // methods +1
-    assertEquals(lastFlistA.getAppliedMethods().size() + 1,
-        processed1.getAppliedMethods().size());
-    assertEquals(lastFlistB.getAppliedMethods().size() + 1,
-        processed2.getAppliedMethods().size());
+    assertEquals(lastFlistA.getAppliedMethods().size() + 1, processed1.getAppliedMethods().size());
+    assertEquals(lastFlistB.getAppliedMethods().size() + 1, processed2.getAppliedMethods().size());
     // less feature list rows
     assertTrue(lastFlistA.getNumberOfRows() > processed1.getNumberOfRows());
     assertTrue(lastFlistB.getNumberOfRows() > processed2.getNumberOfRows());
@@ -554,8 +545,8 @@ public class FeatureFindingTest {
     generalParam.setParameter(JoinAlignerParameters.mobilityWeight, 0d);
     generalParam.setParameter(JoinAlignerParameters.MZTolerance, new MZTolerance(0.003, 10));
     generalParam.setParameter(JoinAlignerParameters.MZWeight, 3d);
-    generalParam
-        .setParameter(JoinAlignerParameters.RTTolerance, new RTTolerance(0.2f, Unit.MINUTES));
+    generalParam.setParameter(JoinAlignerParameters.RTTolerance,
+        new RTTolerance(0.2f, Unit.MINUTES));
     generalParam.setParameter(JoinAlignerParameters.RTWeight, 1d);
     generalParam.setParameter(JoinAlignerParameters.SameChargeRequired, false);
     generalParam.setParameter(JoinAlignerParameters.SameIDRequired, false);
@@ -563,8 +554,8 @@ public class FeatureFindingTest {
     generalParam.setParameter(JoinAlignerParameters.peakListName, alignedName);
 
     logger.info("Testing join aligner");
-    TaskResult finished = MZmineTestUtil
-        .callModuleWithTimeout(30, JoinAlignerModule.class, generalParam);
+    TaskResult finished = MZmineTestUtil.callModuleWithTimeout(30, JoinAlignerModule.class,
+        generalParam);
 
     // should have finished by now
     assertEquals(TaskResult.FINISHED, finished, () -> switch (finished) {
@@ -575,8 +566,8 @@ public class FeatureFindingTest {
 
     assertEquals(9, project.getCurrentFeatureLists().size());
     // test feature lists
-    ModularFeatureList processed1 = (ModularFeatureList) project
-        .getFeatureList(getName(alignedName));
+    ModularFeatureList processed1 = (ModularFeatureList) project.getFeatureList(
+        getName(alignedName));
 
     // already save feature lists to last for next steps
     ModularFeatureList lastFlistA = this.lastFlistA;
@@ -588,8 +579,7 @@ public class FeatureFindingTest {
     assertEquals(2, processed1.getRawDataFiles().size());
 
     // methods +1
-    assertEquals(lastFlistA.getAppliedMethods().size() + 1,
-        processed1.getAppliedMethods().size());
+    assertEquals(lastFlistA.getAppliedMethods().size() + 1, processed1.getAppliedMethods().size());
     // less feature list rows
     assertEquals(200, processed1.getNumberOfRows());
 

--- a/src/test/java/FeatureFindingTest.java
+++ b/src/test/java/FeatureFindingTest.java
@@ -55,6 +55,7 @@ import io.github.mzmine.modules.io.import_rawdata_all.AdvancedSpectraImportParam
 import io.github.mzmine.modules.io.import_rawdata_all.AllSpectralDataImportModule;
 import io.github.mzmine.modules.io.import_rawdata_all.AllSpectralDataImportParameters;
 import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.parameters.parametertypes.OriginalFeatureListHandlingParameter.OriginalFeatureListOption;
 import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsSelection;
 import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesSelectionType;
 import io.github.mzmine.parameters.parametertypes.selectors.ScanSelection;
@@ -302,9 +303,9 @@ public class FeatureFindingTest {
     SmoothingParameters paramSmooth = new SmoothingParameters();
     paramSmooth.getParameter(SmoothingParameters.featureLists)
         .setValue(new FeatureListsSelection(lastFlistA, lastFlistB));
-    paramSmooth.setParameter(SmoothingParameters.removeOriginal, false);
-    paramSmooth
-        .setParameter(SmoothingParameters.smoothingAlgorithm, new MZmineProcessingStepImpl<>(SmoothingParameters.sgSmoothing, sgParam));
+    paramSmooth.setParameter(SmoothingParameters.handleOriginal, OriginalFeatureListOption.KEEP);
+    paramSmooth.setParameter(SmoothingParameters.smoothingAlgorithm,
+        new MZmineProcessingStepImpl<>(SmoothingParameters.sgSmoothing, sgParam));
     paramSmooth.setParameter(SmoothingParameters.suffix, smoothSuffix);
 
     logger.info("Testing chromatogram smoothing (RT, 5 dp)");
@@ -469,7 +470,8 @@ public class FeatureFindingTest {
     IsotopeGrouperParameters generalParam = new IsotopeGrouperParameters();
     generalParam.getParameter(IsotopeGrouperParameters.peakLists)
         .setValue(new FeatureListsSelection(lastFlistA, lastFlistB));
-    generalParam.setParameter(IsotopeGrouperParameters.autoRemove, false);
+    generalParam.setParameter(IsotopeGrouperParameters.handleOriginal,
+        OriginalFeatureListOption.KEEP);
     generalParam.setParameter(IsotopeGrouperParameters.maximumCharge, 2);
     generalParam.setParameter(IsotopeGrouperParameters.mobilityTolerace, false);
     generalParam.setParameter(IsotopeGrouperParameters.monotonicShape, true);
@@ -557,6 +559,7 @@ public class FeatureFindingTest {
     generalParam.setParameter(JoinAlignerParameters.RTWeight, 1d);
     generalParam.setParameter(JoinAlignerParameters.SameChargeRequired, false);
     generalParam.setParameter(JoinAlignerParameters.SameIDRequired, false);
+    generalParam.setParameter(JoinAlignerParameters.handleOriginal, OriginalFeatureListOption.KEEP);
     generalParam.setParameter(JoinAlignerParameters.peakListName, alignedName);
 
     logger.info("Testing join aligner");


### PR DESCRIPTION
- Most modules will only expose KEEP or REMOVE original feature list.
- PROCESS IN PLACE is available for: 
- Isotope grouper
- Gap fill
- Feature list rows filter
- Duplicate filter

The gain for feature list rows filter comparing PROCESS IN PLACE to the other options was a time reduction from 7 minutes --> 6 seconds. (no feature list copy)