### PR TITLE
Modular CSV export fixes

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/features/ModularDataModel.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularDataModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2020 The MZmine Development Team
+ * Copyright 2006-2021 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -8,11 +8,12 @@
  * License, or (at your option) any later version.
  *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
- * Public License for more details.
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
  */
 
 package io.github.mzmine.datamodel.features;
@@ -117,6 +118,15 @@ public interface ModularDataModel {
   @Nullable
   default <T extends Object> T get(DataType<T> type) {
     return (T) getMap().get(type);
+  }
+
+  /**
+   * @param type
+   * @return true if value is not null
+   */
+  @Nullable
+  default <T extends Object> boolean hasValueFor(DataType<T> type) {
+    return getMap().get(type) != null;
   }
 
   /**

--- a/src/main/java/io/github/mzmine/datamodel/features/types/ListWithSubsType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/ListWithSubsType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2020 The MZmine Development Team
+ * Copyright 2006-2021 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -8,11 +8,12 @@
  * License, or (at your option) any later version.
  *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
- * Public License for more details.
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
  */
 
 package io.github.mzmine.datamodel.features.types;
@@ -97,10 +98,24 @@ public abstract class ListWithSubsType<T> extends ListDataType<T> implements
   }
 
   @Override
+  @Nullable
+  public String getUniqueID(int subcolumn) {
+    // do not change unique ID
+    List<DataType> list = getSubDataTypes();
+    if (subcolumn >= 0 && subcolumn < list.size()) {
+      return list.get(subcolumn).getUniqueID();
+    } else {
+      throw new IndexOutOfBoundsException(
+          "Sub column index " + subcolumn + " is out of range " + list.size());
+    }
+  }
+
+  @Override
   public @NotNull DataType<?> getType(int index) {
     if (index < 0 || index >= getSubDataTypes().size()) {
-      throw new IndexOutOfBoundsException(String
-          .format("Sub column index %d is out of bounds %d", index, getSubDataTypes().size()));
+      throw new IndexOutOfBoundsException(
+          String.format("Sub column index %d is out of bounds %d", index,
+              getSubDataTypes().size()));
     }
     return getSubDataTypes().get(index);
   }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/annotations/ManualAnnotationType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/annotations/ManualAnnotationType.java
@@ -219,10 +219,23 @@ public class ManualAnnotationType extends DataType<ManualAnnotation> implements 
   }
 
   @Override
+  public @Nullable String getUniqueID(int subcolumn) {
+    List<DataType> list = getSubDataTypes();
+    if (subcolumn >= 0 && subcolumn < list.size()) {
+      return list.get(subcolumn).getUniqueID();
+    } else {
+      throw new IndexOutOfBoundsException(
+          "Sub column index " + subcolumn + " is out of range " + list.size());
+    }
+  }
+
+
+  @Override
   public @NotNull DataType<?> getType(int index) {
     if (index < 0 || index >= getSubDataTypes().size()) {
-      throw new IndexOutOfBoundsException(String
-          .format("Sub column index %d is out of bounds %d", index, getSubDataTypes().size()));
+      throw new IndexOutOfBoundsException(
+          String.format("Sub column index %d is out of bounds %d", index,
+              getSubDataTypes().size()));
     }
     return getSubDataTypes().get(index);
   }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/modifiers/SubColumnsFactory.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/modifiers/SubColumnsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2020 The MZmine Development Team
+ * Copyright 2006-2021 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -8,11 +8,12 @@
  * License, or (at your option) any later version.
  *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
- * Public License for more details.
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
  */
 
 package io.github.mzmine.datamodel.features.types.modifiers;
