### PR TITLE
Optimize ADAP chrom builder, RangeMap

### DIFF
--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ModularADAPChromatogramBuilderTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ModularADAPChromatogramBuilderTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2020 The MZmine Development Team
+ * Copyright 2006-2021 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -8,19 +8,20 @@
  * License, or (at your option) any later version.
  *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
- * Public License for more details.
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
  */
 
 package io.github.mzmine.modules.dataprocessing.featdet_adapchromatogrambuilder;
 
 
 import com.google.common.collect.Range;
-import com.google.common.collect.RangeSet;
-import com.google.common.collect.TreeRangeSet;
+import com.google.common.collect.RangeMap;
+import com.google.common.collect.TreeRangeMap;
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.Scan;
@@ -49,11 +50,9 @@ import io.github.mzmine.util.exceptions.MissingMassListException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -61,74 +60,60 @@ import org.jetbrains.annotations.Nullable;
 
 public class ModularADAPChromatogramBuilderTask extends AbstractTask {
 
-  RangeSet<Double> rangeSet = TreeRangeSet.create();
-  // After each range is created it does not change so we can map the ranges (which will be uniqe)
-  // to the chromatograms
-  HashMap<Range, ADAPChromatogram> rangeToChromMap = new HashMap<>();
+  private static final Logger logger = Logger.getLogger(
+      ModularADAPChromatogramBuilderTask.class.getName());
 
-  private Logger logger = Logger.getLogger(this.getClass().getName());
-
-  private MZmineProject project;
-  private RawDataFile dataFile;
+  private final MZmineProject project;
+  private final RawDataFile dataFile;
 
   private double progress = 0.0;
-  private ScanSelection scanSelection;
+  private final ScanSelection scanSelection;
   private int newFeatureID = 1;
   private Scan[] scans;
 
   // User parameters
-  private String suffix;
-  private MZTolerance mzTolerance;
-  private double minimumHeight;
-  private int minimumScanSpan;
+  private final String suffix;
+  private final MZTolerance mzTolerance;
+  private final int minimumScanSpan;
   // Owen added User parameers;
-  private double IntensityThresh2;
-  private double minIntensityForStartChrom;
+  private final double IntensityThresh2;
+  private final double minIntensityForStartChrom;
 
   private ModularFeatureList newFeatureList;
-  private ParameterSet parameters;
+  private final ParameterSet parameters;
 
   /**
-   * @param dataFile
-   * @param parameters
+   *
    */
   public ModularADAPChromatogramBuilderTask(MZmineProject project, RawDataFile dataFile,
-      ParameterSet parameters, @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
+      ParameterSet parameters, @Nullable MemoryMapStorage storage,
+      @NotNull Instant moduleCallDate) {
     super(storage, moduleCallDate);
     this.project = project;
     this.dataFile = dataFile;
-    this.scanSelection =
-        parameters.getParameter(ADAPChromatogramBuilderParameters.scanSelection).getValue();
+    this.scanSelection = parameters.getParameter(ADAPChromatogramBuilderParameters.scanSelection)
+        .getValue();
 
-    this.mzTolerance =
-        parameters.getParameter(ADAPChromatogramBuilderParameters.mzTolerance).getValue();
-    this.minimumScanSpan =
-        parameters.getParameter(ADAPChromatogramBuilderParameters.minimumScanSpan).getValue();
-    // this.minimumHeight = parameters
-    // .getParameter(ChromatogramBuilderParameters.minimumHeight)
-    // .getValue();
+    this.mzTolerance = parameters.getParameter(ADAPChromatogramBuilderParameters.mzTolerance)
+        .getValue();
+    this.minimumScanSpan = parameters.getParameter(
+        ADAPChromatogramBuilderParameters.minimumScanSpan).getValue();
 
     this.suffix = parameters.getParameter(ADAPChromatogramBuilderParameters.suffix).getValue();
 
     // Owen added parameters
-    this.IntensityThresh2 =
-        parameters.getParameter(ADAPChromatogramBuilderParameters.IntensityThresh2).getValue();
-    this.minIntensityForStartChrom =
-        parameters.getParameter(ADAPChromatogramBuilderParameters.startIntensity).getValue();
+    this.IntensityThresh2 = parameters.getParameter(
+        ADAPChromatogramBuilderParameters.IntensityThresh2).getValue();
+    this.minIntensityForStartChrom = parameters.getParameter(
+        ADAPChromatogramBuilderParameters.startIntensity).getValue();
     this.parameters = parameters;
   }
 
-  /**
-   * @see io.github.mzmine.taskcontrol.Task#getTaskDescription()
-   */
   @Override
   public String getTaskDescription() {
     return "Detecting chromatograms in " + dataFile;
   }
 
-  /**
-   * @see io.github.mzmine.taskcontrol.Task#getFinishedPercentage()
-   */
   @Override
   public double getFinishedPercentage() {
     return progress;
@@ -138,13 +123,9 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
     return dataFile;
   }
 
-  /**
-   * @see Runnable#run()
-   */
+  @SuppressWarnings("UnstableApiUsage")
   @Override
   public void run() {
-    boolean writeChromCDF = true;
-
     setStatus(TaskStatus.PROCESSING);
 
     logger.info(() -> "Started chromatogram builder on " + dataFile);
@@ -153,21 +134,15 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
     if (scans.length == 0) {
       setStatus(TaskStatus.ERROR);
       setErrorMessage("There are no scans satisfying filtering values. Consider updating filters "
-          + "with \"Set filters\" in the \"Scans\" parameter.");
+                      + "with \"Set filters\" in the \"Scans\" parameter.");
       return;
     }
 
-    List<Float> rtListForChromCDF = new ArrayList<>();
-
-        // Check if the scans are properly ordered by RT
-        double prevRT = Double.NEGATIVE_INFINITY;
-        for (Scan s : scans) {
-          if (isCanceled()) {
-            return;
-      }
-
-      if (writeChromCDF) {
-        rtListForChromCDF.add(s.getRetentionTime());
+    // Check if the scans are properly ordered by RT
+    double prevRT = Double.NEGATIVE_INFINITY;
+    for (Scan s : scans) {
+      if (isCanceled()) {
+        return;
       }
 
       if (s.getRetentionTime() < prevRT) {
@@ -183,11 +158,9 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
     }
 
     // Check if the scans are MS1-only or MS2-only.
-    int minMsLevel = Arrays.stream(scans).mapToInt(Scan::getMSLevel).min()
-        .orElseThrow(() -> new IllegalStateException("Cannot find the minimum MS level"));
+    int minMsLevel = Arrays.stream(scans).mapToInt(Scan::getMSLevel).min().orElseThrow(() -> new IllegalStateException("Cannot find the minimum MS level"));
 
-    int maxMsLevel = Arrays.stream(scans).mapToInt(Scan::getMSLevel).max()
-        .orElseThrow(() -> new IllegalStateException("Cannot find the maximum MS level"));
+    int maxMsLevel = Arrays.stream(scans).mapToInt(Scan::getMSLevel).max().orElseThrow(() -> new IllegalStateException("Cannot find the maximum MS level"));
 
     if (minMsLevel != maxMsLevel) {
       MZmineCore.getDesktop().displayMessage(null,
@@ -203,32 +176,35 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
     // update mz avg and other stuff
     //
 
-    // make a list of all the data points
-    List<ExpandedDataPoint> allMzValues = new ArrayList<ExpandedDataPoint>();
+    // map the mz tolerance to chromatograms
+    RangeMap<Double, ADAPChromatogram> rangeToChromMap2 = TreeRangeMap.create();
 
-    ScanDataAccess scanData = EfficientDataAccess
-        .of(dataFile, ScanDataType.CENTROID, scanSelection);
+    // make a list of all the data points
+    List<ExpandedDataPoint> allMzValues = new ArrayList<>();
+
+    ScanDataAccess scanData = EfficientDataAccess.of(dataFile, ScanDataType.CENTROID,
+        scanSelection);
 
     while (scanData.hasNextScan()) {
       if (isCanceled()) {
         return;
       }
 
-      Scan scan = null;
+      Scan scan;
       try {
         scan = scanData.nextScan();
       } catch (MissingMassListException e) {
         setStatus(TaskStatus.ERROR);
-        setErrorMessage("Scan #" + scanData.getCurrentScan().getScanNumber() + " from " + dataFile.getName()
-                        + " does not have a mass list. Pleas run \"Raw data methods\" -> \"Mass detection\".");
+        setErrorMessage(
+            "Scan #" + scanData.getCurrentScan().getScanNumber() + " from " + dataFile.getName()
+            + " does not have a mass list. Pleas run \"Raw data methods\" -> \"Mass detection\".");
         e.printStackTrace();
         return;
       }
 
       int dps = scanData.getNumberOfDataPoints();
       for (int i = 0; i < dps; i++) {
-        ExpandedDataPoint curDatP = new ExpandedDataPoint(scanData.getMzValue(i),
-            scanData.getIntensityValue(i), scan);
+        ExpandedDataPoint curDatP = new ExpandedDataPoint(scanData.getMzValue(i), scanData.getIntensityValue(i), scan);
         allMzValues.add(curDatP);
       }
     }
@@ -236,17 +212,7 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
     // sort data points by intensity
     allMzValues.sort(new DataPointSorter(SortingProperty.Intensity, SortingDirection.Descending));
 
-    // Set<Chromatogram> buildingChromatograms;
-    // buildingChromatograms = new LinkedHashSet<Chromatogram>();
-
-    double maxIntensity = allMzValues.get(0).getIntensity();
-
     // count starts at 1 since we already have added one with a single point.
-
-    // Stopwatch stopwatch = Stopwatch.createUnstarted();
-    // stopwatch2 = Stopwatch.createUnstarted();
-    // Stopwatch stopwatch3 = Stopwatch.createUnstarted();
-
     progress = 0.0;
     double progressStep = (allMzValues.size() > 0) ? 0.5 / allMzValues.size() : 0.0;
 
@@ -258,130 +224,55 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
         return;
       }
 
-      if (mzFeature == null || Double.isNaN(mzFeature.getMZ()) || Double
-          .isNaN(mzFeature.getIntensity())) {
+      if (mzFeature == null || Double.isNaN(mzFeature.getMZ()) || Double.isNaN(
+          mzFeature.getIntensity())) {
         continue;
       }
 
-      //////////////////////////////////////////////////
-
-      Range<Double> containsPointRange = rangeSet.rangeContaining(mzFeature.getMZ());
-
-      Range<Double> toleranceRange = mzTolerance.getToleranceRange(mzFeature.getMZ());
-      if (containsPointRange == null) {
+      final Entry<Range<Double>, ADAPChromatogram> existing = rangeToChromMap2.getEntry(
+          mzFeature.getMZ());
+      if (existing != null) {
+        // add data point to chromatogram
+        existing.getValue().addMzFeature(mzFeature.getScan(), mzFeature);
+      } else {
         // skip it entierly if the intensity is not high enough
         if (mzFeature.getIntensity() < minIntensityForStartChrom) {
           continue;
         }
-        // look +- mz tolerance to see if ther is a range near by.
-        // If there is use the proper boundry of that range for the
-        // new range to insure than NON OF THE RANGES OVERLAP.
-        Range<Double> plusRange = rangeSet.rangeContaining(toleranceRange.upperEndpoint());
-        Range<Double> minusRange = rangeSet.rangeContaining(toleranceRange.lowerEndpoint());
-        Double toBeLowerBound;
-        Double toBeUpperBound;
-
-        double cur_max_testing_mz = mzFeature.getMZ();
-
-        // If both of the above ranges are null then we make the new range spaning the full
-        // mz tolerance range.
-        // If one or both are not null we need to properly modify the range of the new
-        // chromatogram so that none of the points are overlapping.
-        if ((plusRange == null) && (minusRange == null)) {
-          toBeLowerBound = toleranceRange.lowerEndpoint();
-          toBeUpperBound = toleranceRange.upperEndpoint();
-        } else if ((plusRange == null) && (minusRange != null)) {
-          // the upper end point of the minus range will be the lower
-          // range of the new one
-          toBeLowerBound = minusRange.upperEndpoint();
-          toBeUpperBound = toleranceRange.upperEndpoint();
-
-        } else if ((minusRange == null) && (plusRange != null)) {
-          toBeLowerBound = toleranceRange.lowerEndpoint();
-          toBeUpperBound = plusRange.lowerEndpoint();
-          // double tmp_this = plusRange.upperEndpoint();
-          // System.out.println("tmp_this");
-        } else if ((minusRange != null) && (plusRange != null)) {
-          toBeLowerBound = minusRange.upperEndpoint();
-          toBeUpperBound = plusRange.lowerEndpoint();
-        } else {
-          toBeLowerBound = 0.0;
-          toBeUpperBound = 0.0;
-        }
-
-        if (toBeLowerBound < toBeUpperBound) {
-          Range<Double> newRange = Range.open(toBeLowerBound, toBeUpperBound);
-          ADAPChromatogram newChrom = new ADAPChromatogram(dataFile, scans);
-
-          newChrom.addMzFeature(mzFeature.getScan(), mzFeature);
-
-          newChrom.setHighPointMZ(mzFeature.getMZ());
-
-          rangeToChromMap.put(newRange, newChrom);
-          // also need to put it in the set -> this is where the range can be efficiently found.
-
-          rangeSet.add(newRange);
-        } else if (toBeLowerBound.equals(toBeUpperBound) && plusRange != null) {
-          ADAPChromatogram curChrom = rangeToChromMap.get(plusRange);
-          curChrom.addMzFeature(mzFeature.getScan(), mzFeature);
-        } else {
-          throw new IllegalStateException(String.format("Incorrect range [%f, %f] for m/z %f",
-              toBeLowerBound, toBeUpperBound, mzFeature.getMZ()));
-        }
-
-      } else {
-        // In this case we do not need to update the rangeSet
-
-        ADAPChromatogram curChrom = rangeToChromMap.get(containsPointRange);
-
-        curChrom.addMzFeature(mzFeature.getScan(), mzFeature);
-
-        // update the entry in the map
-        rangeToChromMap.put(containsPointRange, curChrom);
+        // add a new chromatogram to the range map - limit ranges to avoid overlap
+        startNewChromatogramLimitMzRanges(rangeToChromMap2, mzFeature);
       }
     }
 
-    // System.out.println("search chroms (ms): " + stopwatch.elapsed(TimeUnit.MILLISECONDS));
-    // System.out.println("making new chrom (ms): " + stopwatch2.elapsed(TimeUnit.MILLISECONDS));
-
     // finish chromatograms
-    Set<Range<Double>> ranges = rangeSet.asRanges();
-    Iterator<Range<Double>> RangeIterator = ranges.iterator();
+    final Map<Range<Double>, ADAPChromatogram> finalRangeMap = rangeToChromMap2.asMapOfRanges();
 
-    List<ADAPChromatogram> buildingChromatograms = new ArrayList<ADAPChromatogram>();
+    List<ADAPChromatogram> buildingChromatograms = new ArrayList<>();
+    int numChromatograms = finalRangeMap.size();
+    progressStep = numChromatograms > 0 ? 0.5 / numChromatograms : 0.0;
 
-    progressStep = (ranges.size() > 0) ? 0.5 / ranges.size() : 0.0;
-    while (RangeIterator.hasNext()) {
+    for (var chromatogram : finalRangeMap.values()) {
       if (isCanceled()) {
         return;
       }
 
-      progress += progressStep;
-
-      Range<Double> curRangeKey = RangeIterator.next();
-
-      ADAPChromatogram chromatogram = rangeToChromMap.get(curRangeKey);
-
       chromatogram.finishChromatogram();
+      progress += progressStep;
 
       // And remove chromatograms who dont have a certian number of continous points above the
       // IntensityThresh2 level.
-      double numberOfContinuousPointsAboveNoise =
-          chromatogram.findNumberOfContinuousPointsAboveNoise(IntensityThresh2);
-      if (numberOfContinuousPointsAboveNoise < minimumScanSpan) {
-        // System.out.println("skipping chromatogram because it does not meet the min point scan
-        // requirements");
-        continue;
-      } else {
+      double numberOfContinuousPointsAboveNoise = chromatogram.findNumberOfContinuousPointsAboveNoise(
+          IntensityThresh2);
+      if (numberOfContinuousPointsAboveNoise >= minimumScanSpan) {
+        // add zeros to edges
+        chromatogram.addNZeros(1, 1);
         buildingChromatograms.add(chromatogram);
       }
-
     }
 
-    buildingChromatograms.forEach(c -> c.addNZeros(1, 1));
     // Sort the final chromatograms by m/z
-    buildingChromatograms
-        .sort(new ADAPChromatogramSorter(SortingProperty.MZ, SortingDirection.Ascending));
+    buildingChromatograms.sort(
+        new ADAPChromatogramSorter(SortingProperty.MZ, SortingDirection.Ascending));
 
     // Create new feature list
     newFeatureList = new ModularFeatureList(dataFile + " " + suffix, getMemoryMapStorage(),
@@ -393,8 +284,8 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
     for (ADAPChromatogram finishedFeature : buildingChromatograms) {
       finishedFeature.setFeatureList(newFeatureList);
       ModularFeature modular = FeatureConvertors.ADAPChromatogramToModularFeature(finishedFeature);
-      ModularFeatureListRow newRow =
-          new ModularFeatureListRow(newFeatureList, newFeatureID, modular);
+      ModularFeatureListRow newRow = new ModularFeatureListRow(newFeatureList, newFeatureID,
+          modular);
       newFeatureList.addRow(newRow);
       // activate shape for this row
       newRow.set(FeatureShapeType.class, true);
@@ -415,6 +306,53 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
     setStatus(TaskStatus.FINISHED);
 
     logger.info(() -> "Finished chromatogram builder on " + dataFile);
+  }
+
+  /**
+   * Starts a new chromatogram and limits its range so that it does not overlap with existing m/z
+   * ranges
+   *
+   * @param rangeToChromMap started chromatograms with their non overlapping m/z range
+   * @param mzFeature       current tested data point
+   */
+  @SuppressWarnings("UnstableApiUsage")
+  private void startNewChromatogramLimitMzRanges(RangeMap<Double, ADAPChromatogram> rangeToChromMap,
+      ExpandedDataPoint mzFeature) {
+    // start new chromatogram and create new range (subract overlapping existing ranges)
+    Range<Double> toleranceRange = mzTolerance.getToleranceRange(mzFeature.getMZ());
+
+    // look +- mz tolerance to see if ther is a range near by.
+    // If there is use the proper boundry of that range for the
+    // new range to insure than NON OF THE RANGES OVERLAP.
+    final Entry<Range<Double>, ADAPChromatogram> minusRange = rangeToChromMap.getEntry(
+        toleranceRange.lowerEndpoint());
+    final Entry<Range<Double>, ADAPChromatogram> plusRange = rangeToChromMap.getEntry(
+        toleranceRange.upperEndpoint());
+
+    // If both of the above ranges are null then we make the new range spaning the full
+    // mz tolerance range.
+    // If one or both are not null we need to properly modify the range of the new
+    // chromatogram so that none of the points are overlapping.
+    Double toBeLowerBound =
+        minusRange == null ? toleranceRange.lowerEndpoint() : minusRange.getKey().upperEndpoint();
+    Double toBeUpperBound =
+        plusRange == null ? toleranceRange.upperEndpoint() : plusRange.getKey().lowerEndpoint();
+
+    if (toBeLowerBound < toBeUpperBound) {
+      // use closed open so that every value may be captured by rangeMap
+      Range<Double> newRange = Range.closedOpen(toBeLowerBound, toBeUpperBound);
+      ADAPChromatogram newChrom = new ADAPChromatogram(dataFile, scans);
+      newChrom.addMzFeature(mzFeature.getScan(), mzFeature);
+      newChrom.setHighPointMZ(mzFeature.getMZ());
+
+      rangeToChromMap.put(newRange, newChrom);
+    } else if (toBeLowerBound.equals(toBeUpperBound) && plusRange != null) {
+      plusRange.getValue().addMzFeature(mzFeature.getScan(), mzFeature);
+    } else {
+      throw new IllegalStateException(
+          String.format("Incorrect range [%f, %f] for m/z %f", toBeLowerBound, toBeUpperBound,
+              mzFeature.getMZ()));
+    }
   }
 
 }


### PR DESCRIPTION
Chromatogram builder was using RangeSet<Double> and a HashMap<Range, Chromatogram>
I changed to single local RangeMap<Double, Chromatogram> and also cleaned up code.

No idea how to really check the maximum memory consumption or the total produced garbage.... But to me it definitely makes sense to use RangeMap instead of two separate classes.


### New RangeMap
![image](https://user-images.githubusercontent.com/10366914/148674561-102e91b1-a5b4-4252-90fa-041d6cba9450.png)

### Old RangeSet + Map<>
![image](https://user-images.githubusercontent.com/10366914/148674786-6a675899-a042-46b3-9429-06c87364c10a.png)
