### PR TITLE
prevent tdf import from infinite loop on corrupt data

### DIFF
--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/TDFUtils.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/TDFUtils.java
@@ -654,8 +654,11 @@ public class TDFUtils {
         final String errorMessage = new String(errorBuffer, "UTF-8");
         logger.fine(() -> "Last TDF import error: " + errorMessage + " length: " + len
             + ". Required buffer size: " + errorCode + " actual size: " + BUFFER_SIZE);
+        if(errorMessage.contains("CorruptFrameDataError")) {
+          throw new IllegalStateException("Error reading tdf raw data. " + errorMessage);
+        }
       } catch (UnsupportedEncodingException e) {
-        e.printStackTrace();
+        logger.log(Level.WARNING, e.getMessage(), e);
       }
       return true;
     } else {


### PR DESCRIPTION
- tdf went into infinite loop when a corrupt frame was in the data
- same method is also used to check for the adequate buffer size, so i just added a message check that throws an exception when corrupt data is found