### PR TITLE
Fix baseline resolver

### DIFF
--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/AbstractResolver.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/AbstractResolver.java
@@ -78,6 +78,10 @@ public abstract class AbstractResolver implements Resolver {
     file = flist.getRawDataFile(0);
   }
 
+  public RawDataFile getRawDataFile() {
+    return file;
+  }
+
   @Override
   public @NotNull <T extends IonTimeSeries<? extends Scan>> List<T> resolve(@NotNull T series,
       @Nullable MemoryMapStorage storage) {

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/FeatureResolverSetupDialog.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/FeatureResolverSetupDialog.java
@@ -377,7 +377,8 @@ public class FeatureResolverSetupDialog extends ParameterSetupDialogWithPreview 
           int resolvedFeatureCounter = 0;
           SimpleColorPalette palette = MZmineCore.getConfiguration().getDefaultColorPalette();
 
-          if (resolver == null) {
+          if (resolver == null || (flistBox.getValue() != null
+              && resolver.getRawDataFile() != flistBox.getValue().getRawDataFile(0))) {
             resolver = ((GeneralResolverParameters) parameterSet).getResolver(parameterSet,
                 (ModularFeatureList) flistBox.getValue());
           }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/FeatureResolverTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/FeatureResolverTask.java
@@ -425,6 +425,7 @@ public class FeatureResolverTask extends AbstractTask {
     processedRows = 0;
     totalRows = originalFeatureList.getNumberOfRows();
     int peakId = 1;
+    final Integer minNumDp = parameters.getValue(GeneralResolverParameters.MIN_NUMBER_OF_DATAPOINTS);
 
     for (int i = 0; i < totalRows; i++) {
       final ModularFeatureListRow originalRow = (ModularFeatureListRow) originalFeatureList.getRow(
@@ -434,7 +435,6 @@ public class FeatureResolverTask extends AbstractTask {
       final ResolvedPeak[] peaks = resolver.resolvePeaks(originalFeature, parameters, rSession,
           mzCenterFunction, msmsRange, RTRangeMSMS);
 
-      final Integer minNumDp = parameters.getValue(GeneralResolverParameters.MIN_NUMBER_OF_DATAPOINTS);
       for (final ResolvedPeak peak : peaks) {
         if(peak.getScanNumbers().length < minNumDp) {
           continue;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/FeatureResolverTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/FeatureResolverTask.java
@@ -434,7 +434,11 @@ public class FeatureResolverTask extends AbstractTask {
       final ResolvedPeak[] peaks = resolver.resolvePeaks(originalFeature, parameters, rSession,
           mzCenterFunction, msmsRange, RTRangeMSMS);
 
+      final Integer minNumDp = parameters.getValue(GeneralResolverParameters.MIN_NUMBER_OF_DATAPOINTS);
       for (final ResolvedPeak peak : peaks) {
+        if(peak.getScanNumbers().length < minNumDp) {
+          continue;
+        }
         peak.setParentChromatogramRowID(originalRow.getID());
         final ModularFeatureListRow newRow = new ModularFeatureListRow(resolvedFeatureList,
             peakId++);

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/GeneralResolverParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/GeneralResolverParameters.java
@@ -24,6 +24,7 @@ import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
 import io.github.mzmine.parameters.parametertypes.ComboParameter;
+import io.github.mzmine.parameters.parametertypes.IntegerParameter;
 import io.github.mzmine.parameters.parametertypes.OriginalFeatureListHandlingParameter;
 import io.github.mzmine.parameters.parametertypes.StringParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
@@ -56,6 +57,9 @@ public abstract class GeneralResolverParameters extends SimpleParameterSet {
   public static final ComboParameter<REngineType> RENGINE_TYPE = new ComboParameter<REngineType>(
       "R engine", "The R engine to be used for communicating with R.", REngineType.values(),
       REngineType.RCALLER);
+
+  public static final IntegerParameter MIN_NUMBER_OF_DATAPOINTS = new IntegerParameter(
+      "Min # of data points", "Minimum number of data points on a feature", 3, true);
 
   public GeneralResolverParameters(Parameter[] parameters) {
     super(parameters);

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/ResolvedPeak.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/ResolvedPeak.java
@@ -102,7 +102,7 @@ public class ResolvedPeak implements PlotXYDataProvider {
   public ResolvedPeak(Feature chromatogram, int regionStart, int regionEnd,
       CenterFunction mzCenterFunction, double msmsRange, float RTRangeMSMS) {
 
-    assert regionEnd > regionStart;
+    assert regionEnd >= regionStart;
 
     this.peakList = chromatogram.getFeatureList();
     this.dataFile = chromatogram.getRawDataFile();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/Resolver.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/Resolver.java
@@ -19,6 +19,7 @@
 package io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution;
 
 import com.google.common.collect.Range;
+import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.featuredata.IntensitySeries;
 import io.github.mzmine.datamodel.featuredata.IonTimeSeries;
@@ -67,6 +68,8 @@ public interface Resolver {
    */
   @NotNull <T extends IonTimeSeries<? extends Scan>> List<T> resolve(@NotNull T series,
       @Nullable MemoryMapStorage storage);
+
+  public RawDataFile getRawDataFile();
 
   @NotNull Class<? extends MZmineModule> getModuleClass();
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/baseline/BaselineFeatureResolver.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/baseline/BaselineFeatureResolver.java
@@ -68,10 +68,11 @@ public class BaselineFeatureResolver implements FeatureResolver {
       final Scan scanNum = scanNumbers.get(i);
       retentionTimes[i] = scanNum.getRetentionTime();
       DataPoint dp = chromatogram.getDataPointAtIndex(i);
-      if (dp != null)
+      if (dp != null) {
         intensities[i] = dp.getIntensity();
-      else
+      } else {
         intensities[i] = 0.0;
+      }
     }
 
     // Get parameters.
@@ -93,8 +94,8 @@ public class BaselineFeatureResolver implements FeatureResolver {
 
         // Search for end of the region
         int currentRegionEnd;
-        for (currentRegionEnd =
-            currentRegionStart + 1; currentRegionEnd < scanCount; currentRegionEnd++) {
+        for (currentRegionEnd = currentRegionStart + 1; currentRegionEnd < scanCount;
+            currentRegionEnd++) {
 
           final DataPoint endPeak = chromatogram.getDataPointAtIndex(currentRegionEnd);
           if (endPeak == null || endPeak.getIntensity() < baselineLevel) {
@@ -110,13 +111,14 @@ public class BaselineFeatureResolver implements FeatureResolver {
         currentRegionEnd--;
 
         // Check current region, if it makes a good peak.
-        if (currentRegionEnd - currentRegionStart > 0 && durationRange
-            .contains(retentionTimes[currentRegionEnd] - retentionTimes[currentRegionStart])
+        if (durationRange.contains(
+            retentionTimes[currentRegionEnd] - retentionTimes[currentRegionStart])
             && currentRegionHeight >= minimumPeakHeight) {
 
           // Create a new ResolvedPeak and add it.
-          resolvedPeaks.add(new ResolvedPeak(chromatogram, currentRegionStart, currentRegionEnd,
-              mzCenterFunction, msmsRange, rTRangeMSMS));
+          resolvedPeaks.add(
+              new ResolvedPeak(chromatogram, currentRegionStart, currentRegionEnd, mzCenterFunction,
+                  msmsRange, rTRangeMSMS));
         }
 
         // Find next peak region, starting from next data point.

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/baseline/BaselineFeatureResolver.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/baseline/BaselineFeatureResolver.java
@@ -110,7 +110,7 @@ public class BaselineFeatureResolver implements FeatureResolver {
         currentRegionEnd--;
 
         // Check current region, if it makes a good peak.
-        if (durationRange
+        if (currentRegionEnd - currentRegionStart > 0 && durationRange
             .contains(retentionTimes[currentRegionEnd] - retentionTimes[currentRegionStart])
             && currentRegionHeight >= minimumPeakHeight) {
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/baseline/BaselineFeatureResolverParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/baseline/BaselineFeatureResolverParameters.java
@@ -44,7 +44,7 @@ public class BaselineFeatureResolverParameters extends GeneralResolverParameters
 
   public BaselineFeatureResolverParameters() {
     super(new Parameter[]{PEAK_LISTS, SUFFIX, handleOriginal, groupMS2Parameters, MIN_PEAK_HEIGHT,
-        PEAK_DURATION, BASELINE_LEVEL});
+        PEAK_DURATION, BASELINE_LEVEL, MIN_NUMBER_OF_DATAPOINTS});
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/centwave/CentWaveResolverParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/centwave/CentWaveResolverParameters.java
@@ -88,7 +88,7 @@ public class CentWaveResolverParameters extends GeneralResolverParameters {
   public CentWaveResolverParameters() {
 
     super(new Parameter[]{PEAK_LISTS, SUFFIX, handleOriginal, groupMS2Parameters, SN_THRESHOLD,
-        PEAK_SCALES, PEAK_DURATION, INTEGRATION_METHOD, RENGINE_TYPE});
+        PEAK_SCALES, PEAK_DURATION, INTEGRATION_METHOD, RENGINE_TYPE, MIN_NUMBER_OF_DATAPOINTS});
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/minimumsearch/MinimumSearchFeatureResolverParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/minimumsearch/MinimumSearchFeatureResolverParameters.java
@@ -29,7 +29,6 @@ import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.impl.IonMobilitySupport;
 import io.github.mzmine.parameters.parametertypes.DoubleParameter;
-import io.github.mzmine.parameters.parametertypes.IntegerParameter;
 import io.github.mzmine.parameters.parametertypes.PercentParameter;
 import io.github.mzmine.parameters.parametertypes.ranges.DoubleRangeParameter;
 import io.github.mzmine.util.ExitCode;
@@ -67,10 +66,6 @@ public class MinimumSearchFeatureResolverParameters extends GeneralResolverParam
   public static final DoubleRangeParameter PEAK_DURATION = new DoubleRangeParameter(
       "Peak duration range (min/mobility)", "Range of acceptable peak lengths",
       MZmineCore.getConfiguration().getRTFormat(), Range.closed(0.0, 10.0));
-
-  public static final IntegerParameter MIN_NUMBER_OF_DATAPOINTS = new IntegerParameter(
-      "Min # of data points", "Minimum number of data points on a feature", 3, true);
-
 
   public MinimumSearchFeatureResolverParameters() {
     super(new Parameter[]{PEAK_LISTS, SUFFIX, handleOriginal, groupMS2Parameters, dimension,

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/noiseamplitude/NoiseAmplitudeFeatureResolverParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/noiseamplitude/NoiseAmplitudeFeatureResolverParameters.java
@@ -44,7 +44,7 @@ public class NoiseAmplitudeFeatureResolverParameters extends GeneralResolverPara
 
   public NoiseAmplitudeFeatureResolverParameters() {
     super(new Parameter[]{PEAK_LISTS, SUFFIX, handleOriginal, groupMS2Parameters, MIN_PEAK_HEIGHT,
-        PEAK_DURATION, NOISE_AMPLITUDE});
+        PEAK_DURATION, NOISE_AMPLITUDE, MIN_NUMBER_OF_DATAPOINTS});
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/savitzkygolay/SavitzkyGolayFeatureResolverParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/savitzkygolay/SavitzkyGolayFeatureResolverParameters.java
@@ -45,7 +45,7 @@ public class SavitzkyGolayFeatureResolverParameters extends GeneralResolverParam
 
   public SavitzkyGolayFeatureResolverParameters() {
     super(new Parameter[]{PEAK_LISTS, SUFFIX, handleOriginal, groupMS2Parameters, MIN_PEAK_HEIGHT,
-        PEAK_DURATION, DERIVATIVE_THRESHOLD_LEVEL, RENGINE_TYPE});
+        PEAK_DURATION, DERIVATIVE_THRESHOLD_LEVEL, RENGINE_TYPE, MIN_NUMBER_OF_DATAPOINTS});
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/util/FeatureConvertors.java
+++ b/src/main/java/io/github/mzmine/util/FeatureConvertors.java
@@ -345,31 +345,6 @@ public class FeatureConvertors {
           "Can not create modular feature from resolvedPeak of non-modular feature list.");
     }
 
-    ModularFeature modularFeature = new ModularFeature(featureList);
-
-    // Add values to feature
-    modularFeature.set(FragmentScanNumbersType.class, resolvedPeak.getAllMS2FragmentScanNumbers());
-    //    modularFeature.set(ScanNumbersType.class, List.of(resolvedPeak.getScanNumbers()));
-
-    modularFeature.set(BestScanNumberType.class, resolvedPeak.getRepresentativeScanNumber());
-    modularFeature.set(IsotopePatternType.class, resolvedPeak.getIsotopePattern());
-    modularFeature.set(FeatureInformationType.class, resolvedPeak.getPeakInformation());
-    modularFeature.set(ChargeType.class, resolvedPeak.getCharge());
-
-    modularFeature.set(RawFileType.class, resolvedPeak.getRawDataFile());
-    modularFeature.set(DetectionType.class, resolvedPeak.getFeatureStatus());
-    modularFeature.set(MZType.class, resolvedPeak.getMZ());
-    modularFeature.set(RTType.class, (float) resolvedPeak.getRT());
-    modularFeature.set(HeightType.class, (float) resolvedPeak.getHeight());
-    modularFeature.set(AreaType.class, (float) resolvedPeak.getArea());
-    modularFeature.set(BestScanNumberType.class, resolvedPeak.getRepresentativeScanNumber());
-
-    // Data points of feature
-    //    modularFeature.set(DataPointsType.class, resolvedPeak.getDataPoints());
-    //    SimpleIonTimeSeries timeSeries = createSimpleTimeSeries(
-    //        ((ModularFeatureList) resolvedPeak.getPeakList()).getMemoryMapStorage(),
-    //        resolvedPeak.getDataPoints().stream().collect(Collectors.toList()),
-    //        Arrays.asList(resolvedPeak.getScanNumbers()));
     IonTimeSeries<? extends Scan> resolvedData = null;
     if (originalData instanceof SimpleIonTimeSeries) {
       resolvedData = ((SimpleIonTimeSeries) originalData).subSeries(
@@ -384,38 +359,9 @@ public class FeatureConvertors {
           "Smoothing is not yet supported for this kind of data. " + originalData.getClass()
               .getName());
     }
-    modularFeature.set(FeatureDataType.class, resolvedData);
 
-    // Ranges
-    Range<Float> rtRange = Range.closed(resolvedPeak.getRawDataPointsRTRange().lowerEndpoint(),
-        resolvedPeak.getRawDataPointsRTRange().upperEndpoint());
-    Range<Double> mzRange = Range.closed(resolvedPeak.getRawDataPointsMZRange().lowerEndpoint(),
-        resolvedPeak.getRawDataPointsMZRange().upperEndpoint());
-    Range<Float> intensityRange = Range.closed(
-        resolvedPeak.getRawDataPointsIntensityRange().lowerEndpoint().floatValue(),
-        resolvedPeak.getRawDataPointsIntensityRange().upperEndpoint().floatValue());
-    modularFeature.set(MZRangeType.class, mzRange);
-    modularFeature.set(RTRangeType.class, rtRange);
-    modularFeature.set(IntensityRangeType.class, intensityRange);
-
-    // TODO this is controlled during feature deconvolution or with a module - do not get all MS2 this way
-    // modularFeature.setAllMS2FragmentScanNumbers(IntStream.of(ScanUtils
-    //    .findAllMS2FragmentScans(resolvedPeak.getRawDataFile(), rtRange, mzRange)).boxed()
-    //    .collect(Collectors.toCollection(FXCollections::observableArrayList)));
-
-    // Quality parameters
-    float fwhm = QualityParameters.calculateFWHM(modularFeature);
-    if (!Float.isNaN(fwhm)) {
-      modularFeature.set(FwhmType.class, fwhm);
-    }
-    float tf = QualityParameters.calculateTailingFactor(modularFeature);
-    if (!Float.isNaN(tf)) {
-      modularFeature.set(TailingFactorType.class, tf);
-    }
-    float af = QualityParameters.calculateAsymmetryFactor(modularFeature);
-    if (!Float.isNaN(af)) {
-      modularFeature.set(AsymmetryFactorType.class, af);
-    }
+    final ModularFeature modularFeature = new ModularFeature(featureList,
+        resolvedPeak.getRawDataFile(), resolvedData, FeatureStatus.DETECTED);
 
     return modularFeature;
   }


### PR DESCRIPTION
Assertion was triggered when there was only one data point in the resolved feature. Don't know how it was handled in MZmine 2, the assertion was there sicne 2010 (accordingto git blame)

Also fixed FeatureConvertors#ResolvedPeakToMoularFeature

Edit: fixes #612 