### PR TITLE
add smiles to nist msp parser, add lipid blast support

### DIFF
--- a/src/main/java/io/github/mzmine/util/spectraldb/entry/DBEntryField.java
+++ b/src/main/java/io/github/mzmine/util/spectraldb/entry/DBEntryField.java
@@ -212,7 +212,7 @@ public enum DBEntryField {
       case RT:
         return "RT";
       case SMILES:
-        return "";
+        return "SMILES";
       case MS_LEVEL:
         return "Spectrum_type";
       case PUBCHEM:

--- a/src/main/java/io/github/mzmine/util/spectraldb/parser/NistMspParser.java
+++ b/src/main/java/io/github/mzmine/util/spectraldb/parser/NistMspParser.java
@@ -126,6 +126,15 @@ public class NistMspParser extends SpectralDBTextParser {
         logger.log(Level.WARNING, "Cannot parse data point", e);
       }
     }
+
+    data = dataAndComment[0].split("\t");
+    if (data.length == 2) {
+      try {
+        return new SimpleDataPoint(Double.parseDouble(data[0]), Double.parseDouble(data[1]));
+      } catch (Exception e) {
+        logger.log(Level.WARNING, "Cannot parse data point", e);
+      }
+    }
     return null;
   }
 


### PR DESCRIPTION
- the smiles tag was not imported from nist msp files
- lipid blast msp format uses tab instead of whitespace to separate mz/intensity
- lipid blast still uses precursortype over precursor_type, apperently contrary to nist