### PR TITLE
Refactor GNPS export

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/features/Feature.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/Feature.java
@@ -183,6 +183,7 @@ public interface Feature {
   /**
    * Returns all scan numbers that represent fragmentations of this feature in MS2 level.
    */
+  @NotNull
   List<Scan> getAllMS2FragmentScans();
 
   /**

--- a/src/main/java/io/github/mzmine/datamodel/features/FeatureListRow.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/FeatureListRow.java
@@ -376,7 +376,8 @@ public interface FeatureListRow extends ModularDataModel {
    */
   default boolean hasMs2Fragmentation() {
     // should be faster. Best fragmentation loops through all spectra to find best
-    return getAllFragmentScans() != null && !getAllFragmentScans().isEmpty();
+    final List<Scan> ms2 = getAllFragmentScans();
+    return ms2 != null && !ms2.isEmpty();
   }
 
   /**

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeature.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeature.java
@@ -364,6 +364,7 @@ public class ModularFeature implements Feature, ModularDataModel {
   }
 
   @Override
+  @NotNull
   public List<Scan> getAllMS2FragmentScans() {
     // return empty list instead
     return Objects.requireNonNullElse(get(FragmentScanNumbersType.class), List.of());

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureListRow.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureListRow.java
@@ -665,16 +665,12 @@ public class ModularFeatureListRow implements FeatureListRow {
     double bestTIC = 0.0;
     Scan bestScan = null;
     for (Feature feature : getFeatures()) {
-      RawDataFile rawData = feature.getRawDataFile();
-      if (rawData == null || feature.getFeatureStatus().equals(FeatureStatus.UNKNOWN)) {
+      Scan theScan = feature.getMostIntenseFragmentScan();
+      if (theScan == null) {
         continue;
       }
 
-      Scan theScan = feature.getMostIntenseFragmentScan();
-      double theTIC = 0.0;
-      if (theScan != null) {
-        theTIC = theScan.getTIC();
-      }
+      double theTIC = Objects.requireNonNullElse(theScan.getTIC(), 0d);
 
       if (theTIC > bestTIC) {
         bestTIC = theTIC;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/group_metacorrelate/export/ExportCorrAnnotationTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/group_metacorrelate/export/ExportCorrAnnotationTask.java
@@ -134,7 +134,7 @@ public class ExportCorrAnnotationTask extends AbstractTask {
       AtomicInteger added = new AtomicInteger(0);
       // for all rows
       for (FeatureListRow r : rows) {
-        if (!filter.filter(r)) {
+        if (!filter.accept(r)) {
           continue;
         }
 
@@ -153,15 +153,15 @@ public class ExportCorrAnnotationTask extends AbstractTask {
             links.entrySet().stream().filter(Objects::nonNull)
                 .filter(e -> e.getKey().getID() > rowID).forEach(e -> {
               FeatureListRow link = e.getKey();
-              if (filter.filter(link)) {
-                IonIdentity id = e.getValue();
-                double dmz = Math.abs(r.getAverageMZ() - link.getAverageMZ());
-                // the data
-                exportEdge(ann, "MS1 annotation", rowID, e.getKey().getID(),
-                    corrForm.format((id.getScore() + adduct.getScore()) / 2d), //
-                    id.getAdduct() + " " + adduct.getAdduct() + " dm/z=" + mzForm.format(dmz));
-                added.incrementAndGet();
-              }
+                  if (filter.accept(link)) {
+                    IonIdentity id = e.getValue();
+                    double dmz = Math.abs(r.getAverageMZ() - link.getAverageMZ());
+                    // the data
+                    exportEdge(ann, "MS1 annotation", rowID, e.getKey().getID(),
+                        corrForm.format((id.getScore() + adduct.getScore()) / 2d), //
+                        id.getAdduct() + " " + adduct.getAdduct() + " dm/z=" + mzForm.format(dmz));
+                    added.incrementAndGet();
+                  }
             });
           });
         }
@@ -253,11 +253,11 @@ public class ExportCorrAnnotationTask extends AbstractTask {
     double sumIntensity = 0;
     for (Map.Entry<FeatureListRow, IonIdentity> entryA : netA.entrySet()) {
       FeatureListRow rowA = entryA.getKey();
-      if (filter.filter(rowA)) {
+      if (filter.accept(rowA)) {
         IonIdentity iinA = entryA.getValue();
         for (Map.Entry<FeatureListRow, IonIdentity> entryB : netB.entrySet()) {
           FeatureListRow rowB = entryB.getKey();
-          if (filter.filter(rowB)) {
+          if (filter.accept(rowB)) {
             IonIdentity iinB = entryB.getValue();
             if (iinA.getAdduct().equals(iinB.getAdduct())) {
               // find pair with the highest sum intensity (that match the row filter)
@@ -443,7 +443,7 @@ public class ExportCorrAnnotationTask extends AbstractTask {
     StringBuilder ann = createHeader();
     for (RowsRelationship rel : relationships) {
       // only export if both rows match
-      if (filter.filter(rel.getRowA()) && filter.filter(rel.getRowB())) {
+      if (filter.accept(rel.getRowA()) && filter.accept(rel.getRowB())) {
         exportEdge(ann, rel.getType().toString(), rel.getRowA().getID(), rel.getRowB().getID(),
             rel.getScoreFormatted(), rel.getAnnotation());
       }
@@ -481,7 +481,7 @@ public class ExportCorrAnnotationTask extends AbstractTask {
     int lastID = 0;
     for (FeatureList pkl : featureLists) {
       for (FeatureListRow r : pkl.getRows()) {
-        if (!filter.filter(r)) {
+        if (!filter.accept(r)) {
           continue;
         }
         renumbered.put(getRowMapKey(r), lastID);
@@ -503,7 +503,7 @@ public class ExportCorrAnnotationTask extends AbstractTask {
 
         // for all rows
         for (FeatureListRow r : rows) {
-          if (!filter.filter(r)) {
+          if (!filter.accept(r)) {
             continue;
           }
 

--- a/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularTask.java
@@ -55,25 +55,21 @@ public class CSVExportModularTask extends AbstractTask {
 
   public static final String DATAFILE_PREFIX = "DATAFILE";
   private static final Logger logger = Logger.getLogger(CSVExportModularTask.class.getName());
-  private ModularFeatureList[] featureLists;
-  private int processedRows = 0, totalRows = 0;
-
+  private final ModularFeatureList[] featureLists;
   // parameter values
-  private File fileName;
-  private String plNamePattern = "{}";
-  private String fieldSeparator;
-  private String idSeparator;
-  private String headerSeparator = ":";
-  private FeatureListRowsFilter filter;
+  private final File fileName;
+  private final String fieldSeparator;
+  private final String idSeparator;
+  private final String headerSeparator = ":";
+  private final FeatureListRowsFilter filter;
+  private int processedRows = 0, totalRows = 0;
 
   public CSVExportModularTask(ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
-    this.featureLists =
-        parameters.getParameter(CSVExportModularParameters.featureLists).getValue()
-            .getMatchingFeatureLists();
+    this.featureLists = parameters.getParameter(CSVExportModularParameters.featureLists).getValue()
+        .getMatchingFeatureLists();
     fileName = parameters.getParameter(CSVExportModularParameters.filename).getValue();
-    fieldSeparator = parameters.getParameter(
-        CSVExportModularParameters.fieldSeparator).getValue();
+    fieldSeparator = parameters.getParameter(CSVExportModularParameters.fieldSeparator).getValue();
     idSeparator = parameters.getParameter(CSVExportModularParameters.idSeparator).getValue();
     this.filter = parameters.getParameter(CSVExportModularParameters.filter).getValue();
   }
@@ -86,13 +82,12 @@ public class CSVExportModularTask extends AbstractTask {
    * @param filter         Row filter
    */
   public CSVExportModularTask(ModularFeatureList[] featureLists, File fileName,
-      String fieldSeparator,
-      String idSeparator, FeatureListRowsFilter filter, @NotNull Instant moduleCallDate) {
+      String fieldSeparator, String idSeparator, FeatureListRowsFilter filter,
+      @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     if (fieldSeparator.equals(idSeparator)) {
-      throw new IllegalArgumentException(MessageFormat
-          .format("Column separator cannot equal the identity separator (currently {0})",
-              idSeparator));
+      throw new IllegalArgumentException(MessageFormat.format(
+          "Column separator cannot equal the identity separator (currently {0})", idSeparator));
     }
     this.featureLists = featureLists;
     this.fileName = fileName;
@@ -120,6 +115,7 @@ public class CSVExportModularTask extends AbstractTask {
     setStatus(TaskStatus.PROCESSING);
 
     // Shall export several files?
+    String plNamePattern = "{}";
     boolean substitute = fileName.getPath().contains(plNamePattern);
 
     // Total number of rows
@@ -129,6 +125,10 @@ public class CSVExportModularTask extends AbstractTask {
 
     // Process feature lists
     for (ModularFeatureList featureList : featureLists) {
+      // Cancel?
+      if (isCanceled()) {
+        return;
+      }
 
       // Filename
       File curFile = fileName;
@@ -136,25 +136,24 @@ public class CSVExportModularTask extends AbstractTask {
         // Cleanup from illegal filename characters
         String cleanPlName = featureList.getName().replaceAll("[^a-zA-Z0-9.-]", "_");
         // Substitute
-        String newFilename =
-            fileName.getPath().replaceAll(Pattern.quote(plNamePattern), cleanPlName);
+        String newFilename = fileName.getPath()
+            .replaceAll(Pattern.quote(plNamePattern), cleanPlName);
         curFile = new File(newFilename);
       }
       curFile = FileAndPathUtil.getRealFilePath(curFile, "csv");
 
       // Open file
 
-      try (BufferedWriter writer = Files
-          .newBufferedWriter(curFile.toPath(), StandardCharsets.UTF_8)) {
-        exportFeatureList(featureList, writer, curFile);
+      try (BufferedWriter writer = Files.newBufferedWriter(curFile.toPath(),
+          StandardCharsets.UTF_8)) {
+        exportFeatureList(featureList, writer);
+
       } catch (IOException e) {
         setStatus(TaskStatus.ERROR);
         setErrorMessage("Could not open file " + curFile + " for writing.");
-        return;
-      }
-
-      // Cancel?
-      if (isCanceled()) {
+        logger.log(Level.WARNING, String.format(
+            "Error writing new CSV format to file: %s for feature list: %s. Message: %s",
+            curFile.getAbsolutePath(), featureList.getName(), e.getMessage()), e);
         return;
       }
 
@@ -170,26 +169,25 @@ public class CSVExportModularTask extends AbstractTask {
     }
   }
 
-  private void exportFeatureList(ModularFeatureList flist, BufferedWriter writer, File fileName)
+  @SuppressWarnings("rawtypes")
+  private void exportFeatureList(ModularFeatureList flist, BufferedWriter writer)
       throws IOException {
     List<RawDataFile> rawDataFiles = flist.getRawDataFiles();
 
-    List<DataType> rowTypes = flist.getRowTypes().values().stream()
-        .filter(this::filterType)
+    List<DataType> rowTypes = flist.getRowTypes().values().stream().filter(this::filterType)
         .collect(Collectors.toList());
 
-    List<DataType> featureTypes = flist.getFeatureTypes().values().stream()
-        .filter(this::filterType)
+    List<DataType> featureTypes = flist.getFeatureTypes().values().stream().filter(this::filterType)
         .collect(Collectors.toList());
 
     // Write feature row headers
-    String header = getJoinedHeader(rowTypes, "");
+    StringBuilder header = new StringBuilder(getJoinedHeader(rowTypes, ""));
     for (RawDataFile raw : rawDataFiles) {
-      header += (header.isEmpty() ? "" : fieldSeparator) + getJoinedHeader(featureTypes,
-          DATAFILE_PREFIX + headerSeparator + raw.getName());
+      header.append((header.length() == 0) ? "" : fieldSeparator)
+          .append(getJoinedHeader(featureTypes, DATAFILE_PREFIX + headerSeparator + raw.getName()));
     }
 
-    writer.append(header);
+    writer.append(header.toString());
     writer.newLine();
 
     // write data
@@ -215,8 +213,8 @@ public class CSVExportModularTask extends AbstractTask {
              || type instanceof LinkedGraphicalType);
   }
 
-  private String joinRowData(ModularFeatureListRow row,
-      List<RawDataFile> raws, List<DataType> rowTypes, List<DataType> featureTypes) {
+  private String joinRowData(ModularFeatureListRow row, List<RawDataFile> raws,
+      List<DataType> rowTypes, List<DataType> featureTypes) {
     StringBuilder b = new StringBuilder();
     joinData(b, row, rowTypes);
 
@@ -313,8 +311,8 @@ public class CSVExportModularTask extends AbstractTask {
   private String getJoinedHeader(List<DataType> types, String prefix) {
     StringBuilder b = new StringBuilder();
     for (DataType t : types) {
-      String header = (prefix == null || prefix.isEmpty() ? "" : prefix + headerSeparator) + t
-          .getHeaderString();
+      String header = (prefix == null || prefix.isEmpty() ? "" : prefix + headerSeparator)
+                      + t.getHeaderString();
       if (t instanceof SubColumnsFactory subCols) {
         int numberOfSub = subCols.getNumberOfSubColumns();
         for (int i = 0; i < numberOfSub; i++) {

--- a/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularTask.java
@@ -194,7 +194,7 @@ public class CSVExportModularTask extends AbstractTask {
 
     // write data
     for (FeatureListRow row : flist.getRows()) {
-      if (!filter.filter(row)) {
+      if (!filter.accept(row)) {
         processedRows++;
         continue;
       }

--- a/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/FeatureListRowsFilter.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/FeatureListRowsFilter.java
@@ -39,7 +39,7 @@ public enum FeatureListRowsFilter {
    *
    * @return true if row conforms to the filter
    */
-  public boolean filter(FeatureListRow row) {
+  public boolean accept(FeatureListRow row) {
     return switch (this) {
       case ALL -> true;
       case ONLY_WITH_MS2 -> row.hasMs2Fragmentation();

--- a/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnExportAndSubmitTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnExportAndSubmitTask.java
@@ -234,8 +234,7 @@ public class GnpsFbmnExportAndSubmitTask extends AbstractTask {
             ? LegacyExportRowDataFileElement.FEATURE_AREA
             : LegacyExportRowDataFileElement.FEATURE_HEIGHT};
 
-    FeatureListRowsFilter filter = parameters.getParameter(GnpsFbmnExportAndSubmitParameters.FILTER)
-        .getValue();
+    FeatureListRowsFilter filter = parameters.getValue(GnpsFbmnExportAndSubmitParameters.FILTER);
 
     ModularFeatureList[] flist = parameters.getParameter(
         GnpsFbmnExportAndSubmitParameters.FEATURE_LISTS).getValue().getMatchingFeatureLists();

--- a/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnExportAndSubmitTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnExportAndSubmitTask.java
@@ -51,7 +51,6 @@ import java.awt.Desktop;
 import java.io.File;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -66,15 +65,20 @@ import org.jetbrains.annotations.NotNull;
 public class GnpsFbmnExportAndSubmitTask extends AbstractTask {
 
   // Logger.
-  private final Logger logger = Logger.getLogger(getClass().getName());
-
-  private ParameterSet parameters;
-  private AtomicDouble progress = new AtomicDouble(0);
-  private FeatureMeasurementType featureMeasure;
+  private static final Logger logger = Logger.getLogger(
+      GnpsFbmnExportAndSubmitTask.class.getName());
+  private final ParameterSet parameters;
+  private final AtomicDouble progress = new AtomicDouble(0);
+  private final FeatureMeasurementType featureMeasure;
+  private final File baseFile;
 
   GnpsFbmnExportAndSubmitTask(ParameterSet parameters, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     this.parameters = parameters;
+    featureMeasure = parameters.getValue(GnpsFbmnExportAndSubmitParameters.FEATURE_INTENSITY);
+    baseFile = FileAndPathUtil.eraseFormat(
+        parameters.getValue(GnpsFbmnExportAndSubmitParameters.FILENAME));
+    parameters.getParameter(GnpsFbmnExportAndSubmitParameters.FILENAME).setValue(baseFile);
   }
 
   @Override
@@ -98,40 +102,33 @@ public class GnpsFbmnExportAndSubmitTask extends AbstractTask {
     final AbstractTask thistask = this;
     setStatus(TaskStatus.PROCESSING);
 
-    boolean openFolder =
-        parameters.getParameter(GnpsFbmnExportAndSubmitParameters.OPEN_FOLDER).getValue();
+    boolean openFolder = parameters.getParameter(GnpsFbmnExportAndSubmitParameters.OPEN_FOLDER)
+        .getValue();
     boolean submit = parameters.getParameter(GnpsFbmnExportAndSubmitParameters.SUBMIT).getValue();
-    File file = parameters.getParameter(GnpsFbmnExportAndSubmitParameters.FILENAME).getValue();
-    file = FileAndPathUtil.eraseFormat(file);
-    parameters.getParameter(GnpsFbmnExportAndSubmitParameters.FILENAME).setValue(file);
-
-    featureMeasure =
-        parameters.getParameter(GnpsFbmnExportAndSubmitParameters.FEATURE_INTENSITY).getValue();
 
     List<AbstractTask> list = new ArrayList<>(4);
     GnpsFbmnMgfExportTask task = new GnpsFbmnMgfExportTask(parameters, getModuleCallDate());
     list.add(task);
 
     // add old csv quant table for old FBMN support
-    list.add(addLegacyQuantTableTask(parameters, null));
+    list.add(addLegacyQuantTableTask(parameters));
     // add new csv export for whole table
-    list.add(addFullQuantTableTask(parameters, null));
+    list.add(addFullQuantTableTask(parameters));
 
     // add csv extra edges
-    list.add(addExtraEdgesTask(parameters, null));
+    list.add(addExtraEdgesTask(parameters));
 
     // finish listener to submit
-    final File fileName = file;
-    final File folder = file.getParentFile();
+    final File folder = baseFile.getParentFile();
     new AllTasksFinishedListener(list, true,
         // succeed
         l -> {
           try {
             logger.info("succeed" + thistask.getStatus().toString());
             if (submit) {
-              GnpsFbmnSubmitParameters param = parameters
-                  .getParameter(GnpsFbmnExportAndSubmitParameters.SUBMIT).getEmbeddedParameters();
-              submit(fileName, param);
+              GnpsFbmnSubmitParameters param = parameters.getParameter(
+                  GnpsFbmnExportAndSubmitParameters.SUBMIT).getEmbeddedParameters();
+              submit(baseFile, param);
             }
 
             // open folder
@@ -197,27 +194,19 @@ public class GnpsFbmnExportAndSubmitTask extends AbstractTask {
    * Export the whole quant table in the new format
    *
    * @param parameters export parameters {@link GnpsFbmnExportAndSubmitParameters}
-   * @param tasks      new task is added to this list of tasks
    */
-  private AbstractTask addFullQuantTableTask(ParameterSet parameters, Collection<Task> tasks) {
+  private AbstractTask addFullQuantTableTask(ParameterSet parameters) {
     File full = parameters.getParameter(GnpsFbmnExportAndSubmitParameters.FILENAME).getValue();
     final String name = FilenameUtils.removeExtension(full.getName());
     full = new File(full.getParentFile(), name + "_quant_full.csv");
 
-    ModularFeatureList[] flist = parameters
-        .getParameter(GnpsFbmnExportAndSubmitParameters.FEATURE_LISTS).getValue()
-        .getMatchingFeatureLists();
+    ModularFeatureList[] flist = parameters.getParameter(
+        GnpsFbmnExportAndSubmitParameters.FEATURE_LISTS).getValue().getMatchingFeatureLists();
 
-    FeatureListRowsFilter filter =
-        parameters.getParameter(GnpsFbmnExportAndSubmitParameters.FILTER).getValue();
+    FeatureListRowsFilter filter = parameters.getParameter(GnpsFbmnExportAndSubmitParameters.FILTER)
+        .getValue();
 
-    CSVExportModularTask quanExportModular = new CSVExportModularTask(flist, full, ",", ";",
-        filter, getModuleCallDate());
-
-    if (tasks != null) {
-      tasks.add(quanExportModular);
-    }
-    return quanExportModular;
+    return new CSVExportModularTask(flist, full, ",", ";", filter, getModuleCallDate());
   }
 
 
@@ -225,71 +214,56 @@ public class GnpsFbmnExportAndSubmitTask extends AbstractTask {
    * Export quant table in new and old format
    *
    * @param parameters export parameters {@link GnpsFbmnExportAndSubmitParameters}
-   * @param tasks      new task is added to this list of tasks
    */
-  private AbstractTask addLegacyQuantTableTask(ParameterSet parameters, Collection<Task> tasks) {
-    File full = parameters.getParameter(GnpsFbmnExportAndSubmitParameters.FILENAME).getValue();
-    final String name = FilenameUtils.removeExtension(full.getName());
-    full = new File(full.getParentFile(), name + "_quant.csv");
+  private AbstractTask addLegacyQuantTableTask(ParameterSet parameters) {
+    final String name = FilenameUtils.removeExtension(baseFile.getName());
+    File full = new File(baseFile.getParentFile(), name + "_quant.csv");
     // add old CSV export
     LegacyExportRowCommonElement[] common = new LegacyExportRowCommonElement[]{
         LegacyExportRowCommonElement.ROW_ID, LegacyExportRowCommonElement.ROW_MZ,
         LegacyExportRowCommonElement.ROW_RT,
         // extra for ion identity networking
-        LegacyExportRowCommonElement.ROW_CORR_GROUP_ID, LegacyExportRowCommonElement.ROW_MOL_NETWORK_ID,
+        LegacyExportRowCommonElement.ROW_CORR_GROUP_ID,
+        LegacyExportRowCommonElement.ROW_MOL_NETWORK_ID,
         LegacyExportRowCommonElement.ROW_BEST_ANNOTATION_AND_SUPPORT,
         LegacyExportRowCommonElement.ROW_NEUTRAL_MASS};
 
     // per raw data file
-    LegacyExportRowDataFileElement[] rawdata = new LegacyExportRowDataFileElement[]
-        {featureMeasure.equals(FeatureMeasurementType.AREA)
+    LegacyExportRowDataFileElement[] rawdata = new LegacyExportRowDataFileElement[]{
+        featureMeasure.equals(FeatureMeasurementType.AREA)
             ? LegacyExportRowDataFileElement.FEATURE_AREA
             : LegacyExportRowDataFileElement.FEATURE_HEIGHT};
 
-    FeatureListRowsFilter filter =
-        parameters.getParameter(GnpsFbmnExportAndSubmitParameters.FILTER).getValue();
+    FeatureListRowsFilter filter = parameters.getParameter(GnpsFbmnExportAndSubmitParameters.FILTER)
+        .getValue();
 
-    ModularFeatureList[] flist = parameters
-        .getParameter(GnpsFbmnExportAndSubmitParameters.FEATURE_LISTS).getValue()
-        .getMatchingFeatureLists();
+    ModularFeatureList[] flist = parameters.getParameter(
+        GnpsFbmnExportAndSubmitParameters.FEATURE_LISTS).getValue().getMatchingFeatureLists();
 
-    LegacyCSVExportTask quanExport = new LegacyCSVExportTask(flist, full, ",", common, rawdata,
-        false, ";", filter, getModuleCallDate());
-
-    if (tasks != null) {
-      tasks.add(quanExport);
-    }
-    return quanExport;
+    return new LegacyCSVExportTask(flist, full, ",", common, rawdata, false, ";", filter,
+        getModuleCallDate());
   }
 
 
   /**
    * Export extra edges (wont create files if empty)
-   *
-   * @param parameters
-   * @param tasks
    */
-  private AbstractTask addExtraEdgesTask(ParameterSet parameters, Collection<Task> tasks) {
+  private AbstractTask addExtraEdgesTask(ParameterSet parameters) {
     File full = parameters.getParameter(GnpsFbmnExportAndSubmitParameters.FILENAME).getValue();
     FeatureListRowsFilter filter = parameters.getParameter(GnpsFbmnExportAndSubmitParameters.FILTER)
         .getValue();
-    boolean mergeLists =
-        parameters.getParameter(GnpsFbmnExportAndSubmitParameters.MERGE_PARAMETER).getValue();
 
     boolean exAnn = true;
     if (parameters.getParameter(GnpsFbmnExportAndSubmitParameters.SUBMIT).getValue()) {
-      exAnn = parameters.getParameter(GnpsFbmnExportAndSubmitParameters.SUBMIT).getEmbeddedParameters()
+      exAnn = parameters.getParameter(GnpsFbmnExportAndSubmitParameters.SUBMIT)
+          .getEmbeddedParameters()
           .getParameter(GnpsFbmnSubmitParameters.EXPORT_ION_IDENTITY_NETWORKS).getValue();
     }
-    ModularFeatureList[] flist = parameters
-        .getParameter(GnpsFbmnExportAndSubmitParameters.FEATURE_LISTS).getValue()
-        .getMatchingFeatureLists();
+    ModularFeatureList[] flist = parameters.getParameter(
+        GnpsFbmnExportAndSubmitParameters.FEATURE_LISTS).getValue().getMatchingFeatureLists();
 
-    AbstractTask extraEdgeExport = new ExportCorrAnnotationTask(flist, full, 0, filter, exAnn, false, false, false, getModuleCallDate());
-
-    if (tasks != null)
-      tasks.add(extraEdgeExport);
-    return extraEdgeExport;
+    return new ExportCorrAnnotationTask(flist, full, 0, filter, exAnn, false, false, false,
+        getModuleCallDate());
   }
 
 }

--- a/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnExportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnExportTask.java
@@ -63,7 +63,6 @@ import org.jetbrains.annotations.NotNull;
 public class GnpsFbmnExportTask extends AbstractTask {
   private final FeatureList[] featureLists;
   private final File fileName;
-  private final String plNamePattern = "{}";
   private int currentIndex = 0;
   private final MsMsSpectraMergeParameters mergeParameters;
 
@@ -86,8 +85,9 @@ public class GnpsFbmnExportTask extends AbstractTask {
   public double getFinishedPercentage() {
     if (featureLists.length == 0)
       return 1;
-    else
-      return currentIndex / featureLists.length;
+    else {
+      return currentIndex / (double) featureLists.length;
+    }
   }
 
   @Override
@@ -95,6 +95,7 @@ public class GnpsFbmnExportTask extends AbstractTask {
     setStatus(TaskStatus.PROCESSING);
 
     // Shall export several files?
+    String plNamePattern = "{}";
     boolean substitute = fileName.getPath().contains(plNamePattern);
 
     // Process feature lists

--- a/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnMgfExportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnMgfExportTask.java
@@ -32,7 +32,6 @@ package io.github.mzmine.modules.io.export_features_gnps.fbmn;
 import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.MassList;
 import io.github.mzmine.datamodel.Scan;
-import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.main.MZmineCore;
@@ -43,9 +42,11 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.files.FileAndPathUtil;
+import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.text.DecimalFormat;
 import java.text.MessageFormat;
 import java.text.NumberFormat;
@@ -61,9 +62,9 @@ import org.jetbrains.annotations.NotNull;
  * Exports all files needed for GNPS
  *
  * @author Robin Schmid (robinschmid@uni-muenster.de)
- *
  */
 public class GnpsFbmnMgfExportTask extends AbstractTask {
+
   // Logger.
   private final Logger logger = Logger.getLogger(getClass().getName());
 
@@ -71,9 +72,9 @@ public class GnpsFbmnMgfExportTask extends AbstractTask {
   private final FeatureList[] featureLists;
   private final File fileName;
   private final String plNamePattern = "{}";
-  private int currentIndex = 0;
+  private final MsMsSpectraMergeModule merger;
   private final MsMsSpectraMergeParameters mergeParameters;
-
+  private int currentIndex = 0;
   // by robin
   private NumberFormat mzForm = MZmineCore.getConfiguration().getMZFormat();
   private NumberFormat intensityForm = MZmineCore.getConfiguration().getIntensityFormat();
@@ -97,14 +98,16 @@ public class GnpsFbmnMgfExportTask extends AbstractTask {
     } else {
       mergeParameters = null;
     }
+    merger = MZmineCore.getModuleInstance(MsMsSpectraMergeModule.class);
   }
 
   @Override
   public double getFinishedPercentage() {
-    if (featureLists.length == 0)
+    if (featureLists.length == 0) {
       return 1;
-    else
+    } else {
       return currentIndex / featureLists.length;
+    }
   }
 
   @Override
@@ -116,6 +119,11 @@ public class GnpsFbmnMgfExportTask extends AbstractTask {
 
     // Process feature lists
     for (FeatureList featureList : featureLists) {
+      // Cancel?
+      if (isCanceled()) {
+        return;
+      }
+
       currentIndex++;
 
       // Filename
@@ -137,48 +145,30 @@ public class GnpsFbmnMgfExportTask extends AbstractTask {
       }
 
       // Open file
-      FileWriter writer;
-      try {
-        writer = new FileWriter(curFile);
-      } catch (Exception e) {
-        setStatus(TaskStatus.ERROR);
-        setErrorMessage("Could not open file " + curFile + " for writing.");
-        return;
-      }
+      try (BufferedWriter writer = Files.newBufferedWriter(curFile.toPath(),
+          StandardCharsets.UTF_8)) {
 
-      try {
-        export(featureList, writer, curFile);
+        export(featureList, writer);
       } catch (IOException e) {
         setStatus(TaskStatus.ERROR);
-        setErrorMessage("Error while writing into file " + curFile + ": " + e.getMessage());
-        return;
-      }
-
-      // Cancel?
-      if (isCanceled()) {
-        return;
-      }
-
-      // Close file
-      try {
-        writer.close();
-      } catch (Exception e) {
-        setStatus(TaskStatus.ERROR);
-        setErrorMessage("Could not close file " + curFile);
+        setErrorMessage("Error during mgf export to " + curFile);
+        logger.log(Level.WARNING, "Error during mgf export: " + e.getMessage(), e);
         return;
       }
 
       // If feature list substitution pattern wasn't found,
       // treat one feature list only
-      if (!substitute)
+      if (!substitute) {
         break;
+      }
     }
 
-    if (getStatus() == TaskStatus.PROCESSING)
+    if (getStatus() == TaskStatus.PROCESSING) {
       setStatus(TaskStatus.FINISHED);
+    }
   }
 
-  private int export(FeatureList featureList, FileWriter writer, File curFile) throws IOException {
+  private int export(FeatureList featureList, BufferedWriter writer) throws IOException {
     final String newLine = System.lineSeparator();
 
     // count exported
@@ -190,13 +180,10 @@ public class GnpsFbmnMgfExportTask extends AbstractTask {
       }
 
       String rowID = Integer.toString(row.getID());
-      double retTimeInSeconds = ((row.getAverageRT() * 60 * 100.0) / 100.);
+      final Float averageRT = row.getAverageRT();
+      double retTimeInSeconds = averageRT == null ? 0d : ((averageRT * 60 * 100.0) / 100.);
 
       // Get the MS/MS scan number
-      Feature bestFeature = row.getBestFeature();
-      if (bestFeature == null) {
-        continue;
-      }
       Scan msmsScan = row.getMostIntenseFragmentScan();
       if (msmsScan != null) {
         // MS/MS scan must exist, because msmsScanNumber was > 0
@@ -209,61 +196,64 @@ public class GnpsFbmnMgfExportTask extends AbstractTask {
           return count;
         }
 
-        writer.write("BEGIN IONS" + newLine);
+        writer.append("BEGIN IONS").append(newLine);
+        writer.append("FEATURE_ID=").append(rowID).write(newLine);
 
-        if (rowID != null)
-          writer.write("FEATURE_ID=" + rowID + newLine);
-
-        String mass = mzForm.format(row.getAverageMZ());
-        if (mass != null)
-          writer.write("PEPMASS=" + mass + newLine);
-
-        if (rowID != null) {
-          writer.write("SCANS=" + rowID + newLine);
-          writer.write("RTINSECONDS=" + rtsForm.format(retTimeInSeconds) + newLine);
+        final Double mz = row.getAverageMZ();
+        if (mz != null) {
+          writer.append("PEPMASS=").append(mzForm.format(mz)).write(newLine);
         }
 
-        int msmsCharge = Objects.requireNonNullElse(msmsScan.getPrecursorCharge(), 0);
+        writer.append("SCANS=").append(rowID).write(newLine);
+        writer.append("RTINSECONDS=").append(rtsForm.format(retTimeInSeconds)).write(newLine);
+
+        int msmsCharge = Objects.requireNonNullElse(msmsScan.getPrecursorCharge(), 1);
         String msmsPolarity = msmsScan.getPolarity().asSingleChar();
-        if (msmsPolarity.equals("0"))
-          msmsPolarity = "";
-        if (msmsCharge == 0) {
-          msmsCharge = 1;
+        if (!(msmsPolarity.equals("+") || msmsPolarity.equals("-"))) {
           msmsPolarity = "";
         }
+
         writer.write("CHARGE=" + msmsCharge + msmsPolarity + newLine);
+        writer.append("MSLEVEL=2").write(newLine);
 
-        writer.write("MSLEVEL=2" + newLine);
-
-        DataPoint[] dataPoints = massList.getDataPoints();
+        DataPoint[] dataPoints = null;
+        // merge MS/MS spectra
         if (mergeParameters != null) {
-          MsMsSpectraMergeModule merger =
-              MZmineCore.getModuleInstance(MsMsSpectraMergeModule.class);
-          MergedSpectrum spectrum =
-              merger.getBestMergedSpectrum(mergeParameters, row);
-          if (spectrum != null) {
-            dataPoints = spectrum.data;
-            writer.write("MERGED_STATS=");
-            writer.write(spectrum.getMergeStatsDescription());
-            writer.write(newLine);
+          try {
+            MergedSpectrum spectrum = merger.getBestMergedSpectrum(mergeParameters, row);
+            if (spectrum != null) {
+              dataPoints = spectrum.data;
+              writer.write("MERGED_STATS=");
+              writer.write(spectrum.getMergeStatsDescription());
+              writer.write(newLine);
+            }
+          } catch (Exception ex) {
+            logger.log(Level.WARNING, "Error during MS2 merge in mgf export: " + ex.getMessage(),
+                ex);
           }
         }
-        for (DataPoint feature : dataPoints) {
-          writer.write(mzForm.format(feature.getMZ()) + " " + intensityForm.format(feature.getIntensity())
-              + newLine);
+        // nothing after merging or no merging active
+        if (dataPoints == null) {
+          dataPoints = massList.getDataPoints();
         }
-        writer.write("END IONS" + newLine);
-        writer.write(newLine);
+
+        for (DataPoint feature : dataPoints) {
+          writer.append(mzForm.format(feature.getMZ())).append(" ")
+              .append(intensityForm.format(feature.getIntensity())).write(newLine);
+        }
+        //
+        writer.append("END IONS").append(newLine).write(newLine);
         count++;
       }
     }
 
-    if (count == 0)
+    if (count == 0) {
       logger.log(Level.WARNING, "No MS/MS scans exported.");
-    else
+    } else {
       logger.info(
           MessageFormat.format("Total of {0} feature rows (MS/MS mass lists) were exported ({1})",
               count, featureList.getName()));
+    }
 
     return count;
   }

--- a/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnMgfExportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnMgfExportTask.java
@@ -175,7 +175,7 @@ public class GnpsFbmnMgfExportTask extends AbstractTask {
     int count = 0;
     for (FeatureListRow row : featureList.getRows()) {
       // do not export if no MSMS
-      if (!filter.filter(row)) {
+      if (!filter.accept(row)) {
         continue;
       }
 

--- a/src/main/java/io/github/mzmine/util/FeatureConvertors.java
+++ b/src/main/java/io/github/mzmine/util/FeatureConvertors.java
@@ -204,8 +204,7 @@ public class FeatureConvertors {
     modularFeature.setRepresentativeScan(manualFeature.getRepresentativeScanNumber());
     // Add values to feature
 
-    modularFeature.set(FragmentScanNumbersType.class,
-        List.of(manualFeature.getAllMS2FragmentScanNumbers()));
+    modularFeature.setAllMS2FragmentScans(List.of(manualFeature.getAllMS2FragmentScanNumbers()));
 //    modularFeature.set(ScanNumbersType.class, List.of(manualFeature.getScanNumbers()));
 
     modularFeature.set(RawFileType.class, manualFeature.getRawDataFile());


### PR DESCRIPTION
The GNPS export used some unsafe methods to open / save files.
There are reports of mismatches between the number of exported features for mgf and csv export despite using the same rows filter for only those with MS2.

I will open a separate PR removing the best fragmentation DataType - we should only use the list of all fragment scans and sort it regarding the "best" scan = first in list.
Similar to Ion Identities and other List types