### PR TITLE
Filter 13C isotopes

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/MassSpectrum.java
+++ b/src/main/java/io/github/mzmine/datamodel/MassSpectrum.java
@@ -19,6 +19,8 @@
 package io.github.mzmine.datamodel;
 
 import com.google.common.collect.Range;
+import io.github.mzmine.util.ArrayUtils;
+import java.util.Arrays;
 import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -69,14 +71,12 @@ public interface MassSpectrum extends Iterable<DataPoint> {
   double[] getIntensityValues(@NotNull double[] dst);
 
   /**
-   *
    * @param index The data point index.
    * @return The m/z at the given index.
    */
   double getMzValue(int index);
 
   /**
-   *
    * @param index The data point index.
    * @return The intensity at the given index.
    */
@@ -86,34 +86,129 @@ public interface MassSpectrum extends Iterable<DataPoint> {
    * @return The m/z value of the highest data point of this spectrum or null if the spectrum has 0
    * data points.
    */
-  @Nullable
-  Double getBasePeakMz();
+  @Nullable Double getBasePeakMz();
 
   /**
    * @return The intensity value of the highest data point of this spectrum or null if the spectrum
    * has 0 data points.
    */
-  @Nullable
-  Double getBasePeakIntensity();
+  @Nullable Double getBasePeakIntensity();
 
   /**
    * @return The index of the top intensity data point or null if the spectrum has 0 data points.
    */
-  @Nullable
-  Integer getBasePeakIndex();
+  @Nullable Integer getBasePeakIndex();
 
   /**
    * @return The m/z range of this spectrum or null if the spectrum has 0 data points.
    */
-  @Nullable
-  Range<Double> getDataPointMZRange();
+  @Nullable Range<Double> getDataPointMZRange();
 
   /**
    * @return The sum of intensities of all data points or null if the spectrum has 0 data points.
    */
-  @Nullable
-  Double getTIC();
+  @Nullable Double getTIC();
 
+
+  /**
+   * Searches for the given mz value - or the closest available signal in this spectrum. Copied from
+   * {@link Arrays#binarySearch(double[], double)}
+   *
+   * @param mz                 search for this mz value
+   * @param defaultToClosestMz return the closest mz value
+   * @return this index of the given mz value or the closest available mz if checked. index of the
+   * search key, if it is contained in the array; otherwise, (-(insertion point) - 1). The insertion
+   * point is defined as the point at which the key would be inserted into the array: the index of
+   * the first element greater than the key, or a.length if all elements in the array are less than
+   * the specified key. Note that this guarantees that the return value will be >= 0 if and only if
+   * the key is found.
+   */
+  default int binarySearch(double mz, boolean defaultToClosestMz) {
+    return binarySearch(mz, defaultToClosestMz, 0, getNumberOfDataPoints());
+  }
+
+  /**
+   * Searches for the given mz value - or the closest available signal in this spectrum. Copied from
+   * {@link Arrays#binarySearch(double[], double)}
+   *
+   * @param mz                 search for this mz value
+   * @param defaultToClosestMz return the closest mz value
+   * @param fromIndex          inclusive lower end
+   * @param toIndex            exclusive upper end
+   * @return this index of the given mz value or the closest available mz if checked. index of the
+   * search key, if it is contained in the array; otherwise, (-(insertion point) - 1). The insertion
+   * point is defined as the point at which the key would be inserted into the array: the index of
+   * the first element greater than the key, or a.length if all elements in the array are less than
+   * the specified key. Note that this guarantees that the return value will be >= 0 if and only if
+   * the key is found.
+   */
+  default int binarySearch(double mz, boolean defaultToClosestMz, int fromIndex, int toIndex) {
+    if (toIndex == 0) {
+      return -1;
+    }
+    final int numberOfDataPoints = getNumberOfDataPoints();
+    ArrayUtils.rangeCheck(numberOfDataPoints, fromIndex, toIndex);
+
+    int low = fromIndex;
+    int high = toIndex - 1;
+
+    while (low <= high) {
+      int mid = (low + high) >>> 1; // bit shift by 1 for sum of positive integers = / 2
+      double midMz = getMzValue(mid);
+
+      if (midMz < mz) {
+        low = mid + 1;  // Neither mz is NaN, thisVal is smaller
+      } else if (midMz > mz) {
+        high = mid - 1; // Neither mz is NaN, thisVal is larger
+      } else {
+        long midBits = Double.doubleToLongBits(midMz);
+        long keyBits = Double.doubleToLongBits(mz);
+        if (midBits == keyBits) {
+          return mid;  // Key found
+        } else if (midBits < keyBits) {
+          low = mid + 1;  // (-0.0, 0.0) or (!NaN, NaN)
+        } else {
+          high = mid - 1;  // (0.0, -0.0) or (NaN, !NaN)
+        }
+      }
+    }
+    if (defaultToClosestMz) {
+      if (low >= numberOfDataPoints) {
+        return numberOfDataPoints - 1;
+      }
+      // might be higher or lower
+      final double adjacentMZ = getMzValue(low);
+      // check for closest distance to mz
+      if (adjacentMZ <= mz && low + 1 < numberOfDataPoints) {
+        final double higherMZ = getMzValue(low + 1);
+        return (Math.abs(mz - adjacentMZ) <= Math.abs(higherMZ - mz)) ? low : low + 1;
+      } else if (adjacentMZ > mz && low - 1 >= 0) {
+        final double lowerMZ = getMzValue(low - 1);
+        return (Math.abs(mz - adjacentMZ) <= Math.abs(lowerMZ - mz)) ? low : low - 1;
+      } else {
+        // there was only one data point
+        return low;
+      }
+    }
+    return -(low + 1);  // key not found.
+  }
+
+  /**
+   * Searches for the given mz value - or the closest available signal in this spectrum. Copied from
+   * {@link Arrays#binarySearch(double[], double)}
+   *
+   * @param mz                 search for this mz value
+   * @param defaultToClosestMz return the closest mz value
+   * @return this index of the given mz value or the closest available mz if checked. index of the
+   * search key, if it is contained in the array; otherwise, (-(insertion point) - 1). The insertion
+   * point is defined as the point at which the key would be inserted into the array: the index of
+   * the first element greater than the key, or a.length if all elements in the array are less than
+   * the specified key. Note that this guarantees that the return value will be >= 0 if and only if
+   * the key is found.
+   */
+  default int indexOf(double mz, boolean defaultToClosestMz) {
+    return binarySearch(mz, defaultToClosestMz);
+  }
 
   /**
    * Creates a stream of DataPoints to iterate over this array. To avoid consuming memory for each

--- a/src/main/java/io/github/mzmine/datamodel/features/types/annotations/SpectralLibraryMatchesType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/annotations/SpectralLibraryMatchesType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2020 The MZmine Development Team
+ * Copyright 2006-2021 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -8,11 +8,12 @@
  * License, or (at your option) any later version.
  *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
- * Public License for more details.
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
  */
 
 package io.github.mzmine.datamodel.features.types.annotations;
@@ -71,12 +72,11 @@ public class SpectralLibraryMatchesType extends
           createEntry(CosineScoreType.class, match -> (float) match.getSimilarity().getScore()),
           createEntry(MatchingSignalsType.class, match -> match.getSimilarity().getOverlap()),
           createEntry(PrecursorMZType.class,
-              match -> (double) match.getEntry().getField(DBEntryField.MZ).orElse(null)),
+              match -> match.getEntry().getField(DBEntryField.MZ).orElse(null)),
           createEntry(NeutralMassType.class,
-              match -> (double) match.getEntry().getField(DBEntryField.EXACT_MASS).orElse(null)),
+              match -> match.getEntry().getField(DBEntryField.EXACT_MASS).orElse(null)),
           createEntry(CCSType.class, match -> match.getEntry().getOrElse(DBEntryField.CCS, null)),
