### PR TITLE
set values for RowsFilter step in wizard

### DIFF
--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_rowsfilter/RowsFilterParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_rowsfilter/RowsFilterParameters.java
@@ -98,7 +98,7 @@ public class RowsFilterParameters extends SimpleParameterSet {
 
   public static final ComboParameter<String> REMOVE_ROW = new ComboParameter<String>(
       "Keep or remove rows", "If selected, rows will be removed based on criteria instead of kept",
-      removeRowChoices);
+      removeRowChoices, removeRowChoices[0]);
 
 
   public static final OriginalFeatureListHandlingParameter handleOriginal = new OriginalFeatureListHandlingParameter(

--- a/src/main/java/io/github/mzmine/modules/tools/batchwizard/BatchWizardController.java
+++ b/src/main/java/io/github/mzmine/modules/tools/batchwizard/BatchWizardController.java
@@ -302,21 +302,34 @@ public class BatchWizardController {
       ParameterSet hplcParameters) {
     final int minSamples = hplcParameters.getValue(BatchWizardHPLCParameters.minNumberOfSamples);
 
-    // need to create new because we do not want to set all parameters here - go with defaults
-    final ParameterSet param = new RowsFilterParameters().cloneParameterSet();
+    final ParameterSet param = MZmineCore.getConfiguration()
+        .getModuleParameters(RowsFilterModule.class).cloneParameterSet();
     param.setParameter(RowsFilterParameters.FEATURE_LISTS,
         new FeatureListsSelection(FeatureListsSelectionType.BATCH_LAST_FEATURELISTS));
+    param.setParameter(RowsFilterParameters.SUFFIX,
+        "2iso" + (minSamples > 1 ? " " + minSamples + "peak" : ""));
     param.setParameter(RowsFilterParameters.MIN_FEATURE_COUNT, minSamples > 1);
     param.getParameter(RowsFilterParameters.MIN_FEATURE_COUNT).getEmbeddedParameter()
         .setValue((double) minSamples);
     param.setParameter(RowsFilterParameters.MIN_ISOTOPE_PATTERN_COUNT, true);
     param.getParameter(RowsFilterParameters.MIN_ISOTOPE_PATTERN_COUNT).getEmbeddedParameter()
         .setValue(2);
+    param.setParameter(RowsFilterParameters.MZ_RANGE, false);
+    param.setParameter(RowsFilterParameters.RT_RANGE, false);
+    param.setParameter(RowsFilterParameters.FEATURE_DURATION, false);
+    param.setParameter(RowsFilterParameters.FWHM, false);
+    param.setParameter(RowsFilterParameters.CHARGE, false);
+    param.setParameter(RowsFilterParameters.KENDRICK_MASS_DEFECT, false);
+    param.setParameter(RowsFilterParameters.GROUPSPARAMETER, RowsFilterParameters.defaultGrouping);
+    param.setParameter(RowsFilterParameters.HAS_IDENTITIES, false);
+    param.setParameter(RowsFilterParameters.IDENTITY_TEXT, false);
+    param.setParameter(RowsFilterParameters.COMMENT_TEXT, false);
+    param.setParameter(RowsFilterParameters.REMOVE_ROW, RowsFilterParameters.removeRowChoices[0]);
+    param.setParameter(RowsFilterParameters.MS2_Filter, false);
+    param.setParameter(RowsFilterParameters.Reset_ID, false);
+    param.setParameter(RowsFilterParameters.massDefect, false);
     param.setParameter(RowsFilterParameters.handleOriginal,
         hplcParameters.getValue(BatchWizardHPLCParameters.handleOriginalFeatureLists));
-    param.setParameter(RowsFilterParameters.MS2_Filter, false);
-    param.setParameter(RowsFilterParameters.SUFFIX,
-        "2iso" + (minSamples > 1 ? " " + minSamples + "peak" : ""));
 
     return new MZmineProcessingStepImpl<>(MZmineCore.getModuleInstance(RowsFilterModule.class),
         param);

--- a/src/main/java/io/github/mzmine/parameters/ParameterSet.java
+++ b/src/main/java/io/github/mzmine/parameters/ParameterSet.java
@@ -18,6 +18,7 @@
 package io.github.mzmine.parameters;
 
 import io.github.mzmine.parameters.impl.IonMobilitySupport;
+import io.github.mzmine.parameters.parametertypes.OptionalParameter;
 import io.github.mzmine.util.ExitCode;
 import java.util.Collection;
 import javafx.beans.property.BooleanProperty;
@@ -81,10 +82,16 @@ public interface ParameterSet extends ParameterContainer {
     getParameter(parameter).setValue(value);
   }
 
+  default <V, T extends UserParameter<V, ?>> void setParameter(OptionalParameter<T> optParam,
+      boolean enabled, V value) {
+    optParam.setValue(enabled);
+    optParam.getEmbeddedParameter().setValue(value);
+  }
+
   /**
-   * Returns BooleanProperty which value is changed when some parameter of this ParameterSet is changed.
-   * It is useful to perform operations directly dependant on the components corresponding to this
-   * ParameterSet (e.g. TextField of a parameter is changed -> preview plot is updated).
+   * Returns BooleanProperty which value is changed when some parameter of this ParameterSet is
+   * changed. It is useful to perform operations directly dependant on the components corresponding
+   * to this ParameterSet (e.g. TextField of a parameter is changed -> preview plot is updated).
    *
    * @return BooleanProperty signalizing a change of any parameter of this ParameterSet
    */

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/BooleanParameter.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/BooleanParameter.java
@@ -18,10 +18,10 @@
 
 package io.github.mzmine.parameters.parametertypes;
 
-import java.util.Collection;
-import org.w3c.dom.Element;
 import io.github.mzmine.parameters.UserParameter;
+import java.util.Collection;
 import javafx.scene.control.CheckBox;
+import org.w3c.dom.Element;
 
 /**
  * Simple Parameter implementation
@@ -34,10 +34,10 @@ public class BooleanParameter implements UserParameter<Boolean, CheckBox> {
   private Boolean value;
 
   public BooleanParameter(String name, String description) {
-    this(name, description, null);
+    this(name, description, false);
   }
 
-  public BooleanParameter(String name, String description, Boolean defaultValue) {
+  public BooleanParameter(String name, String description, boolean defaultValue) {
     this.name = name;
     this.description = description;
     this.value = defaultValue;


### PR DESCRIPTION
- several NPE in the parameter set of the rows filter step from the batch wizard, because the "default" values were not set. 

- set default value = false for BooleanParameter
- add 
``` 
default <V, T extends UserParameter<V, ?>> void setParameter(OptionalParameter<T> optParam,
      boolean enabled, V value)
```
to ParameterSet for more convenient setting of optional parameters