### PR TITLE
Cyclic IMS support

### DIFF
--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzml/MSDKmzMLImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzml/MSDKmzMLImportTask.java
@@ -236,7 +236,11 @@ public class MSDKmzMLImportTask extends AbstractTask {
 
     for (MsScan scan : file.getScans()) {
       MzMLMsScan mzMLScan = (MzMLMsScan) scan;
-      if (mzMLScan.getMobility().mobilityType() == MobilityType.TIMS && mobilities[0] - mobilities[1] < 0) {
+      if(mzMLScan.getMobility() == null) {
+        continue;
+      }
+      if (mzMLScan.getMobility().mobilityType() == MobilityType.TIMS
+          && mobilities[0] - mobilities[1] < 0) {
         // for tims, mobilities must be sorted in descending order, so if [0]-[1] < 0, we must reverse
         ArrayUtils.reverse(mobilities);
       }
@@ -316,10 +320,18 @@ public class MSDKmzMLImportTask extends AbstractTask {
       throws IOException {
     final RangeMap<Double, Integer> mobilityCounts = TreeRangeMap.create();
 
-    final boolean isTims =
-        ((MzMLMsScan) file.getScans().get(0)).getMobility().mobilityType() == MobilityType.TIMS;
+    boolean isTims;
+    try {
+      isTims =
+          ((MzMLMsScan) file.getScans().get(0)).getMobility().mobilityType() == MobilityType.TIMS;
+    } catch (NullPointerException e) {
+      isTims = false;
+    }
     for (MsScan scan : file.getScans()) {
       MzMLMsScan mzMLScan = (MzMLMsScan) scan;
+      if(((MzMLMsScan) scan).getMobility() == null) {
+        continue;
+      }
       final double mobility = mzMLScan.getMobility().mobility();
       final Entry<Range<Double>, Integer> entry = mobilityCounts.getEntry(mobility);
       if (entry == null) {
@@ -343,8 +355,7 @@ public class MSDKmzMLImportTask extends AbstractTask {
     final double tenthDiff = medianDiff / 10;
     RangeMap<Double, Integer> realMobilities = TreeRangeMap.create();
     for (int i = 0; i < mobilityValues.length; i++) {
-      realMobilities.put(
-          Range.closed(mobilityValues[i] - tenthDiff, mobilityValues[i] + tenthDiff),
+      realMobilities.put(Range.closed(mobilityValues[i] - tenthDiff, mobilityValues[i] + tenthDiff),
           isTims ? mobilityValues.length - 1 - i : i); // reverse scan number order for tims
     }
 

--- a/src/main/java/io/github/mzmine/util/RawDataFileTypeDetector.java
+++ b/src/main/java/io/github/mzmine/util/RawDataFileTypeDetector.java
@@ -150,7 +150,7 @@ public class RawDataFileTypeDetector {
           } else {
             InputStreamReader reader2 =
                 new InputStreamReader(new FileInputStream(fileName), StandardCharsets.ISO_8859_1);
-            char buffer2[] = new char[4096];
+            char buffer2[] = new char[4096 * 10];
             String content = new String(buffer2);
             boolean containsScan = false, containsAccession = false;
             while (containsScan == false && containsAccession == false) {
@@ -162,7 +162,6 @@ public class RawDataFileTypeDetector {
             }
             reader2.close();
             if (content.contains("1002476") || content.contains("1002815")) { // accession for
-                                                                              // mobility
               return RawDataFileType.MZML_IMS;
             } else {
               return RawDataFileType.MZML;
@@ -186,5 +185,4 @@ public class RawDataFileTypeDetector {
     return null;
 
   }
-
 }


### PR DESCRIPTION
Draft PR until i know what's going on with the cyclic IMS data. 

In the converted mzML data, there were scans with and without mobility information. I'm guessing it's accumulated MS1/MS2 frames, but i'm not sure. 

This fix will ignore the accumulated frames and only import the mobility scans. (if the assumptions are correct)

- ignore scans without mobility information in mzml