-          createEntry(CCSRelativeErrorType.class, SpectralDBFeatureIdentity::getCCSError)
-      );
+          createEntry(CCSRelativeErrorType.class, SpectralDBFeatureIdentity::getCCSError));
   // Unmodifiable list of all subtypes
   private static final List<DataType> subTypes = List.of(new SpectralLibraryMatchesType(),
       new CompoundNameType(), new IonAdductType(),

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_rowsfilter/Isotope13CFilter.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_rowsfilter/Isotope13CFilter.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2006-2021 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+package io.github.mzmine.modules.dataprocessing.filter_rowsfilter;
+
+import io.github.mzmine.datamodel.IsotopePattern;
+import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
+import io.github.mzmine.util.Isotope;
+import io.github.mzmine.util.IsotopePatternUtils;
+import io.github.mzmine.util.IsotopesUtils;
+import java.util.ArrayList;
+import java.util.List;
+import org.openscience.cdk.Element;
+
+/**
+ * @author Robin Schmid (https://github.com/robinschmid)
+ */
+public class Isotope13CFilter {
+
+  private final MZTolerance mzTolerance;
+  private final int maxCharge;
+  private final boolean filter13Isotope;
+  private final Isotope[] excludedIsotopes;
+
+  public Isotope13CFilter(MZTolerance mzTolerance, int maxCharge, boolean filter13Isotope,
+      List<Element> elements) {
+    this.mzTolerance = mzTolerance;
+    this.maxCharge = maxCharge;
+    this.filter13Isotope = filter13Isotope;
+
+    if (elements != null && !elements.isEmpty()) {
+      List<Isotope> isotopes = new ArrayList<>();
+      for (Element element : elements) {
+        isotopes.addAll(IsotopesUtils.getIsotopeRecord(element.getSymbol()));
+      }
+      excludedIsotopes = isotopes.toArray(new Isotope[0]);
+    } else {
+      excludedIsotopes = null;
+    }
+  }
+
+  /**
+   * Check if main m/z has a 13C isotope signal. If set filter13CIsotope is set, the signal must not
+   * be preceded by another 13C isotope signal.
+   *
+   * @param pattern search in this pattern
+   * @param mainMZ  check this mz for 13C isotope signals
+   * @return true if mainMZ has a 13C isotope signal and is itself not a 13C or other isotope signal
+   * of preceding signals.
+   */
+  public boolean accept(IsotopePattern pattern, double mainMZ) {
+    return IsotopePatternUtils.check13CPattern(pattern, mainMZ, mzTolerance, maxCharge,
+        filter13Isotope, excludedIsotopes);
+  }
+}

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_rowsfilter/Isotope13CFilter.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_rowsfilter/Isotope13CFilter.java
@@ -35,13 +35,15 @@ public class Isotope13CFilter {
   private final MZTolerance mzTolerance;
   private final int maxCharge;
   private final boolean filter13Isotope;
+  private final boolean applyMinCEstimation;
   private final Isotope[] excludedIsotopes;
 
   public Isotope13CFilter(MZTolerance mzTolerance, int maxCharge, boolean filter13Isotope,
-      List<Element> elements) {
+      List<Element> elements, boolean applyMinCEstimation) {
     this.mzTolerance = mzTolerance;
     this.maxCharge = maxCharge;
     this.filter13Isotope = filter13Isotope;
+    this.applyMinCEstimation = applyMinCEstimation;
 
     if (elements != null && !elements.isEmpty()) {
       List<Isotope> isotopes = new ArrayList<>();
@@ -65,6 +67,6 @@ public class Isotope13CFilter {
    */
   public boolean accept(IsotopePattern pattern, double mainMZ) {
     return IsotopePatternUtils.check13CPattern(pattern, mainMZ, mzTolerance, maxCharge,
-        filter13Isotope, excludedIsotopes);
+        filter13Isotope, excludedIsotopes, applyMinCEstimation);
   }
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_rowsfilter/Isotope13CFilterParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_rowsfilter/Isotope13CFilterParameters.java
@@ -38,12 +38,18 @@ public class Isotope13CFilterParameters extends SimpleParameterSet {
   public static final IntegerParameter maxCharge = new IntegerParameter("Max charge",
       "Maximum allowed charge state", 1);
   public static final BooleanParameter removeIfMainIs13CIsotope = new BooleanParameter(
-      "Remove 13C isotopes",
+      "Remove if 13C",
       "Checks if the main m/z (row) is a 13C isotope of a preceding signal. Default: true", true);
+  public static final BooleanParameter applyMinCEstimation = new BooleanParameter(
+      "Estimate minimum carbon",
+      "Estimates the minimum number of carbons based on m/z and mass defect. Uses estimates derived from the COCONUT database. Default: true",
+      true);
+
   private static final Logger logger = Logger.getLogger(Isotope13CFilterParameters.class.getName());
 
   public Isotope13CFilterParameters() {
-    super(new Parameter[]{mzTolerance, maxCharge, removeIfMainIs13CIsotope, elements});
+    super(new Parameter[]{mzTolerance, maxCharge, applyMinCEstimation, removeIfMainIs13CIsotope,
+        elements});
   }
 
   /**
@@ -56,7 +62,8 @@ public class Isotope13CFilterParameters extends SimpleParameterSet {
   public static Isotope13CFilter createFilter(ParameterSet parameters) {
     try {
       return new Isotope13CFilter(parameters.getValue(mzTolerance), parameters.getValue(maxCharge),
-          parameters.getValue(removeIfMainIs13CIsotope), parameters.getValue(elements));
+          parameters.getValue(removeIfMainIs13CIsotope), parameters.getValue(elements),
+          parameters.getValue((applyMinCEstimation)));
     } catch (Exception ex) {
       logger.log(Level.WARNING, "Cannot create filter. " + ex.getMessage(), ex);
       return null;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_rowsfilter/Isotope13CFilterParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_rowsfilter/Isotope13CFilterParameters.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2006-2021 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+package io.github.mzmine.modules.dataprocessing.filter_rowsfilter;
+
+import io.github.mzmine.parameters.Parameter;
+import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.parameters.impl.SimpleParameterSet;
+import io.github.mzmine.parameters.parametertypes.BooleanParameter;
+import io.github.mzmine.parameters.parametertypes.IntegerParameter;
+import io.github.mzmine.parameters.parametertypes.elements.ElementsParameter;
+import io.github.mzmine.parameters.parametertypes.tolerances.MZToleranceParameter;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.jetbrains.annotations.Nullable;
+
+public class Isotope13CFilterParameters extends SimpleParameterSet {
+
+  public static final ElementsParameter elements = new ElementsParameter("Exclude isotopes",
+      "Similar to remove 13C isotopes, this parameter allows to exclude main signals (rows) "
+      + "that are flagged as isotopes of this element, by searching for preceding signals.");
+  public static final MZToleranceParameter mzTolerance = new MZToleranceParameter(0.0005, 10);
+  public static final IntegerParameter maxCharge = new IntegerParameter("Max charge",
+      "Maximum allowed charge state", 1);
+  public static final BooleanParameter removeIfMainIs13CIsotope = new BooleanParameter(
+      "Remove 13C isotopes",
+      "Checks if the main m/z (row) is a 13C isotope of a preceding signal. Default: true", true);
+  private static final Logger logger = Logger.getLogger(Isotope13CFilterParameters.class.getName());
+
+  public Isotope13CFilterParameters() {
+    super(new Parameter[]{mzTolerance, maxCharge, removeIfMainIs13CIsotope, elements});
+  }
+
+  /**
+   * Creates a filter instance to validate 13C isotope pattern
+   *
+   * @param parameters instance of this parameter class
+   * @return a filter or null
+   */
+  @Nullable
+  public static Isotope13CFilter createFilter(ParameterSet parameters) {
+    try {
+      return new Isotope13CFilter(parameters.getValue(mzTolerance), parameters.getValue(maxCharge),
+          parameters.getValue(removeIfMainIs13CIsotope), parameters.getValue(elements));
+    } catch (Exception ex) {
+      logger.log(Level.WARNING, "Cannot create filter. " + ex.getMessage(), ex);
+      return null;
+    }
+  }
+
+  /**
+   * Creates a filter instance to validate 13C isotope pattern
+   *
+   * @return a filter or null
+   */
+  public Isotope13CFilter createFilter() {
+    return createFilter(this);
+  }
+}

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_rowsfilter/RowsFilterParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_rowsfilter/RowsFilterParameters.java
@@ -60,6 +60,13 @@ public class RowsFilterParameters extends SimpleParameterSet {
       new IntegerParameter("Minimum features in an isotope pattern",
           "Minimum number of features required in an isotope pattern"));
 
+  public static final OptionalModuleParameter<Isotope13CFilterParameters> ISOTOPE_FILTER_13C = new OptionalModuleParameter<>(
+      "Validate 13C isotope pattern",
+      "Searches for an +1 13C signal (considering possible charge states) \n"
+      + "within estimated range of carbon atoms. Optionally: Detect and filter rows \n"
+      + "that are 13C isotopes by searching for preceding -1 signal.",
+      new Isotope13CFilterParameters(), false);
+
   public static final OptionalParameter<MZRangeParameter> MZ_RANGE = new OptionalParameter<>(
       new MZRangeParameter());
 
@@ -104,8 +111,7 @@ public class RowsFilterParameters extends SimpleParameterSet {
   public static final OriginalFeatureListHandlingParameter handleOriginal = new OriginalFeatureListHandlingParameter(
       true);
 
-  public static final BooleanParameter MS2_Filter = new BooleanParameter(
-      "Feature with MS2 scan",
+  public static final BooleanParameter MS2_Filter = new BooleanParameter("Feature with MS2 scan",
       "If checked, the rows that don't contain MS2 scan will be removed.");
   public static final BooleanParameter Reset_ID = new BooleanParameter(
       "Reset the feature number ID",
@@ -119,9 +125,9 @@ public class RowsFilterParameters extends SimpleParameterSet {
 
   public RowsFilterParameters() {
     super(new Parameter[]{FEATURE_LISTS, SUFFIX, MIN_FEATURE_COUNT, MIN_ISOTOPE_PATTERN_COUNT,
-        MZ_RANGE, RT_RANGE, FEATURE_DURATION, FWHM, CHARGE, KENDRICK_MASS_DEFECT, GROUPSPARAMETER,
-        HAS_IDENTITIES, IDENTITY_TEXT, COMMENT_TEXT, REMOVE_ROW, MS2_Filter, Reset_ID, massDefect,
-        handleOriginal});
+        ISOTOPE_FILTER_13C, MZ_RANGE, RT_RANGE, FEATURE_DURATION, FWHM, CHARGE,
+        KENDRICK_MASS_DEFECT, GROUPSPARAMETER, HAS_IDENTITIES, IDENTITY_TEXT, COMMENT_TEXT,
+        REMOVE_ROW, MS2_Filter, Reset_ID, massDefect, handleOriginal});
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/tolerances/PercentTolerance.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/tolerances/PercentTolerance.java
@@ -1,19 +1,19 @@
 /*
- *  Copyright 2006-2020 The MZmine Development Team
+ * Copyright 2006-2021 The MZmine Development Team
  *
- *  This file is part of MZmine.
+ * This file is part of MZmine.
  *
- *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
- *  General Public License as published by the Free Software Foundation; either version 2 of the
- *  License, or (at your option) any later version.
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
  *
- *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
- *  Public License for more details.
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License along with MZmine; if not,
- *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
- *  USA
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
  */
 
 package io.github.mzmine.parameters.parametertypes.tolerances;
@@ -38,6 +38,64 @@ public class PercentTolerance {
     tolerance = percentTolerance;
   }
 
+  /**
+   * @return The error in per cent. 10 % = 0.1
+   */
+  public static double getPercentError(int base, int value) {
+    return Math.abs(value - base) / (double) base;
+  }
+
+  /**
+   * @return The error in per cent. 10 % = 0.1
+   */
+  public static double getPercentError(long base, long value) {
+    return Math.abs(value - base) / (double) base;
+  }
+
+  /**
+   * @return The error in per cent. 10 % = 0.1
+   */
+  public static float getPercentError(float base, float value) {
+    return Math.abs(value - base) / base;
+  }
+
+  /**
+   * @return The error in per cent. 10 % = 0.1
+   */
+  public static double getPercentError(double base, double value) {
+    return Math.abs(value - base) / base;
+  }
+
+  /**
+   * @return The error in per cent. 10 % = 0.1
+   */
+  public static Float getPercentError(@Nullable Float base, @Nullable Float value) {
+    if (base == null || value == null) {
+      return null;
+    }
+    return Math.abs(value - base) / base;
+  }
+
+  /**
+   * @return The error in per cent. 10 % = 0.1
+   */
+  public static Double getPercentError(@Nullable Double base, @Nullable Double value) {
+    if (base == null || value == null) {
+      return null;
+    }
+    return Math.abs(value - base) / base;
+  }
+
+  /**
+   * @return The error in per cent. 10 % = 0.1
+   */
+  public static Double getPercentError(@Nullable Integer base, @Nullable Integer value) {
+    if (base == null || value == null) {
+      return null;
+    }
+    return Math.abs(value - base) / (double) base;
+  }
+
   public boolean matches(int base, int value) {
     return Double.compare(getPercentError(base, value), tolerance) <= 0;
   }
@@ -53,39 +111,6 @@ public class PercentTolerance {
   public boolean matches(double base, double value) {
     return Double.compare(getPercentError(base, value), tolerance) <= 0;
   }
-
-  /**
-   *
-   * @return The error in per cent. 10 % = 0.1
-   */
-  public static double getPercentError(int base, int value) {
-    return Math.abs(value - base) / (double) base;
-  }
-
-  /**
-   *
-   * @return The error in per cent. 10 % = 0.1
-   */
-  public static double getPercentError(long base, long value) {
-    return Math.abs(value - base) / (double) base;
-  }
-
-  /**
-   *
-   * @return The error in per cent. 10 % = 0.1
-   */
-  public static double getPercentError(float base, float value) {
-    return Math.abs(value - base) / base;
-  }
-
-  /**
-   *
-   * @return The error in per cent. 10 % = 0.1
-   */
-  public static double getPercentError(double base, double value) {
-    return Math.abs(value - base) / base;
-  }
-
 
   /**
    * @param base  The base value of this range ("what it is supposed to be")

--- a/src/main/java/io/github/mzmine/util/ArrayUtils.java
+++ b/src/main/java/io/github/mzmine/util/ArrayUtils.java
@@ -22,10 +22,29 @@ import java.util.Arrays;
 
 public class ArrayUtils {
 
+  /**
+   * Throws out of range exceptions
+   *
+   * @param arrayLength
+   * @param fromIndex
+   * @param toIndex
+   */
+  public static void rangeCheck(int arrayLength, int fromIndex, int toIndex) {
+    if (fromIndex > toIndex) {
+      throw new IllegalArgumentException("fromIndex(" + fromIndex + ") > toIndex(" + toIndex + ")");
+    }
+    if (fromIndex < 0) {
+      throw new ArrayIndexOutOfBoundsException(fromIndex);
+    }
+    if (toIndex > arrayLength) {
+      throw new ArrayIndexOutOfBoundsException(toIndex);
+    }
+  }
+
   public static <T> int indexOf(T needle, T[] haystack) {
     for (int i = 0; i < haystack.length; i++) {
-      if ((haystack[i] != null && haystack[i].equals(needle))
-          || (needle == null && haystack[i] == null)) {
+      if ((haystack[i] != null && haystack[i].equals(needle)) || (needle == null
+                                                                  && haystack[i] == null)) {
         return i;
       }
     }

--- a/src/main/java/io/github/mzmine/util/IntRange.java
+++ b/src/main/java/io/github/mzmine/util/IntRange.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2006-2021 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+package io.github.mzmine.util;
+
+/**
+ * @author Robin Schmid (https://github.com/robinschmid)
+ */
+public record IntRange(int minInclusive, int maxExclusive) {
+
+  public static final IntRange EMPTY = new IntRange(-1, -1);
+
+  public boolean contains(int i) {
+    return i >= minInclusive && i < maxExclusive;
+  }
+
+  public int size() {
+    return maxExclusive - minInclusive;
+  }
+
+  public boolean isEmpty() {
+    return this == EMPTY || size() == 0;
+  }
+}

--- a/src/main/java/io/github/mzmine/util/Isotope.java
+++ b/src/main/java/io/github/mzmine/util/Isotope.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2006-2021 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+package io.github.mzmine.util;
+
+/**
+ * An isotope that stores the absolute delta mass to the most abundant natural isotope and the
+ * relative intensity as percentage of the most abundant
+ *
+ * @author Robin Schmid (https://github.com/robinschmid)
+ */
+public record Isotope(String atom, int atomNumber, double exactMass, double deltaMass,
+                      double relativeIntensity) {
+
+}

--- a/src/main/java/io/github/mzmine/util/IsotopePatternUtils.java
+++ b/src/main/java/io/github/mzmine/util/IsotopePatternUtils.java
@@ -18,16 +18,6 @@
 
 package io.github.mzmine.util;
 
-import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.logging.Logger;
-import java.util.regex.Pattern;
-import org.jetbrains.annotations.NotNull;
-import org.apache.commons.lang3.StringUtils;
-import org.openscience.cdk.interfaces.IIsotope;
 import com.google.common.collect.Range;
 import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.IsotopePattern;
@@ -42,25 +32,37 @@ import io.github.mzmine.modules.visualization.spectra.simplespectra.datapointpro
 import io.github.mzmine.modules.visualization.spectra.simplespectra.datapointprocessing.datamodel.results.DPPResult;
 import io.github.mzmine.modules.visualization.spectra.simplespectra.datapointprocessing.datamodel.results.DPPResult.ResultType;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.openscience.cdk.interfaces.IIsotope;
 
 /**
- *
  * @author SteffenHeu steffen.heuckeroth@gmx.de / s_heuc03@uni-muenster.de
- *
  */
 public class IsotopePatternUtils {
 
+  public static final double C13_MZ = 13.003355;
+  public static final double C13_MZ_DELTA = 1.003355;
+  public static final double C13_REL_ABUNDANCE = 0.0108;
   private static final Logger logger = Logger.getLogger(IsotopePatternUtils.class.getName());
-  private static final NumberFormat format = MZmineCore.getConfiguration().getMZFormat();;
+  private static final NumberFormat format = MZmineCore.getConfiguration().getMZFormat();
 
   /**
    * Finds data points with the best m/z differences (lowest) to a predicted isotope peak.
    *
-   * @param dp The base data point.
+   * @param dp                 The base data point.
    * @param originalDataPoints Array of all peaks in consideration
-   * @param i_dp the start index inside originalDataPoints to search for.
-   * @param mzTolerance m/z Tolerance range.
-   * @param isoMzDiff m/z difference added by an isotope peak.
+   * @param i_dp               the start index inside originalDataPoints to search for.
+   * @param mzTolerance        m/z Tolerance range.
+   * @param isoMzDiff          m/z difference added by an isotope peak.
    * @return
    */
   public static DataPoint findBestMZDiff(DataPoint dp, DataPoint[] originalDataPoints, int i_dp,
@@ -76,14 +78,16 @@ public class IsotopePatternUtils {
 
       // if the data point p is below the mz tolerance range, we go for
       // the next one.
-      if (p.getMZ() < mzTolerance.getToleranceRange(dp.getMZ() + isoMzDiff).lowerEndpoint())
+      if (p.getMZ() < mzTolerance.getToleranceRange(dp.getMZ() + isoMzDiff).lowerEndpoint()) {
         continue;
+      }
 
       // if the m/z of this data point (p) is bigger than the m/z of (dp +
       // pattern width +
       // merge) then we don't need to check anymore
-      if (p.getMZ() > mzTolerance.getToleranceRange(dp.getMZ() + isoMzDiff).upperEndpoint())
+      if (p.getMZ() > mzTolerance.getToleranceRange(dp.getMZ() + isoMzDiff).upperEndpoint()) {
         break;
+      }
 
       // now check the ppm difference and compare the mass differences
       double ppm = getPpmDiff(p.getMZ(), dp.getMZ() + isoMzDiff);
@@ -96,7 +100,7 @@ public class IsotopePatternUtils {
       }
 
     } // end of ascending datapoint mz loop
-      // now we checked all peaks upcoming peaks in the spectrum
+    // now we checked all peaks upcoming peaks in the spectrum
 
     return bestdp;
   }
@@ -105,11 +109,11 @@ public class IsotopePatternUtils {
    * Searches for an isotopic peaks (pattern) of the data point dp within an array of data points by
    * the elements m/z differences.
    *
-   * @param dp the base peak with lowest m/z.
+   * @param dp                 the base peak with lowest m/z.
    * @param originalDataPoints All the data points in consideration for isotope peaks.
-   * @param mzTolerance the m/z tolerance.
-   * @param pattern The isotope pattern of an element to search for.
-   * @param mzrange the range of m/z to search for isotope peaks.
+   * @param mzTolerance        the m/z tolerance.
+   * @param pattern            The isotope pattern of an element to search for.
+   * @param mzrange            the range of m/z to search for isotope peaks.
    * @return dp will be modified and given an DPPIsotopePatternResult.
    */
   public static ProcessedDataPoint findIsotopicPeaks(ProcessedDataPoint dp,
@@ -117,8 +121,9 @@ public class IsotopePatternUtils {
       SimpleIsotopePattern pattern, Range<Double> mzrange, int maxCharge) {
     // dp is the peak we are currently searching an isotope pattern for
 
-    if (maxCharge < 1 || !mzrange.contains(dp.getMZ()))
+    if (maxCharge < 1 || !mzrange.contains(dp.getMZ())) {
       return dp;
+    }
 
     int i_dp = ArrayUtils.indexOf(dp, originalDataPoints);
 
@@ -150,9 +155,11 @@ public class IsotopePatternUtils {
       // check if results are good, we must have found a peak for every
       // isotope of the current
       // element, else we have to discard the results
-      for (int isotopeindex = 0; isotopeindex < numIsotopes; isotopeindex++)
-        if (bestdp[isotopeindex] == null)
+      for (int isotopeindex = 0; isotopeindex < numIsotopes; isotopeindex++) {
+        if (bestdp[isotopeindex] == null) {
           return dp;
+        }
+      }
 
       // ok every peak has been found, now assign the pattern and link the
       // data points
@@ -160,10 +167,10 @@ public class IsotopePatternUtils {
       // of the elemental
       // composition later on
       for (int isotopeIndex = 1; isotopeIndex < numIsotopes; isotopeIndex++) { // TODO;
-                                                                               // changed
-                                                                               // to
-                                                                               // 1
-                                                                               // here
+        // changed
+        // to
+        // 1
+        // here
         ProcessedDataPoint p = bestdp[isotopeIndex];
         dp.addResult(
             new DPPIsotopicPeakResult(p, pattern.getIsotopeComposition(isotopeIndex), i_charge));
@@ -179,20 +186,20 @@ public class IsotopePatternUtils {
    * merged into the parent. This method recursively calls itself and will merge all results into
    * the parent peak. The results of the child peaks will be removed, the isotopic composition is
    * updated on every merge step, making it possible to be evaluated in later steps.
-   *
+   * <p>
    * Please note, that on bigger isotope patterns the parent might contain a peak twice. This has
    * the following reason (e.g.:) Let's assume an isotope pattern of C1 Cl1
-   *
+   * <p>
    * This isotope pattern will have the following compositions: A: 12C, 35Cl
-   *
+   * <p>
    * B: 13C, 35Cl
-   *
+   * <p>
    * C: 12C, 37Cl D: 13C, 37Cl
-   *
+   * <p>
    * When using the findIsotopicPeaks method, the following assignments will be made:
-   *
+   * <p>
    * A -> B (13C of A) A -> C (37Cl of A) B -> D (37Cl of B) C -> D (13C of C)
-   *
+   * <p>
    * As you can see, D has been assigned twice. This is correct behaviour of the method, but if the
    * convertIsotopicPeakResultsToPattern method was called now, it would contain peak D twice, even
    * though there was only one peak. Comparing isotope patterns now would lead to wrong results.
@@ -205,15 +212,17 @@ public class IsotopePatternUtils {
 
     List<DPPIsotopicPeakResult> iprs = getIsotopicPeakResults(parent);
 
-    if (iprs.isEmpty())
+    if (iprs.isEmpty()) {
       return;
+    }
 
     List<Integer> charges = getChargeStates(iprs);
 
     for (DPPIsotopicPeakResult ipr : iprs) {
       ProcessedDataPoint child = ipr.getValue();
-      if (child == parent)
+      if (child == parent) {
         continue;
+      }
 
       mergeIsotopicPeakResults(child);
 
@@ -236,7 +245,7 @@ public class IsotopePatternUtils {
    * Takes all DPPIsotopicPeakResults of one charge and puts them into one isotope pattern (per
    * charge).
    *
-   * @param dp A ProcessedDataPoint
+   * @param dp          A ProcessedDataPoint
    * @param keepResults if false, all DPPIsotopicPeakResults will be removed from this data point.
    */
   public static void convertIsotopicPeakResultsToPattern(ProcessedDataPoint dp,
@@ -244,8 +253,9 @@ public class IsotopePatternUtils {
     sortAndRemoveDuplicateIsotopicPeakResult(dp);
     List<DPPIsotopicPeakResult> iprs = getIsotopicPeakResults(dp);
 
-    if (iprs.isEmpty())
+    if (iprs.isEmpty()) {
       return;
+    }
 
     List<Integer> charges = getChargeStates(iprs);
     List<ProcessedDataPoint> peaks = new ArrayList<>();
@@ -272,8 +282,9 @@ public class IsotopePatternUtils {
       peaks.clear();
       isotopes.clear();
     }
-    if (!keepResults)
+    if (!keepResults) {
       dp.removeAllResultsByType(ResultType.ISOTOPICPEAK);
+    }
   }
 
   public static String makePatternSuggestion(String[] composition) {
@@ -308,8 +319,9 @@ public class IsotopePatternUtils {
     }
 
     String formula = "";
-    for (int i = 0; i < elements.length; i++)
+    for (int i = 0; i < elements.length; i++) {
       formula += elements[i] + elementCount[i];
+    }
 
     return formula;
   }
@@ -327,15 +339,17 @@ public class IsotopePatternUtils {
     String merged = "";
 
     String[] isotopes = descr.split(Pattern.quote("["));
-    for (String isotope : isotopes)
+    for (String isotope : isotopes) {
       set.add("[" + isotope);
+    }
     set.remove("[");
 
     for (String str : set) {
       String count = "";
       int c = StringUtils.countMatches(descr, str);
-      if (c > 1)
+      if (c > 1) {
         count = String.valueOf(c);
+      }
 
       merged += str + count;
     }
@@ -361,15 +375,18 @@ public class IsotopePatternUtils {
           String[] str = comp.split(Pattern.quote(isotopes[i]));
           if (str.length > 1 && !str[1].startsWith("[")) {
             int end = str[1].indexOf("[");
-            if (end < 0)
+            if (end < 0) {
               end = str[1].length();
+            }
             counts[i] = Integer.valueOf(str[1].substring(0, end));
-          } else
+          } else {
             counts[i] = 1;
+          }
         }
 
-        if (counts[i] > max[i])
+        if (counts[i] > max[i]) {
           max[i] = counts[i];
+        }
       }
     }
 
@@ -377,7 +394,6 @@ public class IsotopePatternUtils {
   }
 
   /**
-   *
    * @param comps Isotope composition of an isotope pattern in the format [13]C[37]Cl[13]C
    * @return Array of all occurring isotopes within comp
    */
@@ -393,12 +409,11 @@ public class IsotopePatternUtils {
       }
     }
     set.remove("["); // gets added by default due to split, removing should
-                     // be faster than a check
+    // be faster than a check
     return set.toArray(new String[0]);
   }
 
   /**
-   *
    * @param isotopes Array of strings, each String must contain one expression like [37]Cl
    * @return Array of only element strings, no duplicates
    */
@@ -452,8 +467,9 @@ public class IsotopePatternUtils {
     }
 
     dp.removeAllResultsByType(ResultType.ISOTOPICPEAK);
-    for (DPPIsotopicPeakResult r : results)
+    for (DPPIsotopicPeakResult r : results) {
       dp.addResult(r);
+    }
   }
 
   /**
@@ -466,13 +482,15 @@ public class IsotopePatternUtils {
       @NotNull ProcessedDataPoint dp) {
     List<DPPIsotopicPeakResult> results = new ArrayList<>();
 
-    if (!dp.resultTypeExists(ResultType.ISOTOPICPEAK))
+    if (!dp.resultTypeExists(ResultType.ISOTOPICPEAK)) {
       return results;
+    }
 
     List<DPPResult<?>> patternResults = dp.getAllResultsByType(ResultType.ISOTOPICPEAK);
 
-    for (int i = 0; i < patternResults.size(); i++)
+    for (int i = 0; i < patternResults.size(); i++) {
       results.add((DPPIsotopicPeakResult) patternResults.get(i));
+    }
 
     return results;
   }
@@ -487,22 +505,23 @@ public class IsotopePatternUtils {
       @NotNull ProcessedDataPoint dp) {
     List<DPPIsotopePatternResult> results = new ArrayList<>();
 
-    if (!dp.resultTypeExists(ResultType.ISOTOPEPATTERN))
+    if (!dp.resultTypeExists(ResultType.ISOTOPEPATTERN)) {
       return results;
+    }
 
     List<DPPResult<?>> patternResults = dp.getAllResultsByType(ResultType.ISOTOPEPATTERN);
 
-    for (int i = 0; i < patternResults.size(); i++)
+    for (int i = 0; i < patternResults.size(); i++) {
       results.add((DPPIsotopePatternResult) patternResults.get(i));
+    }
 
     return results;
   }
 
   /**
-   *
    * @param dp a processed data point.
    * @return an empty list if no isotope pattern was detected, a list of the charge states if there
-   *         was at least one charge detected.
+   * was at least one charge detected.
    */
   public static List<Integer> getChargeStates(ProcessedDataPoint dp) {
     List<Integer> charges = new ArrayList<>();
@@ -529,8 +548,9 @@ public class IsotopePatternUtils {
     List<Integer> charges = new ArrayList<Integer>();
 
     for (DPPIsotopicPeakResult ipr : iprs) {
-      if (!charges.contains(ipr.getCharge()))
+      if (!charges.contains(ipr.getCharge())) {
         charges.add(ipr.getCharge());
+      }
     }
 
     return charges;
@@ -556,12 +576,14 @@ public class IsotopePatternUtils {
 
     // loop all new isotopes
     for (IIsotope isotope : isotopes) {
-      if (isotope.getNaturalAbundance() < minAbundance)
+      if (isotope.getNaturalAbundance() < minAbundance) {
         continue;
+      }
       // the difference added by the heavier isotope peak
       double possiblemzdiff = isotope.getExactMass() - isotopeBaseMass;
-      if (possiblemzdiff < 0.000001)
+      if (possiblemzdiff < 0.000001) {
         continue;
+      }
       boolean add = true;
       for (DataPoint patternDataPoint : pattern) {
         // here check for every peak in the pattern, if a new peak would
@@ -578,20 +600,22 @@ public class IsotopePatternUtils {
             // dont look at the total
             // composition,
             // so we dont know the intensity ratios
-            logger.info("possible overlap found: " + i + " * pattern dp = "
-                + patternDataPoint.getMZ() + "\toverlaps with " + isotope.getMassNumber()
-                + isotope.getSymbol() + " (" + (isotopeBaseMass - isotope.getExactMass())
-                + ")\tdiff: " + Math.abs(patternDataPoint.getMZ() * i - possiblemzdiff));
+            logger.info(
+                "possible overlap found: " + i + " * pattern dp = " + patternDataPoint.getMZ()
+                + "\toverlaps with " + isotope.getMassNumber() + isotope.getSymbol() + " (" + (
+                    isotopeBaseMass - isotope.getExactMass()) + ")\tdiff: " + Math.abs(
+                    patternDataPoint.getMZ() * i - possiblemzdiff));
             add = false;
           }
           i++;
           // logger.info("do");
         } while (patternDataPoint.getMZ() * i <= possiblemzdiff + mergeWidth
-            && patternDataPoint.getMZ() != 0.0);
+                 && patternDataPoint.getMZ() != 0.0);
       }
 
-      if (add)
+      if (add) {
         newPeaks.add(new SimpleDataPoint(possiblemzdiff, 1));
+      }
     }
 
     // now add all new mzs to the isotopePattern
@@ -613,8 +637,9 @@ public class IsotopePatternUtils {
   // -------------------------------------------------------------------------------------------
   // old-new
   public static void mergeIsotopePatternResults(ProcessedDataPoint dp) {
-    if (!dp.resultTypeExists(ResultType.ISOTOPEPATTERN))
+    if (!dp.resultTypeExists(ResultType.ISOTOPEPATTERN)) {
       return;
+    }
 
     List<DPPIsotopePatternResult> patternResults = getIsotopePatternResults(dp);
     List<DPPResult<?>> newResults = new ArrayList<>();
@@ -628,8 +653,9 @@ public class IsotopePatternUtils {
         List<DPPIsotopePatternResult> pPatternResults = getIsotopePatternResults(p);
 
         for (DPPIsotopePatternResult pPatternResult : pPatternResults) {
-          if (pPatternResult.getCharge() != patternCharge)
+          if (pPatternResult.getCharge() != patternCharge) {
             continue;
+          }
 
           ProcessedDataPoint[] dataPoints = pPatternResult.getLinkedDataPoints();
           p.removeResult(pPatternResult);
@@ -645,9 +671,10 @@ public class IsotopePatternUtils {
     dp.addAllResults(newResults);
 
     logger.finest("-------------------------");
-    for (DPPResult<?> result : newResults)
-      logger.finest("FINAL: " + format.format(dp.getMZ()) + " pattern: "
-          + getResultIsoComp((DPPIsotopePatternResult) result));
+    for (DPPResult<?> result : newResults) {
+      logger.finest("FINAL: " + format.format(dp.getMZ()) + " pattern: " + getResultIsoComp(
+          (DPPIsotopePatternResult) result));
+    }
 
     // TODO: test
   }
@@ -656,15 +683,227 @@ public class IsotopePatternUtils {
     String str = "";
     for (ProcessedDataPoint dp : result.getLinkedDataPoints()) {
       String c = "";
-      DPPIsotopeCompositionResult comps =
-          (DPPIsotopeCompositionResult) dp.getFirstResultByType(ResultType.ISOTOPECOMPOSITION);
-      for (String comp : comps.getValue())
+      DPPIsotopeCompositionResult comps = (DPPIsotopeCompositionResult) dp.getFirstResultByType(
+          ResultType.ISOTOPECOMPOSITION);
+      for (String comp : comps.getValue()) {
         c += comp + ", ";
-      if (c.length() > 2)
+      }
+      if (c.length() > 2) {
         c = c.substring(0, c.length() - 2);
+      }
       str += format.format(dp.getMZ()) + " (" + c + "), ";
     }
     str = str.substring(0, str.length() - 2);
     return str;
+  }
+
+  public static boolean check13CPattern(IsotopePattern pattern, double mainMZ, MZTolerance mzTol,
+      int maxCharge) {
+    return check13CPattern(pattern, mainMZ, mzTol, maxCharge, null);
+  }
+
+  /**
+   * Evaluate if mainMZ defines the monoisotopic (or at least the smallest detected isotope) by
+   * checking the +1 signal with 13C isotope abundances and delta m/z. Returns false, if the pattern
+   * contains a 13C isotope with matching abundance preceding the main signal.
+   *
+   * @param pattern         the isotope pattern
+   * @param mainMZ          the row m/z that should be the monoisotopic m/z
+   * @param mzTol           tolerance to match signals. All signals in range will be considered -
+   *                        only one has to match the criteria
+   * @param maxCharge       maximum allowed charge. will test charge 1<=max
+   * @param excludedMzDiffs option to exclude specific isotopes. {@link IsotopesUtils#getIsotopeRecord(String,
+   *                        int)} Method will return false when a preceding signal is found matching
+   *                        the intensity and m/z difference of a provided isotope (m/z difference
+   *                        to the maximum abundant isotope)
+   * @return only true if the +1 peak for 13C isotope is found. false otherwise or if there is a
+   * preceding 13C isotope or one of the excluded isotopes (e.g., 18O)
+   */
+  public static boolean check13CPattern(IsotopePattern pattern, double mainMZ, MZTolerance mzTol,
+      int maxCharge, @Nullable Isotope[] excludedMzDiffs) {
+    // result:
+    boolean plusOneIsotopeFound = false;
+
+    int maxIndex = findMaxIndex(pattern, mainMZ, mzTol, 0);
+    if (maxIndex < 0) {
+      return false;
+    }
+
+    // highest main signal
+    final double newMainMZ = pattern.getMzValue(maxIndex);
+    final double mainHeight = pattern.getIntensityValue(maxIndex);
+
+    // look at +1 peak for 13C
+    // exclude all -1 peaks from excludedMzDiffs
+    for (int charge = 1; charge <= maxCharge; charge++) {
+      // looks at a -1 peak
+      if (excludedMzDiffs != null) {
+        for (Isotope excludedMzDiff : excludedMzDiffs) {
+          // open limits for the minimum ratio - which defines the maximum intensity of the preceding signal
+          double minRatio = excludedMzDiff.relativeIntensity() * 0.2;
+          double maxRatio =
+              estimateMaxXAtoms(excludedMzDiff, mainMZ, charge) * excludedMzDiff.relativeIntensity()
+              * 1.15;
+          double isotopeMZ = newMainMZ - (excludedMzDiff.deltaMass() / charge);
+          Range<Double> estimatedIntensityRange = Range.closed(mainHeight / maxRatio,
+              mainHeight / minRatio);
+          boolean mainIsIsotopeSignal = hasSignalMatchingIntensityRange(pattern, isotopeMZ, mzTol,
+              estimatedIntensityRange, maxIndex - 1, -1);
+          if (mainIsIsotopeSignal) {
+            return false;
+          }
+        }
+      }
+
+      // estimate min max carbons
+      double estimatedMinC = estimateMinCAtoms(newMainMZ, charge);
+      double estimatedMaxC = estimateMaxCAtoms(newMainMZ, charge);
+      // add some tolerance on lower and upper bounds
+      double minRatio = estimatedMinC * C13_REL_ABUNDANCE * 0.85;
+      double maxRatio = estimatedMaxC * C13_REL_ABUNDANCE * 1.15;
+
+      // if signal has preceeding 13C signal within intensity range - flag as isotope and return false
+      Range<Double> estimatedIntensityRange = Range.closed(mainHeight / maxRatio,
+          mainHeight / minRatio);
+      double isotopeMZ = newMainMZ - (C13_MZ_DELTA / charge);
+      boolean mainIsIsotopeSignal = hasSignalMatchingIntensityRange(pattern, isotopeMZ, mzTol,
+          estimatedIntensityRange, maxIndex - 1, -1);
+      if (mainIsIsotopeSignal) {
+        return false;
+      }
+
+      // check if this signal is actually the +1 peak
+      // +1 carbon isotope peak
+      // when found - still check if other condition for other charge states result in false
+      // when charge state is 2, the +2 13C signal may be found as a potential +1 13C signal
+      if (!plusOneIsotopeFound) {
+        isotopeMZ = newMainMZ + (C13_MZ_DELTA / charge);
+        estimatedIntensityRange = Range.closed(mainHeight * minRatio, mainHeight * maxRatio);
+        plusOneIsotopeFound = hasSignalMatchingIntensityRange(pattern, isotopeMZ, mzTol,
+            estimatedIntensityRange, maxIndex + 1, 1);
+      }
+    }
+    return plusOneIsotopeFound;
+  }
+
+  private static double estimateMaxXAtoms(Isotope isotope, double mz, int charge) {
+    if (mz <= 0) {
+      return -1;
+    }
+    // just estimate a very high number of possible isotopes
+    // 2 isotopes per carbon
+    return mz * charge / (6 + isotope.exactMass());
+  }
+
+  private static double estimateMaxCAtoms(double mz, int charge) {
+    if (mz <= 0) {
+      return -1;
+    }
+    // highly aromatic rings C + 0.1 H (just an estimate)
+    // Kind and Fiehn 7 golden rules 0.1 <= H/C <= 6
+    return mz / 12.1 * charge;
+  }
+
+  private static double estimateMinCAtoms(double mz, int charge) {
+    if (mz <= 0) {
+      return -1;
+    }
+    // N/C ratio <= 4, O/C ratio <= 3, P/C ratio <= 2, S/C ratio <= 3
+    return 3 * charge;
+  }
+
+  private static int findMaxIndex(IsotopePattern pattern, double mainMZ, MZTolerance mzTol,
+      int startIndex) {
+    final Range<Double> mainMZrange = mzTol.getToleranceRange(mainMZ);
+    int maxIndex = -1;
+    double maxIntensity = -1;
+    final int size = pattern.getNumberOfDataPoints();
+    for (int index = startIndex; index < size; index++) {
+      double mz = pattern.getMzValue(index);
+      if (mz < mainMZrange.lowerEndpoint()) {
+        continue;
+      } else if (mz > mainMZrange.upperEndpoint()) {
+        break;
+      } else {
+        double intensity = pattern.getIntensityValue(index);
+        if (intensity >= maxIntensity) {
+          maxIntensity = intensity;
+          maxIndex = index;
+        }
+      }
+    }
+    return maxIndex;
+  }
+
+  /**
+   * @param pattern
+   * @param mainMZ
+   * @param mzTol
+   * @param startIndex
+   * @return an index range that contains all
+   */
+  private static IntRange findIndexRange(IsotopePattern pattern, double mainMZ, MZTolerance mzTol,
+      int startIndex) {
+    return findIndexRange(pattern, mainMZ, mzTol, startIndex, 1);
+  }
+
+  private static IntRange findIndexRange(IsotopePattern pattern, double mainMZ, MZTolerance mzTol,
+      int startIndex, int direction) {
+    final Range<Double> mainMZrange = mzTol.getToleranceRange(mainMZ);
+    final int size = pattern.getNumberOfDataPoints();
+    int firstMatch = -1;
+    for (int index = startIndex; index < size && index >= 0; index += direction) {
+      double mz = pattern.getMzValue(index);
+      if (mz < mainMZrange.lowerEndpoint()) {
+        continue;
+      } else if (mz > mainMZrange.upperEndpoint()) {
+        return new IntRange(firstMatch, index);
+      } else if (firstMatch == -1) {
+        firstMatch = index;
+      }
+    }
+    return firstMatch == -1 ? IntRange.EMPTY : new IntRange(firstMatch, size);
+  }
+
+  /**
+   * Search for signals in mz and intensity ranges
+   *
+   * @param startIndex start at this index
+   * @param direction  iterate in this direction (-1 or +1)
+   * @return true if signal found in mz and intensity ranges. false otherwise
+   */
+  private static boolean hasSignalMatchingIntensityRange(IsotopePattern pattern, double searchMZ,
+      MZTolerance mzTol, Range<Double> intensityRange, int startIndex, int direction) {
+    final Range<Double> mainMZrange = mzTol.getToleranceRange(searchMZ);
+    final int size = pattern.getNumberOfDataPoints();
+    if (direction > 0) {
+      for (int index = startIndex; index < size; index++) {
+        double mz = pattern.getMzValue(index);
+        if (mz < mainMZrange.lowerEndpoint()) {
+          continue;
+        } else if (mz > mainMZrange.upperEndpoint()) {
+          // no signal found
+          return false;
+        } else if (intensityRange.contains(pattern.getIntensityValue(index))) {
+          // in intensity range, in mz range
+          return true;
+        }
+      }
+    } else {
+      // find preceeding signals
+      for (int index = startIndex; index >= 0; index--) {
+        double mz = pattern.getMzValue(index);
+        if (mz < mainMZrange.lowerEndpoint()) {
+          return false;
+        } else if (mz > mainMZrange.upperEndpoint()) {
+          // no signal found
+          continue;
+        } else if (intensityRange.contains(pattern.getIntensityValue(index))) {
+          // in intensity range, in mz range
+          return true;
+        }
+      }
+    }
+    return false;
   }
 }

--- a/src/main/java/io/github/mzmine/util/IsotopesUtils.java
+++ b/src/main/java/io/github/mzmine/util/IsotopesUtils.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
@@ -116,6 +117,25 @@ public class IsotopesUtils {
         : new Isotope(elementSymbol, result.getAtomicNumber(), result.getExactMass(),
             Math.abs(result.getExactMass() - main.getExactMass()),
             result.getNaturalAbundance() / main.getNaturalAbundance());
+  }
+
+  /**
+   * The isotope of an element with mass number might include isotopes with no natural abundance.
+   *
+   * @param elementSymbol An element symbol to search for
+   * @return the isotope of an element with specific mass number or empty list if not available
+   */
+  public static List<Isotope> getIsotopeRecord(String elementSymbol) {
+    final IIsotope[] isotopes = getIsotopes(elementSymbol, true);
+    final IIsotope main = Arrays.stream(isotopes)
+        .max(Comparator.comparingDouble(IIsotope::getNaturalAbundance)).orElse(null);
+    if (main == null) {
+      return List.of();
+    }
+    return Arrays.stream(isotopes).filter(iso -> !main.equals(iso)).map(
+        result -> new Isotope(elementSymbol, result.getAtomicNumber(), result.getExactMass(),
+            Math.abs(result.getExactMass() - main.getExactMass()),
+            result.getNaturalAbundance() / main.getNaturalAbundance())).toList();
   }
 
   /**

--- a/src/main/java/io/github/mzmine/util/IsotopesUtils.java
+++ b/src/main/java/io/github/mzmine/util/IsotopesUtils.java
@@ -52,6 +52,73 @@ public class IsotopesUtils {
   }
 
   /**
+   * Gets an array of all NATURALLY OCCURRING isotopes known to the IsotopeFactory for the given
+   * element symbol.
+   *
+   * @param elementSymbol An element symbol to search for
+   * @return An array of isotopes that matches the given element symbol or an empty array
+   */
+  public static IIsotope[] getIsotopes(String elementSymbol) {
+    return getIsotopes(elementSymbol, true);
+  }
+
+  /**
+   * Gets an array of all isotopes known to the IsotopeFactory for the given element symbol.
+   *
+   * @param elementSymbol An element symbol to search for
+   * @param onlyNatural   only elements with natural abundance > 0
+   * @return An array of isotopes that matches the given element symbol or an empty array
+   */
+  public static IIsotope[] getIsotopes(String elementSymbol, boolean onlyNatural) {
+    if (onlyNatural) {
+      return isotopes.getIsotopes(elementSymbol);
+    } else {
+      return Arrays.stream(isotopes.getIsotopes(elementSymbol))
+          .filter(iso -> iso.getNaturalAbundance() > 0).toArray(IIsotope[]::new);
+    }
+  }
+
+  /**
+   * The isotope of an element with mass number might include isotopes with no natural abundance.
+   *
+   * @param elementSymbol An element symbol to search for
+   * @param massNumber    the isotope with this mass number
+   * @return the isotope of an element with specific mass number or null if not available (
+   */
+  public static IIsotope getIsotopes(String elementSymbol, int massNumber) {
+    for (IIsotope iso : getIsotopes(elementSymbol, false)) {
+      if (iso.getMassNumber() == massNumber) {
+        return iso;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * The isotope of an element with mass number might include isotopes with no natural abundance.
+   *
+   * @param elementSymbol An element symbol to search for
+   * @param massNumber    the isotope with this mass number
+   * @return the isotope of an element with specific mass number or null if not available (
+   */
+  public static Isotope getIsotopeRecord(String elementSymbol, int massNumber) {
+    IIsotope result = null;
+    IIsotope main = null;
+    for (IIsotope iso : getIsotopes(elementSymbol, false)) {
+      if (main == null || main.getNaturalAbundance() < iso.getNaturalAbundance()) {
+        main = iso;
+      }
+      if (iso.getMassNumber() == massNumber) {
+        result = iso;
+      }
+    }
+    return result == null ? null
+        : new Isotope(elementSymbol, result.getAtomicNumber(), result.getExactMass(),
+            Math.abs(result.getExactMass() - main.getExactMass()),
+            result.getNaturalAbundance() / main.getNaturalAbundance());
+  }
+
+  /**
    * Returns pairwise m/z differences between stable isotopes within given chemical elements. Final
    * differences are obtained by dividing isotope mass differences with 1, 2, ..., maxCharge values.
    * For example, for elements == [H, C] and maxCharge == 2 this method returns [C13 - C12, (C13 -
@@ -69,7 +136,8 @@ public class IsotopesUtils {
     for (Element element : elements) {
 
       // Filter out not stable isotopes
-      List<IIsotope> abundantIsotopes = Arrays.stream(isotopes.getIsotopes(element.getSymbol()))
+      List<IIsotope> abundantIsotopes = Arrays.stream(
+              isotopes.getIsotopes(element.getAtomicNumber()))
           .filter(i -> Doubles.compare(i.getNaturalAbundance(), 0) > 0d).toList();
 
       // Compute pairwise mass differences and divide each one with charges up to maxCharge

--- a/src/test/java/IsotopesUtilsTest.java
+++ b/src/test/java/IsotopesUtilsTest.java
@@ -17,14 +17,20 @@
  */
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.mzmine.datamodel.DataPoint;
+import io.github.mzmine.datamodel.IsotopePattern;
+import io.github.mzmine.datamodel.IsotopePattern.IsotopePatternStatus;
 import io.github.mzmine.datamodel.impl.SimpleDataPoint;
+import io.github.mzmine.datamodel.impl.SimpleIsotopePattern;
 import io.github.mzmine.datamodel.impl.masslist.SimpleMassList;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.util.DataPointSorter;
 import io.github.mzmine.util.DataPointUtils;
+import io.github.mzmine.util.Isotope;
+import io.github.mzmine.util.IsotopePatternUtils;
 import io.github.mzmine.util.IsotopesUtils;
 import io.github.mzmine.util.SortingDirection;
 import io.github.mzmine.util.SortingProperty;
@@ -32,6 +38,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.Element;
+import org.openscience.cdk.interfaces.IIsotope;
 
 /**
  * @author Robin Schmid (https://github.com/robinschmid)
@@ -43,9 +50,8 @@ class IsotopesUtilsTest {
    */
   @Test
   void testIsotopesMzDiffsNotNegative() {
-    List<Element> elements = List
-        .of(new Element("C"), new Element("Cl"), new Element("Fe"), new Element("Ca"),
-            new Element("Cu"), new Element("Gd"), new Element("Sn"));
+    List<Element> elements = List.of(new Element("C"), new Element("Cl"), new Element("Fe"),
+        new Element("Ca"), new Element("Cu"), new Element("Gd"), new Element("Sn"));
     List<Double> diffs = IsotopesUtils.getIsotopesMzDiffs(elements, 1);
 
     for (double d : diffs) {
@@ -95,24 +101,57 @@ class IsotopesUtilsTest {
   @Test
   void findsIsotopePatternStartingAtPeak3() {
     List<Element> elements = List.of(new Element("C"), new Element("Br"));
-    List<Double> diffs = IsotopesUtils
-        .getIsotopesMzDiffsCombined(elements, 1, new MZTolerance(0.006, 20));
+    List<Double> diffs = IsotopesUtils.getIsotopesMzDiffsCombined(elements, 1,
+        new MZTolerance(0.006, 20));
     MZTolerance mzTol = new MZTolerance(0.002, 5);
     final List<DataPoint> isotopes = getBr3C10IsotopePatter();
 
     final SimpleMassList spec = toMassSpec(isotopes, true);
 
     // find all isotopes starting at dp 3 which is the max
-    final List<DataPoint> detected = IsotopesUtils
-        .findIsotopesInScan(diffs, mzTol, spec, isotopes.get(2));
+    final List<DataPoint> detected = IsotopesUtils.findIsotopesInScan(diffs, mzTol, spec,
+        isotopes.get(2));
 
     assertEquals(isotopes, detected);
 
     // find all isotopes starting at dp 7 which is very low
-    final List<DataPoint> detected2 = IsotopesUtils
-        .findIsotopesInScan(diffs, mzTol, spec, isotopes.get(6));
+    final List<DataPoint> detected2 = IsotopesUtils.findIsotopesInScan(diffs, mzTol, spec,
+        isotopes.get(6));
 
     assertEquals(isotopes, detected2);
+  }
+
+  public List<DataPoint> getC300H600IsotopePattern() {
+    return new ArrayList<>(
+        List.of(new SimpleDataPoint(4204.6945, 17.74), new SimpleDataPoint(4205.6978, 57.56),
+            new SimpleDataPoint(4205.7007, 1.22), new SimpleDataPoint(4206.7012, 93.08),
+            new SimpleDataPoint(4206.7041, 3.97), new SimpleDataPoint(4207.7045, 100.00),
+            new SimpleDataPoint(4207.7075, 6.42), new SimpleDataPoint(4208.7079, 80.31),
+            new SimpleDataPoint(4208.7108, 6.90), new SimpleDataPoint(4209.7112, 51.42),
+            new SimpleDataPoint(4209.7142, 5.54), new SimpleDataPoint(4210.7146, 27.34),
+            new SimpleDataPoint(4210.7175, 3.55), new SimpleDataPoint(4211.7180, 12.42),
+            new SimpleDataPoint(4211.7209, 1.89), new SimpleDataPoint(4212.7213, 4.92),
+            new SimpleDataPoint(4213.7247, 1.73)));
+
+  }
+
+  public List<DataPoint> getC12H24O12IsotopePattern() {
+    return new ArrayList<>(
+        List.of(new SimpleDataPoint(360.1262, 100.00), new SimpleDataPoint(361.1296, 13.44),
+            new SimpleDataPoint(361.1325, 0.28), new SimpleDataPoint(362.1305, 2.47),
+            new SimpleDataPoint(362.1330, 0.83), new SimpleDataPoint(363.1339, 0.33)));
+  }
+
+  public List<DataPoint> getC120H200IsotopePattern() {
+    return new ArrayList<>(List.of(new SimpleDataPoint(1641.5645, 77.05), // %	[12]C120[1]H200
+        new SimpleDataPoint(1642.5678, 100.00), // %	[12]C119[13]C[1]H200
+        new SimpleDataPoint(1642.5707, 1.77), // %	[12]C120[1]H199[2]H
+        new SimpleDataPoint(1643.5712, 64.35), // %	[12]C118[13]C2[1]H200
+        new SimpleDataPoint(1643.5741, 2.30), // %	[12]C119[13]C[1]H199[2]H
+        new SimpleDataPoint(1644.5745, 27.38), // %	[12]C117[13]C3[1]H200
+        new SimpleDataPoint(1644.5774, 1.48), // %	[12]C118[13]C2[1]H199[2]H
+        new SimpleDataPoint(1645.5779, 8.66), // %	[12]C116[13]C4[1]H200
+        new SimpleDataPoint(1646.5812, 2.17)));// %	[12]C115[13]C5[1]H200
   }
 
   public List<DataPoint> getBr3C10IsotopePatter() {
@@ -154,4 +193,118 @@ class IsotopesUtilsTest {
     double[][] mzIntensity = DataPointUtils.getDataPointsAsDoubleArray(isotopes);
     return new SimpleMassList(null, mzIntensity[0], mzIntensity[1]);
   }
+
+  private IsotopePattern getPattern(List<DataPoint> dataPoints) {
+    return new SimpleIsotopePattern(dataPoints.toArray(DataPoint[]::new),
+        IsotopePatternStatus.DETECTED, "");
+  }
+
+  @Test
+  void testFilter13C() {
+    final MZTolerance mzTol = new MZTolerance(0.0015, 10);
+
+    final Isotope[] isotope18O = new Isotope[]{IsotopesUtils.getIsotopeRecord("O", 18),
+        IsotopesUtils.getIsotopeRecord("H", 2)};
+    final List<List<DataPoint>> patterns = List.of(getC12H24O12IsotopePattern(),
+        getC120H200IsotopePattern(), getC300H600IsotopePattern());
+
+    for (int p = 0; p < patterns.size(); p++) {
+      final List<DataPoint> dataPoints = patterns.get(p);
+      for (int charge = 1; charge <= 4; charge++) {
+        IsotopePattern pattern = getPattern(
+            charge > 1 ? applyCharge(dataPoints, charge) : dataPoints);
+        assertTrue(IsotopePatternUtils.check13CPattern(pattern, pattern.getMzValue(0), mzTol, 4),
+            String.format(
+                "Monoisotopic peak of pattern p=%d was falsely identified as potential isotope signal at charge %d",
+                p, charge));
+        assertTrue(
+            IsotopePatternUtils.check13CPattern(pattern, pattern.getMzValue(0) + 0.001, mzTol, 4),
+            String.format(
+                "Monoisotopic peak of pattern p=%d was falsely identified as potential isotope signal at charge %d",
+                p, charge));
+        assertTrue(
+            IsotopePatternUtils.check13CPattern(pattern, pattern.getMzValue(0) - 0.001, mzTol, 4),
+            String.format(
+                "Monoisotopic peak of pattern p=%d was falsely identified as potential isotope signal at charge %d",
+                p, charge));
+        for (int i = 1; i < pattern.getNumberOfDataPoints(); i++) {
+          // all other should find a previous signal
+          assertFalse(IsotopePatternUtils.check13CPattern(pattern, pattern.getMzValue(i), mzTol, 4,
+              isotope18O), String.format(
+              "Isotope peak %d of pattern p=%d was falsely identified as potential monoisotopic signal at charge %d",
+              i, p, charge));
+        }
+      }
+    }
+
+    final Isotope[] br = new Isotope[]{IsotopesUtils.getIsotopeRecord("Br", 81)};
+    final IsotopePattern br3C10 = getPattern(getBr3C10IsotopePatter());
+    // check different main m/z (owuld be row m/z)
+    double mz1 = br3C10.getMzValue(0);
+    assertTrue(IsotopePatternUtils.check13CPattern(br3C10, mz1, mzTol, 3));
+    // for the Br containing pattern the +2 peak is at 100 % currently it cannot be destiguished from the monoisotopic peak - it returns true
+    for (int i = 1; i < br3C10.getNumberOfDataPoints(); i++) {
+      // all other should find a previous signal
+      assertFalse(IsotopePatternUtils.check13CPattern(br3C10, br3C10.getMzValue(i), mzTol, 2, br),
+          String.format("Br3C10 isotope signal i=%d detected as main", i));
+    }
+
+    // change up some of the intensities - should be false in the end
+    // first and second data point similar intensity
+    final List<DataPoint> dps = getC12H24O12IsotopePattern();
+    final DataPoint old = dps.remove(0);
+    dps.add(0, new SimpleDataPoint(old.getMZ(), dps.get(0).getIntensity() * 1.2));
+    IsotopePattern pattern = getPattern(dps);
+    assertFalse(
+        IsotopePatternUtils.check13CPattern(pattern, pattern.getMzValue(0), mzTol, 2, isotope18O));
+
+  }
+
+  @Test
+  void testBinarySearchMassSpectrum() {
+    final IsotopePattern isotopes = getPattern(getBr3C10IsotopePatter());
+    final double mz3 = isotopes.getMzValue(3);
+
+    assertEquals(3, isotopes.binarySearch(mz3, true));
+    assertEquals(3, isotopes.binarySearch(mz3, false));
+    assertEquals(3, isotopes.binarySearch(mz3 + 0.00001, true));
+    assertEquals(-5, isotopes.binarySearch(mz3 + 0.00001, false));
+    assertEquals(3, isotopes.binarySearch(mz3 - 0.00001, true));
+    assertEquals(-4, isotopes.binarySearch(mz3 - 0.00001, false));
+
+    assertEquals(0, isotopes.binarySearch(isotopes.getMzValue(0), true));
+    assertEquals(0, isotopes.binarySearch(isotopes.getMzValue(0), false));
+    // out of bounds
+    assertEquals(0, isotopes.binarySearch(isotopes.getMzValue(0) - 0.0001, true));
+    assertEquals(-1, isotopes.binarySearch(isotopes.getMzValue(0) - 0.0001, false));
+
+    final int size = isotopes.getNumberOfDataPoints();
+    assertEquals(size - 1, isotopes.binarySearch(isotopes.getMzValue(size - 1), true));
+    assertEquals(size - 1, isotopes.binarySearch(isotopes.getMzValue(size - 1), false));
+    // out of bounds
+    assertEquals(size - 1, isotopes.binarySearch(isotopes.getMzValue(size - 1) + 0.001, true));
+    assertEquals(-(size + 1), isotopes.binarySearch(isotopes.getMzValue(size - 1) + 0.001, false));
+  }
+
+  @Test
+  void testGetIsotope() {
+    final IIsotope o18 = IsotopesUtils.getIsotopes("O", 18);
+    assertTrue(o18.getNaturalAbundance() > 0);
+    assertEquals(16, o18.getAtomicNumber());
+    assertEquals(18, o18.getMassNumber());
+    final IIsotope c13 = IsotopesUtils.getIsotopes("C", 13);
+    assertTrue(c13.getNaturalAbundance() > 1);
+
+    // nonsense
+    final IIsotope[] nothing = IsotopesUtils.getIsotopes("CBr");
+    assertTrue(nothing.length == 0);
+  }
+
+  private List<DataPoint> applyCharge(List<DataPoint> dps, int charge) {
+    return dps.stream()
+        .map(dp -> (DataPoint) new SimpleDataPoint(dp.getMZ() / charge, dp.getIntensity()))
+        .toList();
+  }
+
+
 }

--- a/src/test/java/IsotopesUtilsTest.java
+++ b/src/test/java/IsotopesUtilsTest.java
@@ -292,7 +292,7 @@ class IsotopesUtilsTest {
   void testGetIsotope() {
     final IIsotope o18 = IsotopesUtils.getIsotopes("O", 18);
     assertTrue(o18.getNaturalAbundance() > 0);
-    assertEquals(16, o18.getAtomicNumber());
+    assertEquals(8, o18.getAtomicNumber());
     assertEquals(18, o18.getMassNumber());
     final IIsotope c13 = IsotopesUtils.getIsotopes("C", 13);
     assertTrue(c13.getNaturalAbundance() > 1);

--- a/src/test/java/IsotopesUtilsTest.java
+++ b/src/test/java/IsotopesUtilsTest.java
@@ -229,10 +229,11 @@ class IsotopesUtilsTest {
                 p, charge));
         for (int i = 1; i < pattern.getNumberOfDataPoints(); i++) {
           // all other should find a previous signal
-          assertFalse(IsotopePatternUtils.check13CPattern(pattern, pattern.getMzValue(i), mzTol, 4,
-              isotope18O), String.format(
-              "Isotope peak %d of pattern p=%d was falsely identified as potential monoisotopic signal at charge %d",
-              i, p, charge));
+          assertFalse(
+              IsotopePatternUtils.check13CPattern(pattern, pattern.getMzValue(i), mzTol, 4, true,
+                  isotope18O), String.format(
+                  "Isotope peak %d of pattern p=%d was falsely identified as potential monoisotopic signal at charge %d",
+                  i, p, charge));
         }
       }
     }
@@ -245,7 +246,8 @@ class IsotopesUtilsTest {
     // for the Br containing pattern the +2 peak is at 100 % currently it cannot be destiguished from the monoisotopic peak - it returns true
     for (int i = 1; i < br3C10.getNumberOfDataPoints(); i++) {
       // all other should find a previous signal
-      assertFalse(IsotopePatternUtils.check13CPattern(br3C10, br3C10.getMzValue(i), mzTol, 2, br),
+      assertFalse(
+          IsotopePatternUtils.check13CPattern(br3C10, br3C10.getMzValue(i), mzTol, 2, true, br),
           String.format("Br3C10 isotope signal i=%d detected as main", i));
     }
 
@@ -255,8 +257,8 @@ class IsotopesUtilsTest {
     final DataPoint old = dps.remove(0);
     dps.add(0, new SimpleDataPoint(old.getMZ(), dps.get(0).getIntensity() * 1.2));
     IsotopePattern pattern = getPattern(dps);
-    assertFalse(
-        IsotopePatternUtils.check13CPattern(pattern, pattern.getMzValue(0), mzTol, 2, isotope18O));
+    assertFalse(IsotopePatternUtils.check13CPattern(pattern, pattern.getMzValue(0), mzTol, 2, true,
+        isotope18O));
 
   }
 
@@ -297,7 +299,7 @@ class IsotopesUtilsTest {
 
     // nonsense
     final IIsotope[] nothing = IsotopesUtils.getIsotopes("CBr");
-    assertTrue(nothing.length == 0);
+    assertEquals(0, nothing.length);
   }
 
   private List<DataPoint> applyCharge(List<DataPoint> dps, int charge) {

--- a/src/test/java/IsotopesUtilsTest.java
+++ b/src/test/java/IsotopesUtilsTest.java
@@ -231,7 +231,7 @@ class IsotopesUtilsTest {
           // all other should find a previous signal
           assertFalse(
               IsotopePatternUtils.check13CPattern(pattern, pattern.getMzValue(i), mzTol, 4, true,
-                  isotope18O), String.format(
+                  isotope18O, true), String.format(
                   "Isotope peak %d of pattern p=%d was falsely identified as potential monoisotopic signal at charge %d",
                   i, p, charge));
         }
@@ -247,8 +247,8 @@ class IsotopesUtilsTest {
     for (int i = 1; i < br3C10.getNumberOfDataPoints(); i++) {
       // all other should find a previous signal
       assertFalse(
-          IsotopePatternUtils.check13CPattern(br3C10, br3C10.getMzValue(i), mzTol, 2, true, br),
-          String.format("Br3C10 isotope signal i=%d detected as main", i));
+          IsotopePatternUtils.check13CPattern(br3C10, br3C10.getMzValue(i), mzTol, 2, true, br,
+              true), String.format("Br3C10 isotope signal i=%d detected as main", i));
     }
 
     // change up some of the intensities - should be false in the end
@@ -258,7 +258,7 @@ class IsotopesUtilsTest {
     dps.add(0, new SimpleDataPoint(old.getMZ(), dps.get(0).getIntensity() * 1.2));
     IsotopePattern pattern = getPattern(dps);
     assertFalse(IsotopePatternUtils.check13CPattern(pattern, pattern.getMzValue(0), mzTol, 2, true,
-        isotope18O));
+        isotope18O, true));
 
   }
 


### PR DESCRIPTION
Added a more comprehensive 13C isotope filter to the rows filter. Previously, we only filter for minimum signals in an isotope pattern. For the Isotope finder, which is more inclusive, we need a better 13C filter.
- for each row's m/z we search for the +1 13C isotope peak in the isotope pattern and score the height. 
- there might be multiple signals in range so all are considered - only one needs to match the height requirements which derived from estimated min / max number of carbons.
- estimates the minimum and maximum number of 13 carbons based on mass defect and m/z 
- optionally looks for a -1 13C peak in the pattern (with matching height) to flag the row as an isotope and filter it
- optionally uses other elements to make sure we are not looking at a 18O or any other isotope signal (searching for the main signal at -X)
- added plenty of tests to check the performance with multiple charge states considered etc

![image](https://user-images.githubusercontent.com/10366914/150057938-711f7fae-8325-4af4-adf1-5337c99ae45d.png)
