### PR TITLE
fix invalid PaintScale range causing chart freeze

### DIFF
--- a/src/main/java/io/github/mzmine/gui/chartbasics/chartutils/paintscales/PaintScale.java
+++ b/src/main/java/io/github/mzmine/gui/chartbasics/chartutils/paintscales/PaintScale.java
@@ -91,11 +91,9 @@ public class PaintScale extends LookupPaintScale {
 
   private static double getValidUpperBound(double lower, double upper) {
     final double diff = upper - lower;
-    if (Double.compare(diff, 0d) != 0) {
+    if (Double.compare(diff, 0d) > 0) {
       return upper;
     }
-    final double valid = upper + 0.1;
-    assert Double.compare(lower, valid) < 0;
-    return valid;
+    return lower + 0.1d;
   }
 }

--- a/src/main/java/io/github/mzmine/gui/chartbasics/chartutils/paintscales/PaintScale.java
+++ b/src/main/java/io/github/mzmine/gui/chartbasics/chartutils/paintscales/PaintScale.java
@@ -48,7 +48,8 @@ public class PaintScale extends LookupPaintScale {
       PaintScaleBoundStyle paintScaleBoundStyle, Range<Double> scaleRange, Color color) {
     // we add a minimum value on top of the upper endpoint to avoid errors for empty datasets
     // with lower==upper value
-    super(scaleRange.lowerEndpoint(), scaleRange.upperEndpoint() + 0.1d, color);
+    super(scaleRange.lowerEndpoint(),
+        getValidUpperBound(scaleRange.lowerEndpoint(), scaleRange.upperEndpoint()), color);
     this.paintScaleColorStyle = paintScaleColorStyle;
     this.paintScaleBoundStyle = paintScaleBoundStyle;
   }

--- a/src/main/java/io/github/mzmine/gui/chartbasics/chartutils/paintscales/PaintScale.java
+++ b/src/main/java/io/github/mzmine/gui/chartbasics/chartutils/paintscales/PaintScale.java
@@ -34,7 +34,8 @@ public class PaintScale extends LookupPaintScale {
   public PaintScale(Range<Double> scaleRange) {
     // we add a minimum value on top of the upper endpoint to avoid errors for empty datasets
     // with lower==upper value
-    super(scaleRange.lowerEndpoint(), scaleRange.upperEndpoint() + Double.MIN_VALUE,
+    super(scaleRange.lowerEndpoint(),
+        getValidUpperBound(scaleRange.lowerEndpoint(), scaleRange.upperEndpoint()),
         new Color(0, 0, 0, 0f));
   }
 
@@ -47,7 +48,7 @@ public class PaintScale extends LookupPaintScale {
       PaintScaleBoundStyle paintScaleBoundStyle, Range<Double> scaleRange, Color color) {
     // we add a minimum value on top of the upper endpoint to avoid errors for empty datasets
     // with lower==upper value
-    super(scaleRange.lowerEndpoint(), scaleRange.upperEndpoint() + Double.MIN_VALUE, color);
+    super(scaleRange.lowerEndpoint(), scaleRange.upperEndpoint() + 0.1d, color);
     this.paintScaleColorStyle = paintScaleColorStyle;
     this.paintScaleBoundStyle = paintScaleBoundStyle;
   }
@@ -85,5 +86,15 @@ public class PaintScale extends LookupPaintScale {
     }
 
     return super.getPaint(value);
+  }
+
+  private static double getValidUpperBound(double lower, double upper) {
+    final double diff = upper - lower;
+    if (Double.compare(diff, 0d) != 0) {
+      return upper;
+    }
+    final double valid = upper + 0.1;
+    assert Double.compare(lower, valid) < 0;
+    return valid;
   }
 }


### PR DESCRIPTION
it appears Double.MIN_VALUE caused an infinite loop. Increased to 0.1 now and added an assertion to check. If the assertion is triggered anyway, it should preventthe gui from crashing.