### PR TITLE
Patch data point 

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/impl/SimpleDataPoint.java
+++ b/src/main/java/io/github/mzmine/datamodel/impl/SimpleDataPoint.java
@@ -18,10 +18,10 @@
 
 package io.github.mzmine.datamodel.impl;
 
-import java.text.Format;
-
 import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.main.MZmineCore;
+import java.text.Format;
+import java.util.Objects;
 
 /**
  * This class represents one data point of a spectrum (m/z and intensity pair). Data point is
@@ -59,18 +59,20 @@ public class SimpleDataPoint implements DataPoint {
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (!(obj instanceof DataPoint)) {
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    DataPoint dp = (DataPoint) obj;
-    return (Double.compare(this.mz, dp.getMZ()) == 0
-        && Double.compare(this.intensity, dp.getIntensity()) == 0);
+    SimpleDataPoint that = (SimpleDataPoint) o;
+    return Double.compare(that.mz, mz) == 0 && Double.compare(that.intensity, intensity) == 0;
   }
 
   @Override
   public int hashCode() {
-    return (int) (this.mz + this.intensity);
+    return Objects.hash(mz, intensity);
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/util/DataPointSorter.java
+++ b/src/main/java/io/github/mzmine/util/DataPointSorter.java
@@ -31,8 +31,8 @@ public class DataPointSorter implements Comparator<DataPoint> {
   public static final DataPointSorter DEFAULT_INTENSITY = new DataPointSorter(
       SortingProperty.Intensity, SortingDirection.Descending);
 
-  private SortingProperty property;
-  private SortingDirection direction;
+  private final SortingProperty property;
+  private final SortingDirection direction;
 
   public DataPointSorter(SortingProperty property, SortingDirection direction) {
     this.property = property;
@@ -40,7 +40,6 @@ public class DataPointSorter implements Comparator<DataPoint> {
   }
 
   public int compare(DataPoint dp1, DataPoint dp2) {
-
     int result;
 
     switch (property) {


### PR DESCRIPTION
I somehow ended up having contract violations when using the data point sorter during library matching. 
Then I saw that the hash function and equals was a bit off in SimpleDataPoint.
No idea why but this fixed the problem.