### PR TITLE
Final naming of DataType.uniqueID

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/features/types/FeatureGroupType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/FeatureGroupType.java
@@ -33,7 +33,7 @@ public class FeatureGroupType extends DataType<RowGroup> {
   @Override
   public final String getUniqueID() {
     // Never change the ID for compatibility during saving/loading of type
-    return "feature_row_group";
+    return "feature_group";
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/datamodel/features/types/IsotopePatternType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/IsotopePatternType.java
@@ -43,7 +43,7 @@ public class IsotopePatternType extends DataType<IsotopePattern> {
   @Override
   public final String getUniqueID() {
     // Never change the ID for compatibility during saving/loading of type
-    return "isotope_pattern";
+    return "isotopes";
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/datamodel/features/types/annotations/CompoundDatabaseMatchesType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/annotations/CompoundDatabaseMatchesType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2020 The MZmine Development Team
+ * Copyright 2006-2021 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -8,11 +8,12 @@
  * License, or (at your option) any later version.
  *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
- * Public License for more details.
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
  */
 
 package io.github.mzmine.datamodel.features.types.annotations;
@@ -74,7 +75,7 @@ public class CompoundDatabaseMatchesType extends ListWithSubsType<CompoundDBAnno
 
   @Override
   public @NotNull String getUniqueID() {
-    return "compound_database_identity";
+    return "compound_db_identity";
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/datamodel/features/types/annotations/SpectralLibraryMatchesType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/annotations/SpectralLibraryMatchesType.java
@@ -93,7 +93,7 @@ public class SpectralLibraryMatchesType extends
   @Override
   public final String getUniqueID() {
     // Never change the ID for compatibility during saving/loading of type
-    return "spectral_lib_matches";
+    return "spectral_db_matches";
   }
 
   @NotNull

--- a/src/main/java/io/github/mzmine/datamodel/features/types/annotations/compounddb/Structure3dUrlType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/annotations/compounddb/Structure3dUrlType.java
@@ -1,19 +1,19 @@
 /*
- *  Copyright 2006-2020 The MZmine Development Team
+ * Copyright 2006-2021 The MZmine Development Team
  *
- *  This file is part of MZmine.
+ * This file is part of MZmine.
  *
- *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
- *  General Public License as published by the Free Software Foundation; either version 2 of the
- *  License, or (at your option) any later version.
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
  *
- *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
- *  Public License for more details.
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License along with MZmine; if not,
- *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
- *  USA
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
  */
 
 package io.github.mzmine.datamodel.features.types.annotations.compounddb;
@@ -26,7 +26,7 @@ public class Structure3dUrlType extends UrlType implements NullColumnType {
 
   @Override
   public @NotNull String getUniqueID() {
-    return "structure_3d_url_type";
+    return "structure_3d_url";
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/datamodel/features/types/annotations/formula/ConsensusFormulaListType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/annotations/formula/ConsensusFormulaListType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2020 The MZmine Development Team
+ * Copyright 2006-2021 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -8,11 +8,12 @@
  * License, or (at your option) any later version.
  *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
- * Public License for more details.
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
  */
 
 package io.github.mzmine.datamodel.features.types.annotations.formula;
@@ -36,7 +37,7 @@ public class ConsensusFormulaListType extends ListDataType<ResultFormula>
   @Override
   public final String getUniqueID() {
     // Never change the ID for compatibility during saving/loading of type
-    return "consensus_formula_list";
+    return "consensus_formulas";
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/datamodel/features/types/annotations/formula/FormulaListType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/annotations/formula/FormulaListType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2020 The MZmine Development Team
+ * Copyright 2006-2021 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -8,11 +8,12 @@
  * License, or (at your option) any later version.
  *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
- * Public License for more details.
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
  */
 
 package io.github.mzmine.datamodel.features.types.annotations.formula;
@@ -78,7 +79,7 @@ public class FormulaListType extends ListWithSubsType<ResultFormula> implements
   @Override
   public final String getUniqueID() {
     // Never change the ID for compatibility during saving/loading of type
-    return "formula_annotation";
+    return "formulas";
   }
 
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/annotations/formula/FormulaType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/annotations/formula/FormulaType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2020 The MZmine Development Team
+ * Copyright 2006-2021 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -8,11 +8,12 @@
  * License, or (at your option) any later version.
  *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
- * Public License for more details.
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
  */
 
 package io.github.mzmine.datamodel.features.types.annotations.formula;
@@ -38,7 +39,8 @@ public class FormulaType extends StringType
   @Override
   public final String getUniqueID() {
     // Never change the ID for compatibility during saving/loading of type
-    return "formula";
+    // do not mistake with formulas from {@link FormulaListType}
+    return "mol_formula";
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/datamodel/features/types/annotations/formula/SimpleFormulaListType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/annotations/formula/SimpleFormulaListType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2020 The MZmine Development Team
+ * Copyright 2006-2021 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -8,11 +8,12 @@
  * License, or (at your option) any later version.
  *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
- * Public License for more details.
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
  */
 
 package io.github.mzmine.datamodel.features.types.annotations.formula;
@@ -34,7 +35,8 @@ public class SimpleFormulaListType extends ListDataType<ResultFormula>
   @Override
   public final String getUniqueID() {
     // Never change the ID for compatibility during saving/loading of type
-    return "formula_list";
+    // do not mistake with formulas from {@link FormulaListType}
+    return "simple_formulas";
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/datamodel/features/types/annotations/iin/IonAdductType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/annotations/iin/IonAdductType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2020 The MZmine Development Team
+ * Copyright 2006-2021 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -8,11 +8,12 @@
  * License, or (at your option) any later version.
  *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
- * Public License for more details.
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
  */
 
 package io.github.mzmine.datamodel.features.types.annotations.iin;
@@ -52,7 +53,7 @@ public class IonAdductType extends StringType
   @Override
   public final String getUniqueID() {
     // Never change the ID for compatibility during saving/loading of type
-    return "ion_adduct";
+    return "adduct";
   }
 
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/annotations/iin/IonIdentityListType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/annotations/iin/IonIdentityListType.java
@@ -142,7 +142,7 @@ public class IonIdentityListType extends ListWithSubsType<IonIdentity> implement
   @Override
   public final String getUniqueID() {
     // Never change the ID for compatibility during saving/loading of type
-    return "ion_identity_list";
+    return "ion_identities";
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/datamodel/features/types/annotations/iin/IonNetworkIDType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/annotations/iin/IonNetworkIDType.java
@@ -45,7 +45,7 @@ public class IonNetworkIDType extends IntegerType {
   @Override
   public final String getUniqueID() {
     // Never change the ID for compatibility during saving/loading of type
-    return "ion_network_id";
+    return "iin_id";
   }
 
   @NotNull

--- a/src/main/java/io/github/mzmine/datamodel/features/types/annotations/iin/IonTypeType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/annotations/iin/IonTypeType.java
@@ -1,19 +1,19 @@
 /*
- *  Copyright 2006-2020 The MZmine Development Team
+ * Copyright 2006-2021 The MZmine Development Team
  *
- *  This file is part of MZmine.
+ * This file is part of MZmine.
  *
- *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
- *  General Public License as published by the Free Software Foundation; either version 2 of the
- *  License, or (at your option) any later version.
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
  *
- *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
- *  Public License for more details.
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License along with MZmine; if not,
- *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
- *  USA
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
  */
 
 package io.github.mzmine.datamodel.features.types.annotations.iin;
@@ -41,7 +41,7 @@ public class IonTypeType extends DataType<IonType> {
 
   @Override
   public @NotNull String getUniqueID() {
-    return "ion_type_type";
+    return "adduct";
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/datamodel/features/types/annotations/iin/SimpleIonIdentityListType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/annotations/iin/SimpleIonIdentityListType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2020 The MZmine Development Team
+ * Copyright 2006-2021 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -8,11 +8,12 @@
  * License, or (at your option) any later version.
  *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
- * Public License for more details.
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
  */
 
 package io.github.mzmine.datamodel.features.types.annotations.iin;
@@ -40,6 +41,6 @@ public class SimpleIonIdentityListType extends ListDataType<IonIdentity>
   @Override
   public final String getUniqueID() {
     // Never change the ID for compatibility during saving/loading of type
-    return "ion_identity_list_simple";
+    return "ion_identities_simple";
   }
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/AreaRangeType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/AreaRangeType.java
@@ -30,7 +30,7 @@ public class AreaRangeType extends IntensityRangeType {
   @Override
   public final String getUniqueID() {
     // Never change the ID for compatibility during saving/loading of type
-    return "intensity_range";
+    return "area_range";
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/CCSRelativeErrorType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/CCSRelativeErrorType.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2006-2021 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
 package io.github.mzmine.datamodel.features.types.numbers;
 
 import io.github.mzmine.datamodel.features.types.numbers.abstr.FloatType;
@@ -18,7 +36,7 @@ public class CCSRelativeErrorType extends FloatType {
   @Override
   public @NotNull String getUniqueID() {
     // Never change the ID for compatibility during saving/loading of type
-    return "collisional_cross_section_relative_error";
+    return "ccs_percent_error";
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/CCSType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/CCSType.java
@@ -44,7 +44,7 @@ public class CCSType extends FloatType {
   @Override
   public final String getUniqueID() {
     // Never change the ID for compatibility during saving/loading of type
-    return "collisional_cross_section";
+    return "ccs";
   }
 
   @NotNull

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/FragmentScanNumbersType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/FragmentScanNumbersType.java
@@ -41,7 +41,7 @@ public class FragmentScanNumbersType extends ScanNumbersType {
   @Override
   public final String getUniqueID() {
     // Never change the ID for compatibility during saving/loading of type
-    return "fragment_scan_number_list";
+    return "fragment_scans";
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/FwhmType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/FwhmType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2020 The MZmine Development Team
+ * Copyright 2006-2021 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -8,11 +8,12 @@
  * License, or (at your option) any later version.
  *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
- * Public License for more details.
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
  */
 
 package io.github.mzmine.datamodel.features.types.numbers;
@@ -36,7 +37,7 @@ public class FwhmType extends FloatType {
   @Override
   public final String getUniqueID() {
     // Never change the ID for compatibility during saving/loading of type
-    return "full_width_at_half_maximum";
+    return "fwhm";
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/MzAbsoluteDifferenceType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/MzAbsoluteDifferenceType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2020 The MZmine Development Team
+ * Copyright 2006-2021 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -8,11 +8,12 @@
  * License, or (at your option) any later version.
  *
  * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
- * Public License for more details.
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
  */
 
 package io.github.mzmine.datamodel.features.types.numbers;
@@ -38,7 +39,7 @@ public class MzAbsoluteDifferenceType extends DoubleType {
   @Override
   public final String getUniqueID() {
     // Never change the ID for compatibility during saving/loading of type
-    return "mz_diff_absolute";
+    return "mz_diff";
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/SizeType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/SizeType.java
@@ -30,7 +30,7 @@ public class SizeType extends IntegerType {
   @Override
   public final String getUniqueID() {
     // Never change the ID for compatibility during saving/loading of type
-    return "number_of_elements";
+    return "list_size";
   }
 
   @NotNull


### PR DESCRIPTION
Those IDs should be as short as possible while still understood by most without much thinking. We will use them as column headers in the CSV export and in the project export. So they should not change after we release for good.

fwhm, ccs, ... should be okay to abbreviate in my view