### PR TITLE
update gradle, enforce fixed log4j

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -180,6 +180,17 @@ dependencies {
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitversion"
     testImplementation "org.mockito:mockito-inline:$mockitoversion"
     testImplementation "org.mockito:mockito-junit-jupiter:$mockitoversion"
+
+//    https://blog.gradle.org/log4j-vulnerability
+    constraints {
+        implementation("org.apache.logging.log4j:log4j-core") {
+            version {
+                strictly("[2.17, 3[")
+                prefer("2.17.0")
+            }
+            because("CVE-2021-44228, CVE-2021-45046, CVE-2021-45105: Log4j vulnerable to remote code execution and other critical security vulnerabilities")
+        }
+    }
 }
 
 /*

--- a/build.gradle
+++ b/build.gradle
@@ -186,7 +186,7 @@ dependencies {
         implementation("org.apache.logging.log4j:log4j-core") {
             version {
                 strictly("[2.17, 3[")
-                prefer("2.17.0")
+                prefer("2.17.1")
             }
             because("CVE-2021-44228, CVE-2021-45046, CVE-2021-45105: Log4j vulnerable to remote code execution and other critical security vulnerabilities")
         }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 


### PR DESCRIPTION
Enforces updated and fixed version of log4j in our code and it's dependencies.
https://blog.gradle.org/log4j-vulnerability