### PR TITLE
Fix lower==upper bound error in IMS map paintscale

### DIFF
--- a/src/main/java/io/github/mzmine/gui/chartbasics/chartutils/paintscales/PaintScale.java
+++ b/src/main/java/io/github/mzmine/gui/chartbasics/chartutils/paintscales/PaintScale.java
@@ -32,7 +32,10 @@ public class PaintScale extends LookupPaintScale {
   private PaintScaleBoundStyle paintScaleBoundStyle;
 
   public PaintScale(Range<Double> scaleRange) {
-    super(scaleRange.lowerEndpoint(), scaleRange.upperEndpoint(), new Color(0, 0, 0, 0f));
+    // we add a minimum value on top of the upper endpoint to avoid errors for empty datasets
+    // with lower==upper value
+    super(scaleRange.lowerEndpoint(), scaleRange.upperEndpoint() + Double.MIN_VALUE,
+        new Color(0, 0, 0, 0f));
   }
 
   public PaintScale(PaintScaleColorStyle paintScaleColorStyle,
@@ -42,7 +45,9 @@ public class PaintScale extends LookupPaintScale {
 
   public PaintScale(PaintScaleColorStyle paintScaleColorStyle,
       PaintScaleBoundStyle paintScaleBoundStyle, Range<Double> scaleRange, Color color) {
-    super(scaleRange.lowerEndpoint(), scaleRange.upperEndpoint(), color);
+    // we add a minimum value on top of the upper endpoint to avoid errors for empty datasets
+    // with lower==upper value
+    super(scaleRange.lowerEndpoint(), scaleRange.upperEndpoint() + Double.MIN_VALUE, color);
     this.paintScaleColorStyle = paintScaleColorStyle;
     this.paintScaleBoundStyle = paintScaleBoundStyle;
   }


### PR DESCRIPTION
There was an error when starting the IMS overview on one dataset. The map visualization was empty on start up so all data points were 0 - generating a paintscale gave this error 

```
java.lang.IllegalArgumentException: Requires lowerBound < upperBound.
	at org.jfree.chart.renderer.LookupPaintScale.<init>(LookupPaintScale.java:191)
	at io.github.mzmine.gui.chartbasics.chartutils.paintscales.PaintScale.<init>(PaintScale.java:35)
	at io.github.mzmine.util.color.SimpleColorPalette.toPaintScale(SimpleColorPalette.java:250)
	at io.github.mzmine.gui.chartbasics.simplechart.providers.impl.spectra.FrameHeatmapProvider.computeValues(FrameHeatmapProvider.java:127)
	at io.github.mzmine.gui.chartbasics.simplechart.datasets.ColoredXYZDataset.run(ColoredXYZDataset.java:210)
	at io.github.mzmine.taskcontrol.impl.WorkerThread.run(WorkerThread.java:57)
```