### PR TITLE
Tdf pseudo-profile import, allow re-merging of frame spectra

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/impl/AbstractStorableSpectrum.java
+++ b/src/main/java/io/github/mzmine/datamodel/impl/AbstractStorableSpectrum.java
@@ -18,6 +18,7 @@
 
 package io.github.mzmine.datamodel.impl;
 
+import io.github.mzmine.datamodel.Frame;
 import io.github.mzmine.datamodel.featuredata.impl.StorageUtils;
 import io.github.mzmine.util.MemoryMapStorage;
 import java.nio.DoubleBuffer;
@@ -64,8 +65,11 @@ public abstract class AbstractStorableSpectrum extends AbstractMassSpectrum {
 
     assert mzValues.length == intensityValues.length;
     // values shall not be reset, but can be set at a later stage
-    assert this.mzValues == null;
-    assert this.intensityValues == null;
+    if(!(this instanceof Frame)) {
+      // allow re-generation of frame spectra
+      assert this.mzValues == null;
+      assert this.intensityValues == null;
+    }
 
     for (int i = 0; i < mzValues.length - 1; i++) {
       if (mzValues[i] > mzValues[i + 1]) {

--- a/src/main/java/io/github/mzmine/datamodel/impl/MobilityScanStorage.java
+++ b/src/main/java/io/github/mzmine/datamodel/impl/MobilityScanStorage.java
@@ -25,6 +25,8 @@ import io.github.mzmine.datamodel.featuredata.impl.SimpleIonMobilogramTimeSeries
 import io.github.mzmine.datamodel.featuredata.impl.StorageUtils;
 import io.github.mzmine.datamodel.impl.masslist.StoredMobilityScanMassList;
 import io.github.mzmine.modules.dataprocessing.featdet_massdetection.MassDetector;
+import io.github.mzmine.modules.dataprocessing.featdet_massdetection.centroid.CentroidMassDetector;
+import io.github.mzmine.modules.dataprocessing.featdet_massdetection.centroid.CentroidMassDetectorParameters;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.util.MemoryMapStorage;
 import java.nio.DoubleBuffer;
@@ -106,6 +108,18 @@ public class MobilityScanStorage {
    */
   public void generateAndAddMobilityScanMassLists(@Nullable MemoryMapStorage storage,
       @NotNull MassDetector massDetector, @NotNull ParameterSet massDetectorParameters) {
+
+    if (massDetector instanceof CentroidMassDetector &&
+        Double.compare(massDetectorParameters.getValue(CentroidMassDetectorParameters.noiseLevel),
+            0d) == 0) {
+      // no need to run mass detection in this case.
+      massListBasePeakIndices = rawBasePeakIndices;
+      massListMaxNumPoints = rawMaxNumPoints;
+      massListMzValues = rawMzValues;
+      massListIntensityValues = rawIntensityValues;
+      massListStorageOffsets = rawStorageOffsets;
+      return;
+    }
 
     // mobility scan -> [0][] = mzs, [1][] = intensities
     final List<double[][]> data = new ArrayList<>();

--- a/src/main/java/io/github/mzmine/main/MZmineArgumentParser.java
+++ b/src/main/java/io/github/mzmine/main/MZmineArgumentParser.java
@@ -43,6 +43,7 @@ public class MZmineArgumentParser {
   private File preferencesFile;
   private File tempDirectory;
   private boolean isKeepRunningAfterBatch = false;
+  private boolean loadTdfPseudoProfile = false;
   private KeepInMemory isKeepInMemory = null;
 
   public void parse(String[] args) {
@@ -71,6 +72,11 @@ public class MZmineArgumentParser {
     keepInMemory.setRequired(false);
     options.addOption(keepInMemory);
 
+    Option loadTdfPseudoProfile = new Option("tdfpseudoprofile", false,
+        "Loads pseudo-profile frame spectra for tdf files instead of centroided spectra.");
+    loadTdfPseudoProfile.setRequired(false);
+    options.addOption(loadTdfPseudoProfile);
+
     CommandLineParser parser = new BasicParser();
     HelpFormatter formatter = new HelpFormatter();
     CommandLine cmd;
@@ -93,7 +99,7 @@ public class MZmineArgumentParser {
       if (stemp != null) {
         logger.info(
             () -> "Temp directory set by command line, will override all other definitions: "
-                  + stemp);
+                + stemp);
         tempDirectory = new File(stemp);
       }
 
@@ -107,9 +113,12 @@ public class MZmineArgumentParser {
       String keepInData = cmd.getOptionValue(keepInMemory.getLongOpt());
       if (keepInData != null) {
         isKeepInMemory = KeepInMemory.parse(keepInData);
-        logger.info(
-            () -> "the -m / --memory argument was set to " + isKeepInMemory.toString()
-                  + " to keep objects in RAM (scan data, features, etc) which are otherwise stored in memory mapped ");
+        logger.info(() -> "the -m / --memory argument was set to " + isKeepInMemory.toString()
+            + " to keep objects in RAM (scan data, features, etc) which are otherwise stored in memory mapped ");
+      }
+
+      if(cmd.hasOption(loadTdfPseudoProfile.getOpt())) {
+        this.loadTdfPseudoProfile = true;
       }
 
     } catch (ParseException e) {
@@ -158,5 +167,8 @@ public class MZmineArgumentParser {
     return isKeepInMemory;
   }
 
+  public boolean isLoadTdfPseudoProfile() {
+    return loadTdfPseudoProfile;
+  }
 }
 

--- a/src/main/java/io/github/mzmine/main/MZmineCore.java
+++ b/src/main/java/io/github/mzmine/main/MZmineCore.java
@@ -87,6 +87,7 @@ public final class MZmineCore {
   private Desktop desktop;
   private ProjectManagerImpl projectManager;
   private boolean headLessMode = true;
+  private boolean tdfPseudoProfile = false;
   // batch exit code is only set if run in headless mode with batch file
   private ExitCode batchExitCode = null;
 
@@ -125,6 +126,7 @@ public final class MZmineCore {
 
       MZmineArgumentParser argsParser = new MZmineArgumentParser();
       argsParser.parse(args);
+      getInstance().tdfPseudoProfile = argsParser.isLoadTdfPseudoProfile();
 
       // override preferences file by command line argument pref
       final File prefFile = Objects.requireNonNullElse(argsParser.getPreferencesFile(),
@@ -460,5 +462,9 @@ public final class MZmineCore {
 
     projectManager.initModule();
     taskController.initModule();
+  }
+
+  public boolean isTdfPseudoProfile() {
+    return tdfPseudoProfile;
   }
 }

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/TDFImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/TDFImportTask.java
@@ -290,7 +290,7 @@ public class TDFImportTask extends AbstractTask {
         setFinishedPercentage(0.1 * (loadedFrames) / numFrames);
         setDescription(
             "Importing " + rawDataFileName + ": Averaging Frame " + frameId + "/" + numFrames);
-        SimpleFrame frame = // profile frame import disabled
+        SimpleFrame frame =
             !importProfile ? tdfUtils.extractCentroidScanForTimsFrame(newMZmineFile,
                 frameId, metaDataTable, frameTable, framePrecursorTable, maldiFrameInfoTable,
                 ms1Detector, ms1DetectorParam, ms2Detector, ms2DetectorParam)

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/TDFImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/TDFImportTask.java
@@ -290,13 +290,16 @@ public class TDFImportTask extends AbstractTask {
         setFinishedPercentage(0.1 * (loadedFrames) / numFrames);
         setDescription(
             "Importing " + rawDataFileName + ": Averaging Frame " + frameId + "/" + numFrames);
-        SimpleFrame frame =
-            !importProfile ? tdfUtils.extractCentroidScanForTimsFrame(newMZmineFile,
-                frameId, metaDataTable, frameTable, framePrecursorTable, maldiFrameInfoTable,
-                ms1Detector, ms1DetectorParam, ms2Detector, ms2DetectorParam)
-                : tdfUtils.extractProfileScanForFrame(newMZmineFile, frameId, metaDataTable,
-                    frameTable, framePrecursorTable, maldiFrameInfoTable, ms1Detector,
-                    ms1DetectorParam, ms2Detector, ms2DetectorParam);
+        final SimpleFrame frame;
+        if (!importProfile) {
+          frame = tdfUtils.extractCentroidScanForTimsFrame(newMZmineFile, frameId, metaDataTable,
+              frameTable, framePrecursorTable, maldiFrameInfoTable, ms1Detector, ms1DetectorParam,
+              ms2Detector, ms2DetectorParam);
+        } else {
+          frame = tdfUtils.extractProfileScanForFrame(newMZmineFile, frameId, metaDataTable,
+              frameTable, framePrecursorTable, maldiFrameInfoTable, ms1Detector, ms1DetectorParam,
+              ms2Detector, ms2DetectorParam);
+        }
 
         if (frame.getMSLevel() == 1 && ms1Detector != null && ms1DetectorParam != null) {
           frame.addMassList(new ScanPointerMassList(frame));
@@ -445,10 +448,6 @@ public class TDFImportTask extends AbstractTask {
 
       frame.setMobilityScans(spectra, detector != null);
 
-      /*if (detector != null && param != null) {
-        frame.getMobilityScans().forEach(m -> m.addMassList(new ScanPointerMassList(m)));
-      }*/
-
       if (isCanceled()) {
         return;
       }
@@ -456,30 +455,6 @@ public class TDFImportTask extends AbstractTask {
     }
 
   }
-
-  /*private void appendScansFromMaldiTimsSegment(@NotNull final IMSRawDataFile rawDataFile,
-      final long handle, final long firstFrameId, final long lastFrameId,
-      @NotNull final TDFFrameTable tdfFrameTable, @NotNull final TDFMetaDataTable tdfMetaDataTable,
-      @NotNull final TDFMaldiFrameInfoTable tdfMaldiTable) {
-
-    final long numFrames = tdfFrameTable.lastFrameId();
-
-    for (long frameId = firstFrameId; frameId <= lastFrameId; frameId++) {
-      setDescription("Importing " + rawDataFileName + ": Frame " + frameId + "/" + numFrames);
-      setFinishedPercentage(0.9 * frameId / numFrames);
-      final List<Scan> scans = TDFUtils.loadScansForMaldiTimsFrame(handle, frameId, tdfFrameTable,
-          tdfMetaDataTable, tdfMaldiTable);
-
-      try {
-        for (Scan scan : scans) {
-          rawDataFile.addScan(scan);
-        }
-      } catch (IOException e) {
-        e.printStackTrace();
-        TDFUtils.close(handle);
-      }
-    }
-  }*/
 
   private File[] getDataFilesFromDir(File dir) {
 

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/TDFImportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/TDFImportTask.java
@@ -76,10 +76,14 @@ public class TDFImportTask extends AbstractTask {
   private static final Logger logger = Logger.getLogger(TDFImportTask.class.getName());
 
   private final MZmineProject project;
-  @Nullable private final MassDetector ms1Detector;
-  @Nullable private final MassDetector ms2Detector;
-  @Nullable private final ParameterSet ms1DetectorParam;
-  @Nullable private final ParameterSet ms2DetectorParam;
+  @Nullable
+  private final MassDetector ms1Detector;
+  @Nullable
+  private final MassDetector ms2Detector;
+  @Nullable
+  private final ParameterSet ms1DetectorParam;
+  @Nullable
+  private final ParameterSet ms2DetectorParam;
 
   private final boolean denoising = false;
   private static final double NOISE_THRESHOLD = 9E0;
@@ -277,15 +281,22 @@ public class TDFImportTask extends AbstractTask {
     loadedFrames = 0;
     // collect average spectra for each frame
     Set<SimpleFrame> frames = new LinkedHashSet<>();
+
+   final boolean importProfile = MZmineCore.getInstance().isTdfPseudoProfile();
+
     try {
       for (int i = 0; i < numFrames; i++) {
         int frameId = frameTable.getFrameIdColumn().get(i).intValue();
         setFinishedPercentage(0.1 * (loadedFrames) / numFrames);
         setDescription(
             "Importing " + rawDataFileName + ": Averaging Frame " + frameId + "/" + numFrames);
-        SimpleFrame frame = tdfUtils.extractCentroidScanForTimsFrame(newMZmineFile, frameId,
-            metaDataTable, frameTable, framePrecursorTable, maldiFrameInfoTable, ms1Detector,
-            ms1DetectorParam, ms2Detector, ms2DetectorParam);
+        SimpleFrame frame = // profile frame import disabled
+            !importProfile ? tdfUtils.extractCentroidScanForTimsFrame(newMZmineFile,
+                frameId, metaDataTable, frameTable, framePrecursorTable, maldiFrameInfoTable,
+                ms1Detector, ms1DetectorParam, ms2Detector, ms2DetectorParam)
+                : tdfUtils.extractProfileScanForFrame(newMZmineFile, frameId, metaDataTable,
+                    frameTable, framePrecursorTable, maldiFrameInfoTable, ms1Detector,
+                    ms1DetectorParam, ms2Detector, ms2DetectorParam);
 
         if (frame.getMSLevel() == 1 && ms1Detector != null && ms1DetectorParam != null) {
           frame.addMassList(new ScanPointerMassList(frame));

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/TDFUtils.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/TDFUtils.java
@@ -493,8 +493,7 @@ public class TDFUtils {
   }
 
   /**
-   * @return
-   * @deprecated not ready yet, yields to wrong m/z values. How does bruker distribute them?
+   * @return A pseudo profile spectrum
    */
   public SimpleFrame extractProfileScanForFrame(IMSRawDataFile newFile, final long frameId,
       @NotNull final TDFMetaDataTable metaDataTable, @NotNull final TDFFrameTable frameTable,

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/TDFUtils.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/TDFUtils.java
@@ -496,7 +496,6 @@ public class TDFUtils {
    * @return
    * @deprecated not ready yet, yields to wrong m/z values. How does bruker distribute them?
    */
-  @Deprecated
   public SimpleFrame extractProfileScanForFrame(IMSRawDataFile newFile, final long frameId,
       @NotNull final TDFMetaDataTable metaDataTable, @NotNull final TDFFrameTable frameTable,
       @NotNull final FramePrecursorTable framePrecursorTable,

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/TDFUtils.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/TDFUtils.java
@@ -42,6 +42,8 @@ import io.github.mzmine.modules.io.import_rawdata_bruker_tdf.datamodel.sql.TDFMe
 import io.github.mzmine.modules.io.import_rawdata_imzml.Coordinates;
 import io.github.mzmine.modules.io.import_rawdata_mzml.ConversionUtils;
 import io.github.mzmine.parameters.ParameterSet;
+import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -89,10 +91,14 @@ public class TDFUtils {
    * @param size The size
    * @return the array
    */
-  public static int[] createPopulatedArray(final int size) {
+  public static int[] createPopulatedArrayFrom1(final int size) {
+    return createPopulatedArray(size, 1); // scannums start at 1
+  }
+
+  public static int[] createPopulatedArray(final int size, int startOffset) {
     int[] array = new int[size];
     for (int i = 0; i < size; i++) {
-      array[i] = i + 1; // scannums start at 1
+      array[i] = i + startOffset;
     }
     return array;
   }
@@ -311,6 +317,9 @@ public class TDFUtils {
       }
       Arrays.fill(buffer, (byte) 0);
     }
+    if(dataPoints.get(0)[0].length != 0) {
+      logger.finest("data");
+    }
     return dataPoints;
   }
 
@@ -440,7 +449,7 @@ public class TDFUtils {
     }
 
     final double[] mobilities = convertScanNumsToOneOverK0(handle, frameId,
-        createPopulatedArray(numScans));
+        createPopulatedArrayFrom1(numScans));
 
     Range<Double> mzRange = metaDataTable.getMzRange();
 
@@ -466,7 +475,7 @@ public class TDFUtils {
   }
 
   @Nullable
-  public ProfileData extractProfileForFrame(final long frameId, final long startScanNum,
+  public int[] extractProfileForFrame(final long frameId, final long startScanNum,
       final long endScanNum) {
 
     final ProfileData data = new ProfileData();
@@ -479,41 +488,91 @@ public class TDFUtils {
         return null;
       }
 
-      return data;
+      return data.getIntensities();
     }
   }
 
   /**
-   * @param handle
-   * @param frameId
-   * @param scanNum
-   * @param metaDataTable
-   * @param frameTable
    * @return
    * @deprecated not ready yet, yields to wrong m/z values. How does bruker distribute them?
    */
-  /*
-   * @Deprecated public static Scan extractProfileScanForFrame(final long handle, final long
-   * frameId, final int scanNum, final TDFMetaDataTable metaDataTable, final TDFFrameTable
-   * frameTable) {
-   *
-   * final int frameIndex = frameTable.getFrameIdColumn().indexOf(frameId); final int numScans =
-   * frameTable.getNumScansColumn().get(frameIndex).intValue(); final ProfileData data =
-   * extractProfileForFrame(handle, frameId, 0, numScans); final String scanDefinition =
-   * metaDataTable.getInstrumentType() + " - " +
-   * BrukerScanMode.fromScanMode(frameTable.getScanModeColumn().get(frameIndex).intValue()); final
-   * int msLevel = getMZmineMsLevelFromBrukerMsMsType(
-   * frameTable.getMsMsTypeColumn().get(frameIndex).intValue()); final PolarityType polarity =
-   * PolarityType .fromSingleChar((String)
-   * frameTable.getColumn(TDFFrameTable.POLARITY).get(frameIndex));
-   *
-   * final DataPoint[] dps = data.toDataPoints(metaDataTable.getMzRange().lowerEndpoint(),
-   * metaDataTable.getMzRange().upperEndpoint());
-   *
-   * return new SimpleScan(null, scanNum, msLevel, (float)
-   * (frameTable.getTimeColumn().get(frameIndex) / 60), // to minutes 0.d, 0, dps,
-   * MassSpectrumType.CENTROIDED, polarity, scanDefinition, metaDataTable.getMzRange()); }
-   */
+  @Deprecated
+  public SimpleFrame extractProfileScanForFrame(IMSRawDataFile newFile, final long frameId,
+      @NotNull final TDFMetaDataTable metaDataTable, @NotNull final TDFFrameTable frameTable,
+      @NotNull final FramePrecursorTable framePrecursorTable,
+      @Nullable final TDFMaldiFrameInfoTable maldiFrameInfoTable,
+      @Nullable final MassDetector ms1Detector, @Nullable final ParameterSet ms1Param,
+      @Nullable final MassDetector ms2Detector, @Nullable final ParameterSet ms2Param) {
+
+    final int frameIndex = frameTable.getFrameIdColumn().indexOf(frameId);
+    final int numScans = frameTable.getNumScansColumn().get(frameIndex).intValue();
+    final String scanDefinition =
+        metaDataTable.getInstrumentType() + " - " + BrukerScanMode.fromScanMode(
+            frameTable.getScanModeColumn().get(frameIndex).intValue());
+    final int msLevel = getMZmineMsLevelFromBrukerMsMsType(
+        frameTable.getMsMsTypeColumn().get(frameIndex).intValue());
+    final PolarityType polarity = PolarityType.fromSingleChar(
+        (String) frameTable.getColumn(TDFFrameTable.POLARITY).get(frameIndex));
+    final Range<Double> mzRange = metaDataTable.getMzRange();
+
+    final int[] intensityData = extractProfileForFrame(frameId, 0, numScans);
+
+    // remove all extra zeros
+    final IntArrayList filteredMzIndices = new IntArrayList();
+    final DoubleArrayList filteredIntensities = new DoubleArrayList();
+    filteredMzIndices.add(0);
+    filteredIntensities.add(intensityData[0]);
+    for (int i = 1; i < intensityData.length - 1;
+        i++) { // previous , this and next are zero --> do not add this data point
+      if (intensityData[i - 1] != 0 || intensityData[i] != 0 || intensityData[i + 1] != 0) {
+        filteredMzIndices.add(i);
+        filteredIntensities.add(intensityData[i]);
+      }
+    }
+    filteredMzIndices.add(intensityData.length - 1);
+    filteredIntensities.add(intensityData[intensityData.length - 1]);
+
+    final double[] profileMzs = convertIndicesToMZ(handle, frameId,
+        filteredMzIndices.toIntArray());
+
+    final double data[][];
+    boolean massesDetected = false;
+    if (msLevel == 1 && ms1Detector != null && ms1Param != null) {
+      data = ms1Detector.getMassValues(profileMzs,
+          filteredIntensities.toDoubleArray(), ms1Param);
+      massesDetected = true;
+    } else if (msLevel == 2 && ms2Detector != null && ms2Param != null) {
+      data = ms2Detector.getMassValues(profileMzs,
+          filteredIntensities.toDoubleArray(), ms2Param);
+      massesDetected = true;
+    } else {
+      data = new double[2][];
+      data[0] = profileMzs;
+      data[1] = filteredIntensities.toDoubleArray();
+    }
+
+    SimpleFrame frame;
+    if (maldiFrameInfoTable == null || maldiFrameInfoTable.getFrameIdColumn().isEmpty()) {
+      frame = new SimpleFrame(newFile, Math.toIntExact(frameId), msLevel,
+          (float) (frameTable.getTimeColumn().get(frameIndex) / 60), // to minutes
+          data[0], data[1], massesDetected ? MassSpectrumType.CENTROIDED : MassSpectrumType.PROFILE,
+          polarity, scanDefinition, mzRange, MobilityType.TIMS, null);
+    } else {
+      frame = new SimpleImagingFrame(newFile, Math.toIntExact(frameId), msLevel,
+          (float) (frameTable.getTimeColumn().get(frameIndex) / 60), // to minutes
+          data[0], data[1], massesDetected ? MassSpectrumType.CENTROIDED : MassSpectrumType.PROFILE,
+          polarity, scanDefinition, mzRange, MobilityType.TIMS, null);
+      Coordinates coords = new Coordinates(maldiFrameInfoTable.getTransformedXIndexPos(frameIndex),
+          maldiFrameInfoTable.getTransformedYIndexPos(frameIndex), 0);
+      ((SimpleImagingFrame) frame).setCoordinates(coords);
+    }
+
+    final double[] mobilities = convertScanNumsToOneOverK0(handle, frameId,
+        createPopulatedArrayFrom1(numScans));
+    frame.setMobilities(mobilities);
+
+    return frame;
+  }
 
   // ---------------------------------------------------------------------------------------------
   // PASEF MS MS FUNCTIONS

--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/datamodel/callbacks/ProfileData.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/datamodel/callbacks/ProfileData.java
@@ -19,8 +19,6 @@
 package io.github.mzmine.modules.io.import_rawdata_bruker_tdf.datamodel.callbacks;
 
 import com.sun.jna.Pointer;
-import io.github.mzmine.datamodel.DataPoint;
-import io.github.mzmine.datamodel.impl.SimpleDataPoint;
 
 public class ProfileData implements ProfileCallback {
 
@@ -37,16 +35,7 @@ public class ProfileData implements ProfileCallback {
     this.userData = userData;
   }
 
-  public DataPoint[] toDataPoints(double lowMass, double highMass) {
-    assert highMass > lowMass;
-    double range = highMass - lowMass;
-    double step = range/num_points;
-
-    DataPoint[] dps = new DataPoint[(int) num_points];
-
-    for(int i = 0; i < num_points; i++) {
-      dps[i] = new SimpleDataPoint(lowMass + step * i, intensities[i]);
-    }
-    return dps;
+  public int[] getIntensities() {
+    return intensities;
   }
 }


### PR DESCRIPTION
- enabled pseudo-profile import for tdf raw data via command line "-tdfpseudoprofile" (no argument)
  - currently no reason to use this over the centroid import other than testing purposes -> disabled by default and not exposed to the users
- allow merging of mobility scans to frames even if frame data already exists