@@ -38,14 +39,20 @@ public interface SubColumnsFactory {
    *
    * @return list of sub columns
    */
-  @NotNull
-  List<TreeTableColumn<ModularFeatureListRow, Object>> createSubColumns(
+  @NotNull List<TreeTableColumn<ModularFeatureListRow, Object>> createSubColumns(
       final @Nullable RawDataFile raw, final @Nullable SubColumnsFactory parentType);
 
   int getNumberOfSubColumns();
 
-  @Nullable
-  String getHeader(int subcolumn);
+  @Nullable String getHeader(int subcolumn);
+
+  /**
+   * The unique ID in a machine readable format
+   *
+   * @param subcolumn
+   * @return parsable format of ID
+   */
+  @Nullable String getUniqueID(int subcolumn);
 
   /**
    * The data type of the subcolumn
@@ -53,8 +60,7 @@ public interface SubColumnsFactory {
    * @param subcolumn index of subcolumn
    * @return datatype of subcolumn
    */
-  @NotNull
-  DataType<?> getType(int subcolumn);
+  @NotNull DataType<?> getType(int subcolumn);
 
   @Nullable
   String getFormattedSubColValue(int subcolumn, Object cellData);

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/abstr/NumberRangeType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/abstr/NumberRangeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2020 The MZmine Development Team
+ * Copyright 2006-2021 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -8,11 +8,12 @@
  * License, or (at your option) any later version.
  *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
- * Public License for more details.
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
  */
 
 package io.github.mzmine.datamodel.features.types.numbers.abstr;
@@ -75,6 +76,7 @@ public abstract class NumberRangeType<T extends Number & Comparable<?>>
   @Nullable
   @Override
   public String getHeader(int subcolumn) {
+    // is also used as unique ID - do not change or make sure that unique ID is min / max
     switch (subcolumn) {
       case 0:
         return "min";
@@ -87,6 +89,13 @@ public abstract class NumberRangeType<T extends Number & Comparable<?>>
       throw new IndexOutOfBoundsException(
           "Sub column index " + subcolumn + " is out of range " + getNumberOfSubColumns());
     }
+  }
+
+  @Override
+  @Nullable
+  public String getUniqueID(int subcolumn) {
+    // do not change unique ID
+    return getHeader(subcolumn);
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularParameters.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularParameters.java
@@ -21,6 +21,7 @@ package io.github.mzmine.modules.io.export_features_csv;
 import io.github.mzmine.modules.io.export_features_gnps.fbmn.FeatureListRowsFilter;
 import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
+import io.github.mzmine.parameters.parametertypes.BooleanParameter;
 import io.github.mzmine.parameters.parametertypes.ComboParameter;
 import io.github.mzmine.parameters.parametertypes.StringParameter;
 import io.github.mzmine.parameters.parametertypes.filenames.FileNameParameter;
@@ -31,33 +32,31 @@ import javafx.stage.FileChooser.ExtensionFilter;
 
 public class CSVExportModularParameters extends SimpleParameterSet {
 
+  public static final FeatureListsParameter featureLists = new FeatureListsParameter(1);
+  public static final StringParameter fieldSeparator = new StringParameter("Field separator",
+      "Character(s) used to separate fields in the exported file", ",");
+  public static final StringParameter idSeparator = new StringParameter("Identification separator",
+      "Character(s) used to separate multi object columns in the exported file", ";");
+  public static final BooleanParameter omitEmptyColumns = new BooleanParameter(
+      "Remove empty columns", "Removes empty columns during data export", true);
+  public static final ComboParameter<FeatureListRowsFilter> filter = new ComboParameter<>(
+      "Filter rows", "Limit the exported rows to those with MS/MS data (or annotated rows)",
+      FeatureListRowsFilter.values(), FeatureListRowsFilter.ALL);
   private static final List<ExtensionFilter> extensions = List.of( //
       new ExtensionFilter("comma-separated values", "*.csv"), //
       new ExtensionFilter("All files", "*.*") //
   );
-
-
-  public static final FeatureListsParameter featureLists = new FeatureListsParameter(1);
-
   public static final FileNameParameter filename = new FileNameParameter("Filename",
       "Name of the output CSV file. "
-      + "Use pattern \"{}\" in the file name to substitute with feature list name. "
-      + "(i.e. \"blah{}blah.csv\" would become \"blahSourceFeatureListNameblah.csv\"). "
-      + "If the file already exists, it will be overwritten.",
-      extensions, FileSelectionType.SAVE);
+          + "Use pattern \"{}\" in the file name to substitute with feature list name. "
+          + "(i.e. \"blah{}blah.csv\" would become \"blahSourceFeatureListNameblah.csv\"). "
+          + "If the file already exists, it will be overwritten.", extensions,
+      FileSelectionType.SAVE);
 
-  public static final StringParameter fieldSeparator = new StringParameter("Field separator",
-      "Character(s) used to separate fields in the exported file", ",");
-
-  public static final StringParameter idSeparator = new StringParameter("Identification separator",
-      "Character(s) used to separate multi object columns in the exported file", ";");
-
-  public static final ComboParameter<FeatureListRowsFilter> filter = new ComboParameter<>(
-      "Filter rows", "Limit the exported rows to those with MS/MS data (or annotated rows)",
-      FeatureListRowsFilter.values(), FeatureListRowsFilter.ALL);
 
   public CSVExportModularParameters() {
-    super(new Parameter[] {featureLists, filename, fieldSeparator, idSeparator, filter});
+    super(new Parameter[]{featureLists, filename, fieldSeparator, idSeparator, omitEmptyColumns,
+        filter});
   }
 
 }

--- a/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularTask.java
@@ -35,6 +35,7 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.ProcessedItemsCounter;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import io.github.mzmine.util.FeatureListRowSorter;
 import io.github.mzmine.util.files.FileAndPathUtil;
 import io.github.mzmine.util.io.CSVUtils;
 import java.io.BufferedWriter;
@@ -192,7 +193,8 @@ public class CSVExportModularTask extends AbstractTask implements ProcessedItems
   @SuppressWarnings("rawtypes")
   private void exportFeatureList(ModularFeatureList flist, BufferedWriter writer)
       throws IOException {
-    final List<FeatureListRow> rows = flist.getRows().stream().filter(rowFilter::accept).toList();
+    final List<FeatureListRow> rows = flist.getRows().stream().filter(rowFilter::accept)
+        .sorted(FeatureListRowSorter.DEFAULT_ID).toList();
     List<RawDataFile> rawDataFiles = flist.getRawDataFiles();
 
     List<DataType> rowTypes = flist.getRowTypes().values().stream().filter(this::filterType)

--- a/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularTask.java
@@ -325,9 +325,6 @@ public class CSVExportModularTask extends AbstractTask implements ProcessedItems
 
   private <T extends DataType & SubColumnsFactory> String getFormattedValue(
       @Nullable ModularDataModel data, SubColumnsFactory subColFactory, int col) {
-    if (data == null) {
-      return "";
-    }
     Object value = data == null ? null : data.get((DataType) subColFactory);
     if (value == null) {
       value = ((DataType) subColFactory).getDefaultValue();
@@ -336,9 +333,6 @@ public class CSVExportModularTask extends AbstractTask implements ProcessedItems
   }
 
   private String getFormattedValue(@Nullable ModularDataModel data, DataType type) {
-    if (data == null) {
-      return "";
-    }
     Object value = data == null ? null : data.get(type);
     if (value == null) {
       value = type.getDefaultValue();

--- a/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularTask.java
@@ -58,7 +58,7 @@ import org.jetbrains.annotations.Nullable;
 
 public class CSVExportModularTask extends AbstractTask implements ProcessedItemsCounter {
 
-  public static final String DATAFILE_PREFIX = "DATAFILE";
+  public static final String DATAFILE_PREFIX = "datafile";
   private static final Logger logger = Logger.getLogger(CSVExportModularTask.class.getName());
   private final ModularFeatureList[] featureLists;
   // parameter values

--- a/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularTask.java
@@ -67,6 +67,7 @@ public class CSVExportModularTask extends AbstractTask implements ProcessedItems
   private final String idSeparator;
   private final String headerSeparator = ":";
   private final FeatureListRowsFilter filter;
+  private final boolean removeEmptyCols;
   private int processedRows = 0, totalRows = 0;
 
   // track number of exported items
@@ -80,6 +81,7 @@ public class CSVExportModularTask extends AbstractTask implements ProcessedItems
     fieldSeparator = parameters.getParameter(CSVExportModularParameters.fieldSeparator).getValue();
     idSeparator = parameters.getParameter(CSVExportModularParameters.idSeparator).getValue();
     this.filter = parameters.getParameter(CSVExportModularParameters.filter).getValue();
+    removeEmptyCols = parameters.getValue(CSVExportModularParameters.omitEmptyColumns);
   }
 
   /**
@@ -91,7 +93,7 @@ public class CSVExportModularTask extends AbstractTask implements ProcessedItems
    */
   public CSVExportModularTask(ModularFeatureList[] featureLists, File fileName,
       String fieldSeparator, String idSeparator, FeatureListRowsFilter filter,
-      @NotNull Instant moduleCallDate) {
+      boolean removeEmptyCols, @NotNull Instant moduleCallDate) {
     super(null, moduleCallDate); // no new data stored -> null
     if (fieldSeparator.equals(idSeparator)) {
       throw new IllegalArgumentException(MessageFormat.format(
@@ -102,6 +104,7 @@ public class CSVExportModularTask extends AbstractTask implements ProcessedItems
     this.fieldSeparator = fieldSeparator;
     this.idSeparator = idSeparator;
     this.filter = filter;
+    this.removeEmptyCols = removeEmptyCols;
   }
 
   @Override
@@ -331,8 +334,8 @@ public class CSVExportModularTask extends AbstractTask implements ProcessedItems
   private String getJoinedHeader(List<DataType> types, String prefix) {
     StringBuilder b = new StringBuilder();
     for (DataType t : types) {
-      String header = (prefix == null || prefix.isEmpty() ? "" : prefix + headerSeparator)
-                      + t.getHeaderString();
+      String header =
+          (prefix == null || prefix.isEmpty() ? "" : prefix + headerSeparator) + t.getUniqueID();
       if (t instanceof SubColumnsFactory subCols) {
         int numberOfSub = subCols.getNumberOfSubColumns();
         for (int i = 0; i < numberOfSub; i++) {
@@ -340,7 +343,7 @@ public class CSVExportModularTask extends AbstractTask implements ProcessedItems
           if (subType != null && !filterType(subType)) {
             continue;
           }
-          String field = subCols.getHeader(i);
+          String field = subCols.getUniqueID(i);
           if (b.length() != 0) {
             b.append(fieldSeparator);
           }

--- a/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularTask.java
@@ -361,12 +361,19 @@ public class CSVExportModularTask extends AbstractTask implements ProcessedItems
    */
   private boolean modelContainData(ModularDataModel data, DataType type, int sub) {
     final Object mainVal = data.get(type);
-    if (mainVal != null) {
-      return sub == -1 || (type instanceof SubColumnsFactory subFactory
-          && subFactory.getSubColValue(sub, mainVal) != null);
+    if (sub == -1) {
+      return containsData(mainVal);
     }
-    return false;
+    if (type instanceof SubColumnsFactory subFactory) {
+      return containsData(subFactory.getSubColValue(sub, mainVal));
+    }
+    throw new IllegalStateException("Reached invalid case when checking for data");
   }
+
+  private boolean containsData(Object val) {
+    return val != null && !(val instanceof String sval && sval.isBlank());
+  }
+
 
   /**
    * Join headers by field separator and sub data types by headerSeparator (Standard is colon :)

--- a/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularTask.java
@@ -24,7 +24,6 @@ import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.datamodel.features.ModularDataModel;
 import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
-import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.datamodel.features.types.DataType;
 import io.github.mzmine.datamodel.features.types.LinkedGraphicalType;
 import io.github.mzmine.datamodel.features.types.modifiers.NoTextColumn;
@@ -388,93 +387,6 @@ public class CSVExportModularTask extends AbstractTask implements ProcessedItems
       }
     }
     return false;
-  }
-
-  private String joinRowData(ModularFeatureListRow row, List<RawDataFile> raws,
-      List<DataType> rowTypes, List<DataType> featureTypes) {
-    StringBuilder b = new StringBuilder();
-    joinData(b, row, rowTypes);
-
-    // add feature types
-    for (RawDataFile raw : raws) {
-      ModularFeature feature = row.getFeature(raw);
-      if (feature != null) {
-        joinData(b, feature, featureTypes);
-      } else {
-        // no feature for this sample - add empty cells
-        joinEmptyCells(b, featureTypes);
-      }
-    }
-    return b.toString();
-  }
-
-  /**
-   * Fills in empty cells for all data types and their sub types
-   *
-   * @param b         the string builder
-   * @param dataTypes the list of types (with sub types) that are empty
-   */
-  private void joinEmptyCells(StringBuilder b, List<DataType> dataTypes) {
-    for (DataType t : dataTypes) {
-      if (t instanceof SubColumnsFactory subCols) {
-        int numberOfSub = subCols.getNumberOfSubColumns();
-        for (int i = 0; i < numberOfSub; i++) {
-          DataType sub = subCols.getType(i);
-          if (sub != null && !filterType(sub)) {
-            continue;
-          }
-          b.append(fieldSeparator);
-        }
-      } else {
-        b.append(fieldSeparator);
-      }
-    }
-  }
-
-  /**
-   * @param b
-   * @param data  {@link ModularFeatureListRow}, {@link ModularFeature} might be null if not set
-   * @param types
-   * @return
-   */
-  private void joinData(StringBuilder b, @Nullable ModularDataModel data, List<DataType> types) {
-    for (DataType type : types) {
-      if (type instanceof SubColumnsFactory subCols) {
-        Object value = data == null ? null : data.get(type);
-        if (value == null) {
-          value = type.getDefaultValue();
-        }
-        int numberOfSub = subCols.getNumberOfSubColumns();
-        for (int i = 0; i < numberOfSub; i++) {
-          DataType<?> subType = subCols.getType(i);
-          if (subType != null && !filterType(subType)) {
-            continue;
-          }
-          String field = subCols.getFormattedSubColValue(i, value);
-          if (b.length() != 0) {
-            b.append(fieldSeparator);
-          }
-          b.append(csvEscape(field));
-        }
-      } else {
-        Object value = data == null ? null : data.get(type);
-        if (value == null) {
-          value = type.getDefaultValue();
-        }
-        if (b.length() != 0) {
-          b.append(fieldSeparator);
-        }
-        String str;
-        try {
-          str = type.getFormattedString(value);
-        } catch (Exception e) {
-          logger.log(Level.FINEST,
-              "Cannot format value of type " + type.getClass().getName() + " value: " + value, e);
-          str = "";
-        }
-        b.append(csvEscape(str));
-      }
-    }
   }
 
 

--- a/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularTask.java
@@ -48,7 +48,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.ConcurrentModificationException;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -329,9 +328,10 @@ public class CSVExportModularTask extends AbstractTask implements ProcessedItems
     if (data == null) {
       return "";
     }
-    Object value = Objects.requireNonNullElse(
-        data == null ? null : data.get((DataType) subColFactory),
-        ((DataType) subColFactory).getDefaultValue());
+    Object value = data == null ? null : data.get((DataType) subColFactory);
+    if (value == null) {
+      value = ((DataType) subColFactory).getDefaultValue();
+    }
     return csvEscape(subColFactory.getFormattedSubColValue(col, value));
   }
 
@@ -339,8 +339,10 @@ public class CSVExportModularTask extends AbstractTask implements ProcessedItems
     if (data == null) {
       return "";
     }
-    Object value = Objects.requireNonNullElse(data == null ? null : data.get(type),
-        type.getDefaultValue());
+    Object value = data == null ? null : data.get(type);
+    if (value == null) {
+      value = type.getDefaultValue();
+    }
     try {
       return csvEscape(type.getFormattedString(value));
     } catch (Exception e) {

--- a/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularTask.java
@@ -271,8 +271,6 @@ public class CSVExportModularTask extends AbstractTask implements ProcessedItems
    */
   private void addFormattedColumnsRecursively(List<String[]> formattedCols,
       List<FeatureListRow> rows, @Nullable RawDataFile raw, DataType type) {
-    final Stream<? extends ModularDataModel> dataStream = getDataStream(rows, raw, false);
-
     if (type instanceof SubColumnsFactory subFactory) {
       int subCols = subFactory.getNumberOfSubColumns();
       for (int s = 0; s < subCols; s++) {
@@ -284,12 +282,12 @@ public class CSVExportModularTask extends AbstractTask implements ProcessedItems
         }
         // collect column data
         final int subIndex = s;
-        String[] column = dataStream.map(data -> getFormattedValue(data, subFactory, subIndex))
-            .toArray(String[]::new);
+        String[] column = getDataStream(rows, raw, false).map(
+            data -> getFormattedValue(data, subFactory, subIndex)).toArray(String[]::new);
         formattedCols.add(column);
       }
     } else {
-      String[] column = dataStream.map(data -> getFormattedValue(data, type))
+      String[] column = getDataStream(rows, raw, false).map(data -> getFormattedValue(data, type))
           .toArray(String[]::new);
       formattedCols.add(column);
     }

--- a/src/main/java/io/github/mzmine/modules/io/export_features_csv/TableFormat.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_csv/TableFormat.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2006-2021 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+package io.github.mzmine.modules.io.export_features_csv;
+
+/**
+ * @author Robin Schmid (https://github.com/robinschmid)
+ */
+public enum TableFormat {
+  /**
+   * The standard table format that mzmine uses for display with columns for each type
+   */
+  WIDE,
+  /**
+   * AN export format where each type is a new row in the table: Columns are:
+   * feature_id,sample,type,value
+   */
+  LONG;
+
+}

--- a/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/FeatureTableExportType.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/FeatureTableExportType.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2006-2021 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+package io.github.mzmine.modules.io.export_features_gnps.fbmn;
+
+/**
+ * @author Robin Schmid (https://github.com/robinschmid)
+ */
+public enum FeatureTableExportType {
+  /**
+   * all types in MZmine 3 format
+   */
+  COMPREHENSIVE,
+  /**
+   * SIMPLE, MZmine 2 csv type export
+   */
+  SIMPLE,
+  /**
+   * Export both
+   */
+  ALL;
+}

--- a/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnExportAndSubmitParameters.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnExportAndSubmitParameters.java
@@ -64,7 +64,7 @@ public class GnpsFbmnExportAndSubmitParameters extends SimpleParameterSet {
   public static final ComboParameter<FeatureTableExportType> CSV_TYPE = new ComboParameter<>(
       "CSV export",
       "Either the new comprehensive export of MZmine 3 or the legacy export from MZmine 2",
-      FeatureTableExportType.values(), FeatureTableExportType.COMPREHENSIVE);
+      FeatureTableExportType.values(), FeatureTableExportType.SIMPLE);
   public static final ComboParameter<FeatureMeasurementType> FEATURE_INTENSITY = new ComboParameter<>(
       "Feature intensity", "Intensity in the quantification table (csv).",
       FeatureMeasurementType.values(), FeatureMeasurementType.AREA);

--- a/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnExportAndSubmitParameters.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnExportAndSubmitParameters.java
@@ -48,45 +48,41 @@ import org.jetbrains.annotations.NotNull;
 
 public class GnpsFbmnExportAndSubmitParameters extends SimpleParameterSet {
 
+  public static final FeatureListsParameter FEATURE_LISTS = new FeatureListsParameter();
+  public static final OptionalModuleParameter<GnpsFbmnSubmitParameters> SUBMIT = new OptionalModuleParameter<>(
+      "Submit to GNPS", "Directly submits a GNPS job", new GnpsFbmnSubmitParameters());
+  public static final ComboParameter<FeatureListRowsFilter> FILTER = new ComboParameter<>(
+      "Filter rows",
+      "Limit the exported rows to those with MS/MS data or annotated rows (with ion identity)",
+      FeatureListRowsFilter.values(), FeatureListRowsFilter.MS2_OR_ION_IDENTITY);
+  public static final BooleanParameter OPEN_FOLDER = new BooleanParameter("Open folder",
+      "Opens the export folder", false);
+  public static final OptionalModuleParameter<MsMsSpectraMergeParameters> MERGE_PARAMETER = new OptionalModuleParameter<>(
+      "Merge MS/MS (experimental)",
+      "Merge high-quality MS/MS instead of exporting just the most intense one.",
+      new MsMsSpectraMergeParameters(), true);
+  public static final ComboParameter<FeatureTableExportType> CSV_TYPE = new ComboParameter<>(
+      "CSV export",
+      "Either the new comprehensive export of MZmine 3 or the legacy export from MZmine 2",
+      FeatureTableExportType.values(), FeatureTableExportType.COMPREHENSIVE);
+  public static final ComboParameter<FeatureMeasurementType> FEATURE_INTENSITY = new ComboParameter<>(
+      "Feature intensity", "Intensity in the quantification table (csv).",
+      FeatureMeasurementType.values(), FeatureMeasurementType.AREA);
   private static final List<ExtensionFilter> extensions = List.of( //
       new ExtensionFilter("MGF mascot file (spectra)", "*.mgf"), //
       new ExtensionFilter("All files", "*.*") //
   );
-
-
-  public static final FeatureListsParameter FEATURE_LISTS = new FeatureListsParameter();
-
   public static final FileNameParameter FILENAME = new FileNameParameter("Filename",
       "Base name of the output files (.MGF and .CSV). "
-      + "Use pattern \"{}\" in the file name to substitute with feature list name. "
-      + "(i.e. \"blah{}blah.mgf\" would become \"blahSourceFeatureListNameblah.mgf\"). "
-      + "If the file already exists, it will be overwritten.",
-      extensions, FileSelectionType.SAVE);
-
-  public static final OptionalModuleParameter<GnpsFbmnSubmitParameters> SUBMIT =
-      new OptionalModuleParameter<>("Submit to GNPS",
-          "Directly submits a GNPS job", new GnpsFbmnSubmitParameters());
-
-  public static final ComboParameter<FeatureListRowsFilter> FILTER = new ComboParameter<>(
-      "Filter rows", "Limit the exported rows to those with MS/MS data or annotated rows (with ion identity)",
-      FeatureListRowsFilter.values(), FeatureListRowsFilter.MS2_OR_ION_IDENTITY);
-
-  public static final BooleanParameter OPEN_FOLDER =
-      new BooleanParameter("Open folder", "Opens the export folder", false);
-
-  public static final OptionalModuleParameter<MsMsSpectraMergeParameters> MERGE_PARAMETER =
-      new OptionalModuleParameter<>("Merge MS/MS (experimental)",
-          "Merge high-quality MS/MS instead of exporting just the most intense one.",
-          new MsMsSpectraMergeParameters(), true);
-
-  public static final ComboParameter<FeatureMeasurementType> FEATURE_INTENSITY =
-      new ComboParameter<>("Feature intensity", "Intensity in the quantification table (csv).",
-          FeatureMeasurementType.values(), FeatureMeasurementType.AREA);
+          + "Use pattern \"{}\" in the file name to substitute with feature list name. "
+          + "(i.e. \"blah{}blah.mgf\" would become \"blahSourceFeatureListNameblah.mgf\"). "
+          + "If the file already exists, it will be overwritten.", extensions,
+      FileSelectionType.SAVE);
 
 
   public GnpsFbmnExportAndSubmitParameters() {
-    super(new Parameter[]{FEATURE_LISTS, FILENAME, MERGE_PARAMETER, FILTER, FEATURE_INTENSITY, SUBMIT,
-        OPEN_FOLDER});
+    super(new Parameter[]{FEATURE_LISTS, FILENAME, MERGE_PARAMETER, FILTER, FEATURE_INTENSITY,
+        CSV_TYPE, SUBMIT, OPEN_FOLDER});
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnExportAndSubmitTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnExportAndSubmitTask.java
@@ -65,6 +65,7 @@ public class GnpsFbmnExportAndSubmitTask extends AbstractTask {
   private final File baseFile;
   private final ModularFeatureList[] featureLists;
   private final int totalSteps = 4;
+  private final FeatureTableExportType csvType;
   private int currentStep = 0;
   private Task currentTask;
   private String currentDescription = "Export to GNPS FBMN and IIMN";
@@ -76,6 +77,7 @@ public class GnpsFbmnExportAndSubmitTask extends AbstractTask {
     featureLists = parameters.getParameter(GnpsFbmnExportAndSubmitParameters.FEATURE_LISTS)
         .getValue().getMatchingFeatureLists();
     featureMeasure = parameters.getValue(GnpsFbmnExportAndSubmitParameters.FEATURE_INTENSITY);
+    csvType = parameters.getValue(GnpsFbmnExportAndSubmitParameters.CSV_TYPE);
     baseFile = FileAndPathUtil.eraseFormat(
         parameters.getValue(GnpsFbmnExportAndSubmitParameters.FILENAME));
     parameters.getParameter(GnpsFbmnExportAndSubmitParameters.FILENAME).setValue(baseFile);
@@ -131,26 +133,32 @@ public class GnpsFbmnExportAndSubmitTask extends AbstractTask {
       return;
     }
 
+    int csvLineCount = 0;
+    final boolean allCSV = FeatureTableExportType.ALL.equals(csvType);
     // add old csv quant table for old FBMN support
-    currentDescription = "Exporting GNPS legacy csv format (simple csv)";
-    currentTask = addLegacyQuantTableTask(parameters);
-    currentTask.run();
-    currentStep++;
-    int csvLegacyCount = ((ProcessedItemsCounter) currentTask).getProcessedItems();
+    if (allCSV || FeatureTableExportType.SIMPLE.equals(csvType)) {
+      currentDescription = "Exporting GNPS legacy csv format (simple csv)";
+      currentTask = addLegacyQuantTableTask(parameters);
+      currentTask.run();
+      currentStep++;
 
-    if (checkTaskCanceledOrFailed()) {
-      return;
+      csvLineCount = ((ProcessedItemsCounter) currentTask).getProcessedItems();
+      if (checkTaskCanceledOrFailed()) {
+        return;
+      }
     }
 
     // add new csv export for whole table
-    currentDescription = "Exporting MZmine csv format (complete feature table csv)";
-    currentTask = addFullQuantTableTask(parameters);
-    currentTask.run();
-    currentStep++;
-    int csvCount = ((ProcessedItemsCounter) currentTask).getProcessedItems();
+    if (allCSV || FeatureTableExportType.COMPREHENSIVE.equals(csvType)) {
+      currentDescription = "Exporting MZmine csv format (complete feature table csv)";
+      currentTask = addFullQuantTableTask(parameters);
+      currentTask.run();
+      currentStep++;
 
-    if (checkTaskCanceledOrFailed()) {
-      return;
+      csvLineCount = ((ProcessedItemsCounter) currentTask).getProcessedItems();
+      if (checkTaskCanceledOrFailed()) {
+        return;
+      }
     }
 
     // add csv extra edges
@@ -167,14 +175,14 @@ public class GnpsFbmnExportAndSubmitTask extends AbstractTask {
     final File folder = baseFile.getParentFile();
     // csv count is always the same
     // MGF and csv only of MS2 is required for export
-    if (csvCount == csvLegacyCount && (!filter.requiresMS2() || csvCount == mgfCount)) {
+    if (!filter.requiresMS2() || csvLineCount == mgfCount) {
       logger.log(Level.INFO,
-          String.format("GNPS export succeeded. mgf MS2=%d;  csv rows=%d", mgfCount, csvCount));
+          String.format("GNPS export succeeded. mgf MS2=%d;  csv rows=%d", mgfCount, csvLineCount));
       currentDescription = "All GNPS exports successful";
     } else {
       final String error = String.format(
           "GNPS export resulted in files with different length despite using the same filter. Try to use this module manually after running a batch. mgf MS2=%d;  csv rows=%d",
-          mgfCount, csvCount);
+          mgfCount, csvLineCount);
       currentDescription = "Error during csv export";
       logger.log(Level.WARNING, error);
       setErrorMessage(error);
@@ -245,7 +253,8 @@ public class GnpsFbmnExportAndSubmitTask extends AbstractTask {
     FeatureListRowsFilter filter = parameters.getParameter(GnpsFbmnExportAndSubmitParameters.FILTER)
         .getValue();
 
-    return new CSVExportModularTask(featureLists, full, ",", ";", filter, getModuleCallDate());
+    return new CSVExportModularTask(featureLists, full, ",", ";", filter, true,
+        getModuleCallDate());
   }
 
 

--- a/src/main/java/io/github/mzmine/modules/io/export_features_gnps/gc/GnpsGcExportAndSubmitTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_gnps/gc/GnpsGcExportAndSubmitTask.java
@@ -244,8 +244,8 @@ public class GnpsGcExportAndSubmitTask extends AbstractTask {
     FeatureListRowsFilter filter =
         parameters.getParameter(GnpsFbmnExportAndSubmitParameters.FILTER).getValue();
 
-    CSVExportModularTask quanExportModular = new CSVExportModularTask(flist, full, ",", ";",
-        filter, getModuleCallDate());
+    CSVExportModularTask quanExportModular = new CSVExportModularTask(flist, full, ",", ";", filter,
+        true, getModuleCallDate());
 
     if (tasks != null) {
       tasks.add(quanExportModular);

--- a/src/main/java/io/github/mzmine/util/FeatureListRowSorter.java
+++ b/src/main/java/io/github/mzmine/util/FeatureListRowSorter.java
@@ -25,10 +25,13 @@ import java.util.Comparator;
 
 /**
  * Compare feature list rows either by ID, average m/z or median area of peaks
- * 
  */
 public class FeatureListRowSorter implements Comparator<FeatureListRow> {
-  public static final FeatureListRowSorter DEFAULT = new FeatureListRowSorter(SortingProperty.RT, SortingDirection.Ascending);
+
+  public static final FeatureListRowSorter DEFAULT_RT = new FeatureListRowSorter(SortingProperty.RT,
+      SortingDirection.Ascending);
+  public static final FeatureListRowSorter DEFAULT_ID = new FeatureListRowSorter(SortingProperty.ID,
+      SortingDirection.Ascending);
 
   private SortingProperty property;
   private SortingDirection direction;

--- a/src/test/java/MZmineTestUtil.java
+++ b/src/test/java/MZmineTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2020 The MZmine Development Team
+ * Copyright 2006-2021 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -8,11 +8,12 @@
  * License, or (at your option) any later version.
  *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
- * Public License for more details.
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
  */
 
 import com.google.common.collect.Comparators;
@@ -118,7 +119,7 @@ public class MZmineTestUtil {
    * @return
    */
   public static boolean isSorted(FeatureList flist) {
-    return Comparators.isInOrder(flist.getRows(), FeatureListRowSorter.DEFAULT);
+    return Comparators.isInOrder(flist.getRows(), FeatureListRowSorter.DEFAULT_RT);
   }
 
   public static void cleanProject() {


### PR DESCRIPTION
### Based on some feedback for the beta version:
- in FBMN: option to export only simple MZmine 2 feature table - or comprehensive MZmine 3 table (which is very complex for some people and simple downstream pipelines) 

### ModularCSVExport: 
- restructure module to make it clearer
- option to exclude empty columns
- use DataType.getUniqueID instead of getHeader for the column header as it is better parsable in pyhton and R  