### PR TITLE
Update spectrallibrary

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/FeatureIdentity.java
+++ b/src/main/java/io/github/mzmine/datamodel/FeatureIdentity.java
@@ -26,11 +26,16 @@ import java.util.Map;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
+import org.jetbrains.annotations.ApiStatus.ScheduledForRemoval;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * This interface represents an identification result.
+ *
+ * To be replaced by {@link io.github.mzmine.datamodel.features.compoundannotations.FeatureAnnotation}.
  */
+@Deprecated
+@ScheduledForRemoval
 public interface FeatureIdentity extends Cloneable {
 
   public static final String XML_IDENTITY_TYPE_ATTR = "identitytype";

--- a/src/main/java/io/github/mzmine/datamodel/features/FeatureListRow.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/FeatureListRow.java
@@ -29,7 +29,7 @@ import io.github.mzmine.datamodel.features.compoundannotations.CompoundDBAnnotat
 import io.github.mzmine.datamodel.identities.iontype.IonIdentity;
 import io.github.mzmine.modules.dataprocessing.id_formulaprediction.ResultFormula;
 import io.github.mzmine.modules.dataprocessing.id_lipididentification.lipidutils.MatchedLipid;
-import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
+import io.github.mzmine.util.spectraldb.entry.SpectralDBAnnotation;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -256,7 +256,7 @@ public interface FeatureListRow extends ModularDataModel {
 
   void setCompoundAnnotations(List<CompoundDBAnnotation> annotations);
 
-  void addSpectralLibraryMatch(SpectralDBFeatureIdentity id);
+  void addSpectralLibraryMatch(SpectralDBAnnotation id);
 
   /**
    * Correlated features grouped
@@ -416,14 +416,14 @@ public interface FeatureListRow extends ModularDataModel {
    *
    * @param matches new list of matches
    */
-  void setSpectralLibraryMatch(List<SpectralDBFeatureIdentity> matches);
+  void setSpectralLibraryMatch(List<SpectralDBAnnotation> matches);
 
   /**
    * List of library matches sorted from best (index 0) to last match
    *
    * @return list of library matches or an empty list
    */
-  @NotNull List<SpectralDBFeatureIdentity> getSpectralLibraryMatches();
+  @NotNull List<SpectralDBAnnotation> getSpectralLibraryMatches();
 
   /**
    * Add annotations from lipid search
@@ -435,7 +435,7 @@ public interface FeatureListRow extends ModularDataModel {
   // -- ModularFeatureListRow additions
   Stream<ModularFeature> streamFeatures();
 
-  void addSpectralLibraryMatches(List<SpectralDBFeatureIdentity> matches);
+  void addSpectralLibraryMatches(List<SpectralDBAnnotation> matches);
 
   @Nullable Range<Float> getMobilityRange();
 

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureListRow.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureListRow.java
@@ -57,7 +57,7 @@ import io.github.mzmine.util.FeatureUtils;
 import io.github.mzmine.util.SortingDirection;
 import io.github.mzmine.util.SortingProperty;
 import io.github.mzmine.util.scans.FragmentScanSorter;
-import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
+import io.github.mzmine.util.spectraldb.entry.SpectralDBAnnotation;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -558,9 +558,9 @@ public class ModularFeatureListRow implements FeatureListRow {
   }
 
   @Override
-  public void addSpectralLibraryMatch(SpectralDBFeatureIdentity id) {
+  public void addSpectralLibraryMatch(SpectralDBAnnotation id) {
     synchronized (getMap()) {
-      List<SpectralDBFeatureIdentity> matches = get(SpectralLibraryMatchesType.class);
+      List<SpectralDBAnnotation> matches = get(SpectralLibraryMatchesType.class);
       if (matches == null) {
         matches = new ArrayList<>();
       }
@@ -570,9 +570,9 @@ public class ModularFeatureListRow implements FeatureListRow {
   }
 
   @Override
-  public void addSpectralLibraryMatches(List<SpectralDBFeatureIdentity> matches) {
+  public void addSpectralLibraryMatches(List<SpectralDBAnnotation> matches) {
     synchronized (getMap()) {
-      List<SpectralDBFeatureIdentity> old = get(SpectralLibraryMatchesType.class);
+      List<SpectralDBAnnotation> old = get(SpectralLibraryMatchesType.class);
       if (old == null) {
         old = new ArrayList<>();
       }
@@ -588,16 +588,15 @@ public class ModularFeatureListRow implements FeatureListRow {
   }
 
   @Override
-  public void setSpectralLibraryMatch(List<SpectralDBFeatureIdentity> matches) {
+  public void setSpectralLibraryMatch(List<SpectralDBAnnotation> matches) {
     synchronized (getMap()) {
       set(SpectralLibraryMatchesType.class, matches);
     }
   }
 
   @Override
-  @NotNull
-  public List<SpectralDBFeatureIdentity> getSpectralLibraryMatches() {
-    List<SpectralDBFeatureIdentity> matches = get(SpectralLibraryMatchesType.class);
+  public @NotNull List<SpectralDBAnnotation> getSpectralLibraryMatches() {
+    List<SpectralDBAnnotation> matches = get(SpectralLibraryMatchesType.class);
     return matches == null ? List.of() : matches;
   }
 

--- a/src/main/java/io/github/mzmine/datamodel/features/compoundannotations/CompoundDBAnnotation.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/compoundannotations/CompoundDBAnnotation.java
@@ -61,7 +61,7 @@ import org.jetbrains.annotations.Nullable;
 import org.openscience.cdk.interfaces.IMolecularFormula;
 import org.openscience.cdk.tools.manipulator.MolecularFormulaManipulator;
 
-public interface CompoundDBAnnotation extends Cloneable {
+public interface CompoundDBAnnotation extends Cloneable, FeatureAnnotation {
 
   Logger logger = Logger.getLogger(CompoundDBAnnotation.class.getName());
 
@@ -199,16 +199,6 @@ public interface CompoundDBAnnotation extends Cloneable {
       ModularFeatureListRow row) throws XMLStreamException;
 
   @Nullable
-  public default Double getPrecursorMZ() {
-    return get(PrecursorMZType.class);
-  }
-
-  @Nullable
-  public default String getSmiles() {
-    return get(SmilesStructureType.class);
-  }
-
-  @Nullable
   public default DatabaseMatchInfo getDatabaseMatchInfo() {
     return get(DatabaseMatchInfoType.class);
   }
@@ -219,44 +209,64 @@ public interface CompoundDBAnnotation extends Cloneable {
     return databaseMatchInfo == null ? null : databaseMatchInfo.url();
   }
 
+  @Override
   @Nullable
-  public default String getCompundName() {
+  public default Double getPrecursorMZ() {
+    return get(PrecursorMZType.class);
+  }
+
+  @Override
+  @Nullable
+  public default String getSmiles() {
+    return get(SmilesStructureType.class);
+  }
+
+  @Override
+  @Nullable
+  public default String getCompoundName() {
     return get(CompoundNameType.class);
   }
 
+  @Override
   @Nullable
   public default String getFormula() {
     return get(FormulaType.class);
   }
 
+  @Override
   @Nullable
   public default IonType getAdductType() {
     return get(IonTypeType.class);
   }
 
+  @Override
   @Nullable
   public default Float getMobility() {
     return get(MobilityType.class);
   }
 
+  @Override
   @Nullable
   public default Float getCCS() {
     return get(CCSType.class);
   }
 
+  @Override
   @Nullable
   public default Float getRT() {
     return get(RTType.class);
   }
 
-  @Nullable
-  public default String getDatabase() {
-    return get(DatabaseNameType.class);
-  }
-
+  @Override
   @Nullable
   public default Float getScore() {
     return get(CompoundAnnotationScoreType.class);
+  }
+
+  @Override
+  @Nullable
+  public default String getDatabase() {
+    return get(DatabaseNameType.class);
   }
 
   public boolean matches(FeatureListRow row, @Nullable MZTolerance mzTolerance,

--- a/src/main/java/io/github/mzmine/datamodel/features/compoundannotations/CompoundDBAnnotation.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/compoundannotations/CompoundDBAnnotation.java
@@ -64,11 +64,11 @@ import org.openscience.cdk.tools.manipulator.MolecularFormulaManipulator;
 
 public interface CompoundDBAnnotation extends Cloneable, FeatureAnnotation {
 
-  Logger logger = Logger.getLogger(CompoundDBAnnotation.class.getName());
+  public static final Logger logger = Logger.getLogger(CompoundDBAnnotation.class.getName());
 
-  String XML_ELEMENT = "compound_db_annotation";
-  String XML_TYPE_ATTRIBUTE = "annotationtype";
-  String XML_NUM_ENTRIES_ATTR = "entries";
+  public static final String XML_ELEMENT = "compound_db_annotation";
+  public static final String XML_TYPE_ATTRIBUTE = "annotationtype";
+  public static final String XML_NUM_ENTRIES_ATTR = "entries";
 
   @NotNull
   static List<CompoundDBAnnotation> buildCompoundsWithAdducts(
@@ -126,6 +126,7 @@ public interface CompoundDBAnnotation extends Cloneable, FeatureAnnotation {
   static CompoundDBAnnotation loadFromXML(@NotNull final XMLStreamReader reader,
       @NotNull final ModularFeatureList flist, @NotNull final ModularFeatureListRow row)
       throws XMLStreamException {
+    // todo refactor to be loaded via FeatureAnnotation
     if (!(reader.isStartElement() && reader.getLocalName().equals(XML_ELEMENT))) {
       throw new IllegalStateException("Invalid xml element to load CompoundDBAnnotation from.");
     }
@@ -196,9 +197,9 @@ public interface CompoundDBAnnotation extends Cloneable, FeatureAnnotation {
     return get(key);
   }
 
-  Set<DataType<?>> getTypes();
+  public Set<DataType<?>> getTypes();
 
-  void saveToXML(@NotNull XMLStreamWriter writer, ModularFeatureList flist,
+  public void saveToXML(@NotNull XMLStreamWriter writer, ModularFeatureList flist,
       ModularFeatureListRow row) throws XMLStreamException;
 
   @Nullable

--- a/src/main/java/io/github/mzmine/datamodel/features/compoundannotations/CompoundDBAnnotation.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/compoundannotations/CompoundDBAnnotation.java
@@ -1,19 +1,19 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ *  Copyright 2006-2022 The MZmine Development Team
  *
- * This file is part of MZmine.
+ *  This file is part of MZmine.
  *
- * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
- * General Public License as published by the Free Software Foundation; either version 2 of the
- * License, or (at your option) any later version.
+ *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ *  General Public License as published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
  *
- * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License for more details.
+ *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ *  Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
- *
+ *  You should have received a copy of the GNU General Public License along with MZmine; if not,
+ *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ *  USA
  */
 
 package io.github.mzmine.datamodel.features.compoundannotations;
@@ -55,7 +55,6 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -66,8 +65,8 @@ public interface CompoundDBAnnotation extends Cloneable, FeatureAnnotation {
 
   public static final Logger logger = Logger.getLogger(CompoundDBAnnotation.class.getName());
 
-  public static final String XML_ELEMENT = "compound_db_annotation";
-  public static final String XML_TYPE_ATTRIBUTE = "annotationtype";
+  public static final String XML_ELEMENT_OLD = "compound_db_annotation";
+  public static final String XML_TYPE_ATTRIBUTE_OLD = "annotationtype";
   public static final String XML_NUM_ENTRIES_ATTR = "entries";
 
   @NotNull
@@ -121,23 +120,6 @@ public interface CompoundDBAnnotation extends Cloneable, FeatureAnnotation {
     }
 
     throw new CannotDetermineMassException(annotation);
-  }
-
-  static CompoundDBAnnotation loadFromXML(@NotNull final XMLStreamReader reader,
-      @NotNull final ModularFeatureList flist, @NotNull final ModularFeatureListRow row)
-      throws XMLStreamException {
-    // todo refactor to be loaded via FeatureAnnotation
-    if (!(reader.isStartElement() && reader.getLocalName().equals(XML_ELEMENT))) {
-      throw new IllegalStateException("Invalid xml element to load CompoundDBAnnotation from.");
-    }
-
-    return switch (reader.getAttributeValue(null, XML_TYPE_ATTRIBUTE)) {
-      case SimpleCompoundDBAnnotation.XML_TYPE_NAME -> SimpleCompoundDBAnnotation.loadFromXML(
-          reader, flist, row);
-//      case BioTransformerAnnotationImpl.XML_TYPE_NAME -> BioTransformerAnnotationImpl.loadFromXML(
-//          reader, flist, row);
-      default -> null;
-    };
   }
 
   /**

--- a/src/main/java/io/github/mzmine/datamodel/features/compoundannotations/CompoundDBAnnotation.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/compoundannotations/CompoundDBAnnotation.java
@@ -51,6 +51,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.xml.stream.XMLStreamException;
@@ -194,6 +195,8 @@ public interface CompoundDBAnnotation extends Cloneable, FeatureAnnotation {
     }
     return get(key);
   }
+
+  Set<DataType<?>> getTypes();
 
   void saveToXML(@NotNull XMLStreamWriter writer, ModularFeatureList flist,
       ModularFeatureListRow row) throws XMLStreamException;

--- a/src/main/java/io/github/mzmine/datamodel/features/compoundannotations/FeatureAnnotation.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/compoundannotations/FeatureAnnotation.java
@@ -14,8 +14,8 @@ import org.jetbrains.annotations.Nullable;
 
 public interface FeatureAnnotation {
 
-  public static final String XML_ELEMENT = "featureannotation";
-  public static final String XML_TYPE_ATTR = "annotationtype";
+  public static final String XML_ELEMENT = "feature_annotation";
+  public static final String XML_TYPE_ATTR = "annotation_type";
 
   public void saveToXML(@NotNull XMLStreamWriter writer, ModularFeatureList flist,
       ModularFeatureListRow row) throws XMLStreamException;

--- a/src/main/java/io/github/mzmine/datamodel/features/compoundannotations/FeatureAnnotation.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/compoundannotations/FeatureAnnotation.java
@@ -1,6 +1,23 @@
+/*
+ *  Copyright 2006-2022 The MZmine Development Team
+ *
+ *  This file is part of MZmine.
+ *
+ *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ *  General Public License as published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
+ *
+ *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ *  Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with MZmine; if not,
+ *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ *  USA
+ */
+
 package io.github.mzmine.datamodel.features.compoundannotations;
 
-import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.datamodel.identities.iontype.IonType;
@@ -17,20 +34,23 @@ public interface FeatureAnnotation {
   public static final String XML_ELEMENT = "feature_annotation";
   public static final String XML_TYPE_ATTR = "annotation_type";
 
-  public void saveToXML(@NotNull XMLStreamWriter writer, ModularFeatureList flist,
-      ModularFeatureListRow row) throws XMLStreamException;
-
-  public static FeatureAnnotation loadFromXML(XMLStreamReader reader,
-      Collection<RawDataFile> possibleFiles) throws XMLStreamException {
+  public static FeatureAnnotation loadFromXML(XMLStreamReader reader, ModularFeatureList flist,
+      ModularFeatureListRow row) throws XMLStreamException {
     if (!(reader.isStartElement() && reader.getLocalName().equals(XML_ELEMENT))) {
       throw new IllegalStateException("Current element is not a feature annotation element");
     }
 
     return switch (reader.getAttributeValue(null, XML_TYPE_ATTR)) {
-      case SpectralDBAnnotation.XML_ATTR -> SpectralDBAnnotation.loadFromXML(reader, possibleFiles);
+      case SpectralDBAnnotation.XML_ATTR -> SpectralDBAnnotation.loadFromXML(reader,
+          flist.getRawDataFiles());
+      case SimpleCompoundDBAnnotation.XML_ATTR -> SimpleCompoundDBAnnotation.loadFromXML(reader,
+          flist, row);
       default -> null;
     };
   }
+
+  public void saveToXML(@NotNull XMLStreamWriter writer, ModularFeatureList flist,
+      ModularFeatureListRow row) throws XMLStreamException;
 
   @Nullable Double getPrecursorMZ();
 
@@ -52,4 +72,31 @@ public interface FeatureAnnotation {
 
   @Nullable String getDatabase();
 
+  /**
+   * @return A unique identifier for saving any sub-class of this interface to XML.
+   */
+  @NotNull String getXmlAttributeKey();
+
+  /**
+   * Writes an opening tag that conforms with the {@link FeatureAnnotation#loadFromXML(XMLStreamReader,
+   * Collection)} method, so the type can be recognised and delegated to the correct subclass. This
+   * allows combination of multiple different {@link FeatureAnnotation} implementations in a single
+   * list.
+   * <p></p>
+   * Uses {@link FeatureAnnotation#getXmlAttributeKey()} to write the correct tags.
+   *
+   * @param writer The writer
+   */
+  public default void writeOpeningTag(XMLStreamWriter writer) throws XMLStreamException {
+    writer.writeStartElement(FeatureAnnotation.XML_ELEMENT);
+    writer.writeAttribute(FeatureAnnotation.XML_TYPE_ATTR, getXmlAttributeKey());
+  }
+
+  /**
+   * Convenience method to supply developers with a closing method for {@link
+   * FeatureAnnotation#writeOpeningTag(XMLStreamWriter)}.
+   */
+  public default void writeClosingTag(XMLStreamWriter writer) throws XMLStreamException {
+    writer.writeEndElement();
+  }
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/compoundannotations/FeatureAnnotation.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/compoundannotations/FeatureAnnotation.java
@@ -1,0 +1,55 @@
+package io.github.mzmine.datamodel.features.compoundannotations;
+
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.features.ModularFeatureList;
+import io.github.mzmine.datamodel.features.ModularFeatureListRow;
+import io.github.mzmine.datamodel.identities.iontype.IonType;
+import io.github.mzmine.util.spectraldb.entry.SpectralDBAnnotation;
+import java.util.Collection;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.XMLStreamWriter;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public interface FeatureAnnotation {
+
+  public static final String XML_ELEMENT = "featureannotation";
+  public static final String XML_TYPE_ATTR = "annotationtype";
+
+  public void saveToXML(@NotNull XMLStreamWriter writer, ModularFeatureList flist,
+      ModularFeatureListRow row) throws XMLStreamException;
+
+  public static FeatureAnnotation loadFromXML(XMLStreamReader reader,
+      Collection<RawDataFile> possibleFiles) throws XMLStreamException {
+    if (!(reader.isStartElement() && reader.getLocalName().equals(XML_ELEMENT))) {
+      throw new IllegalStateException("Current element is not a feature annotation element");
+    }
+
+    return switch (reader.getAttributeValue(null, XML_TYPE_ATTR)) {
+      case SpectralDBAnnotation.XML_ATTR -> SpectralDBAnnotation.loadFromXML(reader, possibleFiles);
+      default -> null;
+    };
+  }
+
+  @Nullable Double getPrecursorMZ();
+
+  @Nullable String getSmiles();
+
+  @Nullable String getCompoundName();
+
+  @Nullable String getFormula();
+
+  @Nullable IonType getAdductType();
+
+  @Nullable Float getMobility();
+
+  @Nullable Float getCCS();
+
+  @Nullable Float getRT();
+
+  @Nullable Float getScore();
+
+  @Nullable String getDatabase();
+
+}

--- a/src/main/java/io/github/mzmine/datamodel/features/compoundannotations/SimpleCompoundDBAnnotation.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/compoundannotations/SimpleCompoundDBAnnotation.java
@@ -31,8 +31,6 @@ import io.github.mzmine.datamodel.features.types.annotations.compounddb.Structur
 import io.github.mzmine.datamodel.features.types.annotations.compounddb.Structure3dUrlType;
 import io.github.mzmine.datamodel.features.types.annotations.formula.FormulaType;
 import io.github.mzmine.datamodel.features.types.numbers.NeutralMassType;
-import io.github.mzmine.datamodel.identities.iontype.IonType;
-import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.dataprocessing.id_onlinecompounddb.OnlineDatabases;
 import io.github.mzmine.modules.io.projectload.version_3_0.CONST;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
@@ -41,12 +39,12 @@ import io.github.mzmine.parameters.parametertypes.tolerances.mobilitytolerance.M
 import io.github.mzmine.util.FormulaUtils;
 import io.github.mzmine.util.RangeUtils;
 import java.net.URL;
-import java.text.NumberFormat;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Set;
 import java.util.logging.Logger;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
@@ -63,7 +61,7 @@ import org.openscience.cdk.tools.manipulator.MolecularFormulaManipulator;
 public class SimpleCompoundDBAnnotation implements
     CompoundDBAnnotation {
 
-  private final Map<DataType<?>, Object> data = new HashMap<>();
+  protected final Map<DataType<?>, Object> data = new HashMap<>();
 
   public static final String XML_TYPE_NAME = "simplecompounddbannotation";
 
@@ -119,6 +117,7 @@ public class SimpleCompoundDBAnnotation implements
     return (T) value;
   }
 
+  @Override
   public <T> T get(Class<? extends DataType<T>> key) {
     var actualKey = DataTypes.get(key);
     return get(actualKey);
@@ -143,6 +142,11 @@ public class SimpleCompoundDBAnnotation implements
               value.getClass(), actualKey.getClass()));
     }
     return (T) data.put(actualKey, value);
+  }
+
+  @Override
+  public Set<DataType<?>> getTypes() {
+    return data.keySet();
   }
 
   /**
@@ -202,7 +206,7 @@ public class SimpleCompoundDBAnnotation implements
           reader.getAttributeValue(null, CONST.XML_DATA_TYPE_ID_ATTR));
       if (typeForId != null) {
         Object o = typeForId.loadFromXML(reader, flist, row, null, null);
-        id.put((DataType)typeForId, o);
+        id.put((DataType) typeForId, o);
       }
       i++;
 
@@ -316,25 +320,10 @@ public class SimpleCompoundDBAnnotation implements
   @Override
   public String toString() {
 
-    final NumberFormat mzFormat = MZmineCore.getConfiguration().getMZFormat();
-    final NumberFormat scoreFormat = MZmineCore.getConfiguration().getScoreFormat();
-    final IonType adductType = getAdductType();
-
     final StringBuilder b = new StringBuilder();
-
-    if(getCompundName()!= null) {
-      b.append(getCompundName()).append(",");
-    }
-    if(getAdductType() != null) {
-      b.append(" ").append(getAdductType().toString(false)).append(", ");
-    }
-    if(getPrecursorMZ() != null) {
-      b.append(mzFormat.format(getPrecursorMZ())).append(", ");
-    }
-    if(getScore() != null) {
-      b.append(scoreFormat.format(getScore()));
-    }
-    return b.toString();
+    b.append(getCompoundName());
+//    data.forEach((k, v) -> b.append(k.getFormattedStringCheckType(v)).append(" "));
+    return b.toString().trim();
   }
 
   @Override
@@ -346,7 +335,7 @@ public class SimpleCompoundDBAnnotation implements
       return false;
     }
     SimpleCompoundDBAnnotation that = (SimpleCompoundDBAnnotation) o;
-    return data.equals(that.data);
+    return Objects.equals(data, that.data);
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/datamodel/features/compoundannotations/SimpleCompoundDBAnnotation.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/compoundannotations/SimpleCompoundDBAnnotation.java
@@ -1,19 +1,19 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ *  Copyright 2006-2022 The MZmine Development Team
  *
- * This file is part of MZmine.
+ *  This file is part of MZmine.
  *
- * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
- * General Public License as published by the Free Software Foundation; either version 2 of the
- * License, or (at your option) any later version.
+ *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ *  General Public License as published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
  *
- * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License for more details.
+ *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ *  Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
- *
+ *  You should have received a copy of the GNU General Public License along with MZmine; if not,
+ *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ *  USA
  */
 
 package io.github.mzmine.datamodel.features.compoundannotations;
@@ -58,14 +58,16 @@ import org.openscience.cdk.tools.manipulator.MolecularFormulaManipulator;
  * Basic class for a compound annotation. The idea is not for it to be observable or so, but to
  * carry a flexible amount of data while providing a set of minimum defined entries.
  */
-public class SimpleCompoundDBAnnotation implements
-    CompoundDBAnnotation {
+public class SimpleCompoundDBAnnotation implements CompoundDBAnnotation {
 
-  protected final Map<DataType<?>, Object> data = new HashMap<>();
+  // TODO remove all references to this in next release
+  public static final String XML_TYPE_NAME_OLD = "simplecompounddbannotation";
 
-  public static final String XML_TYPE_NAME = "simplecompounddbannotation";
+  public static final String XML_ATTR = "simple_compound_db_annotation";
+
 
   private static final Logger logger = Logger.getLogger(SimpleCompoundDBAnnotation.class.getName());
+  protected final Map<DataType<?>, Object> data = new HashMap<>();
 
   public SimpleCompoundDBAnnotation() {
   }
@@ -104,6 +106,53 @@ public class SimpleCompoundDBAnnotation implements
       put(NeutralMassType.class, MolecularFormulaManipulator.getMass(neutralFormula,
           MolecularFormulaManipulator.MonoIsotopic));
     }
+  }
+
+  public static CompoundDBAnnotation loadFromXML(XMLStreamReader reader, ModularFeatureList flist,
+      ModularFeatureListRow row) throws XMLStreamException {
+    final String startElementName = reader.getLocalName();
+    final String startElementAttrValue = Objects.requireNonNullElse(
+        reader.getAttributeValue(null, XML_TYPE_ATTRIBUTE_OLD),
+        reader.getAttributeValue(null, XML_TYPE_ATTR));
+
+    if (!((reader.isStartElement() && startElementName.equals(XML_ELEMENT_OLD) // old case
+        && startElementAttrValue.equals(XML_TYPE_NAME_OLD))                   // old case
+        || (reader.isStartElement() && startElementName.equals(FeatureAnnotation.XML_ELEMENT)
+        && startElementAttrValue.equals(XML_ATTR)))) {
+      throw new IllegalStateException("Invalid xml element to load CompoundDBAnnotation from.");
+    }
+
+    final SimpleCompoundDBAnnotation id = new SimpleCompoundDBAnnotation();
+    final int numEntries = Integer.parseInt(reader.getAttributeValue(null, XML_NUM_ENTRIES_ATTR));
+
+    int i = 0;
+    while (reader.hasNext() && !(reader.isEndElement() && (reader.getLocalName()
+        .equals(XML_ELEMENT_OLD) || reader.getLocalName().equals(XML_ELEMENT)))) {
+      reader.next();
+
+      if (!(reader.isStartElement() && reader.getLocalName().equals(CONST.XML_DATA_TYPE_ELEMENT))) {
+        continue;
+      }
+
+      final DataType<?> typeForId = DataTypes.getTypeForId(
+          reader.getAttributeValue(null, CONST.XML_DATA_TYPE_ID_ATTR));
+      if (typeForId != null) {
+        Object o = typeForId.loadFromXML(reader, flist, row, null, null);
+        id.put((DataType) typeForId, o);
+      }
+      i++;
+
+      if (i > numEntries) {
+        break;
+      }
+    }
+
+    if (i > numEntries) {
+      throw new IllegalStateException(String.format(
+          "Finished reading db annotation, but did not find all types. Expected %d, found %d.",
+          numEntries, i));
+    }
+    return id;
   }
 
   @Override
@@ -158,8 +207,7 @@ public class SimpleCompoundDBAnnotation implements
   @Override
   public void saveToXML(@NotNull final XMLStreamWriter writer, ModularFeatureList flist,
       ModularFeatureListRow row) throws XMLStreamException {
-    writer.writeStartElement(CompoundDBAnnotation.XML_ELEMENT);
-    writer.writeAttribute(CompoundDBAnnotation.XML_TYPE_ATTRIBUTE, XML_TYPE_NAME);
+    writeOpeningTag(writer);
     writer.writeAttribute(CompoundDBAnnotation.XML_NUM_ENTRIES_ATTR, String.valueOf(data.size()));
 
     for (Entry<DataType<?>, Object> entry : data.entrySet()) {
@@ -180,47 +228,7 @@ public class SimpleCompoundDBAnnotation implements
       }
     }
 
-    writer.writeEndElement();
-  }
-
-  public static CompoundDBAnnotation loadFromXML(XMLStreamReader reader, ModularFeatureList flist,
-      ModularFeatureListRow row) throws XMLStreamException {
-    if (!(reader.isStartElement() && reader.getLocalName().equals(XML_ELEMENT)
-        && reader.getAttributeValue(null, XML_TYPE_ATTRIBUTE).equals(XML_TYPE_NAME))) {
-      throw new IllegalStateException("Invalid xml element to load CompoundDBAnnotation from.");
-    }
-
-    final SimpleCompoundDBAnnotation id = new SimpleCompoundDBAnnotation();
-    final int numEntries = Integer.parseInt(reader.getAttributeValue(null, XML_NUM_ENTRIES_ATTR));
-
-    int i = 0;
-    while (reader.hasNext() && !(reader.isEndElement() && reader.getLocalName()
-        .equals(XML_ELEMENT))) {
-      reader.next();
-
-      if (!(reader.isStartElement() && reader.getLocalName().equals(CONST.XML_DATA_TYPE_ELEMENT))) {
-        continue;
-      }
-
-      final DataType<?> typeForId = DataTypes.getTypeForId(
-          reader.getAttributeValue(null, CONST.XML_DATA_TYPE_ID_ATTR));
-      if (typeForId != null) {
-        Object o = typeForId.loadFromXML(reader, flist, row, null, null);
-        id.put((DataType) typeForId, o);
-      }
-      i++;
-
-      if (i > numEntries) {
-        break;
-      }
-    }
-
-    if (i > numEntries) {
-      throw new IllegalStateException(String.format(
-          "Finished reading db annotation, but did not find all types. Expected %d, found %d.",
-          numEntries, i));
-    }
-    return id;
+    writeClosingTag(writer);
   }
 
   @Override
@@ -319,11 +327,7 @@ public class SimpleCompoundDBAnnotation implements
 
   @Override
   public String toString() {
-
-    final StringBuilder b = new StringBuilder();
-    b.append(getCompoundName());
-//    data.forEach((k, v) -> b.append(k.getFormattedStringCheckType(v)).append(" "));
-    return b.toString().trim();
+    return getCompoundName();
   }
 
   @Override
@@ -336,6 +340,11 @@ public class SimpleCompoundDBAnnotation implements
     }
     SimpleCompoundDBAnnotation that = (SimpleCompoundDBAnnotation) o;
     return Objects.equals(data, that.data);
+  }
+
+  @Override
+  public @NotNull String getXmlAttributeKey() {
+    return XML_ATTR;
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/datamodel/features/types/annotations/CompoundDatabaseMatchesType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/annotations/CompoundDatabaseMatchesType.java
@@ -1,19 +1,19 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ *  Copyright 2006-2022 The MZmine Development Team
  *
- * This file is part of MZmine.
+ *  This file is part of MZmine.
  *
- * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
- * General Public License as published by the Free Software Foundation; either version 2 of the
- * License, or (at your option) any later version.
+ *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ *  General Public License as published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
  *
- * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License for more details.
+ *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ *  Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
- *
+ *  You should have received a copy of the GNU General Public License along with MZmine; if not,
+ *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ *  USA
  */
 
 package io.github.mzmine.datamodel.features.types.annotations;
@@ -23,6 +23,8 @@ import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.datamodel.features.compoundannotations.CompoundDBAnnotation;
+import io.github.mzmine.datamodel.features.compoundannotations.FeatureAnnotation;
+import io.github.mzmine.datamodel.features.compoundannotations.SimpleCompoundDBAnnotation;
 import io.github.mzmine.datamodel.features.types.DataType;
 import io.github.mzmine.datamodel.features.types.ListWithSubsType;
 import io.github.mzmine.datamodel.features.types.annotations.compounddb.CompoundAnnotationScoreType;
@@ -40,6 +42,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.logging.Logger;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
@@ -49,17 +52,16 @@ import org.jetbrains.annotations.Nullable;
 public class CompoundDatabaseMatchesType extends ListWithSubsType<CompoundDBAnnotation> implements
     AnnotationType {
 
-  public CompoundDatabaseMatchesType() {
-  }
-
-
   public static final List<DataType> subTypes = List.of(new CompoundDatabaseMatchesType(),
       new CompoundNameType(), new CompoundAnnotationScoreType(), new FormulaType(),
       new IonTypeType(), new SmilesStructureType(), new InChIStructureType(), new PrecursorMZType(),
-      new MzPpmDifferenceType(), new NeutralMassType(), new RTType(), new CCSType(), new DatabaseMatchInfoType());
+      new MzPpmDifferenceType(), new NeutralMassType(), new RTType(), new CCSType(),
+      new DatabaseMatchInfoType());
+  private static final Logger logger = Logger.getLogger(
+      CompoundDatabaseMatchesType.class.getName());
   private static final Map<Class<? extends DataType>, Function<CompoundDBAnnotation, Object>> mapper = Map.ofEntries(
       //
-      createEntry(CompoundDatabaseMatchesType.class, match -> match.getCompoundName()), //
+      createEntry(CompoundDatabaseMatchesType.class, CompoundDBAnnotation::getCompoundName), //
       createEntry(CompoundNameType.class, CompoundDBAnnotation::getCompoundName), //
       createEntry(CompoundAnnotationScoreType.class, CompoundDBAnnotation::getScore),
       createEntry(FormulaType.class, CompoundDBAnnotation::getFormula), //
@@ -72,6 +74,14 @@ public class CompoundDatabaseMatchesType extends ListWithSubsType<CompoundDBAnno
       createEntry(RTType.class, match -> match.get(new RTType())), //
       createEntry(CCSType.class, CompoundDBAnnotation::getCCS),
       createEntry(DatabaseMatchInfoType.class, match -> match.get(DatabaseMatchInfoType.class)));
+
+  public CompoundDatabaseMatchesType() {
+  }
+
+  private static <T, R> R mapOrElse(@Nullable final T input, @NotNull final Function<T, R> mapper,
+      @Nullable R elze) {
+    return input != null ? mapper.apply(input) : elze;
+  }
 
   @Override
   public @NotNull String getUniqueID() {
@@ -91,11 +101,6 @@ public class CompoundDatabaseMatchesType extends ListWithSubsType<CompoundDBAnno
   @Override
   protected Map<Class<? extends DataType>, Function<CompoundDBAnnotation, Object>> getMapper() {
     return mapper;
-  }
-
-  private static <T, R> R mapOrElse(@Nullable final T input, @NotNull final Function<T, R> mapper,
-      @Nullable R elze) {
-    return input != null ? mapper.apply(input) : elze;
   }
 
   @Override
@@ -138,10 +143,20 @@ public class CompoundDatabaseMatchesType extends ListWithSubsType<CompoundDBAnno
         continue;
       }
 
-      if (reader.getLocalName().equals(CompoundDBAnnotation.XML_ELEMENT)) {
-        final CompoundDBAnnotation id = CompoundDBAnnotation.loadFromXML(reader, flist, row);
+      // todo remove upper branch in next release
+      if (reader.getLocalName().equals(CompoundDBAnnotation.XML_ELEMENT_OLD)) {
+        final CompoundDBAnnotation id = SimpleCompoundDBAnnotation.loadFromXML(reader, flist, row);
         if (id != null) {
           ids.add(id);
+        }
+      } else if (reader.getLocalName().equals(FeatureAnnotation.XML_ELEMENT)) {
+        final FeatureAnnotation id = FeatureAnnotation.loadFromXML(reader, flist, row);
+        if (id instanceof CompoundDBAnnotation cid) {
+          ids.add(cid);
+        } else {
+          logger.warning(
+              () -> "Unexpected annotation type in compound annotations: " + id.getClass()
+                  .getName());
         }
       }
     }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/annotations/CompoundDatabaseMatchesType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/annotations/CompoundDatabaseMatchesType.java
@@ -59,8 +59,8 @@ public class CompoundDatabaseMatchesType extends ListWithSubsType<CompoundDBAnno
       new MzPpmDifferenceType(), new NeutralMassType(), new RTType(), new CCSType(), new DatabaseMatchInfoType());
   private static final Map<Class<? extends DataType>, Function<CompoundDBAnnotation, Object>> mapper = Map.ofEntries(
       //
-      createEntry(CompoundDatabaseMatchesType.class, match -> match.getCompundName()), //
-      createEntry(CompoundNameType.class, CompoundDBAnnotation::getCompundName), //
+      createEntry(CompoundDatabaseMatchesType.class, match -> match.getCompoundName()), //
+      createEntry(CompoundNameType.class, CompoundDBAnnotation::getCompoundName), //
       createEntry(CompoundAnnotationScoreType.class, CompoundDBAnnotation::getScore),
       createEntry(FormulaType.class, CompoundDBAnnotation::getFormula), //
       createEntry(IonTypeType.class, CompoundDBAnnotation::getAdductType), //

--- a/src/main/java/io/github/mzmine/datamodel/features/types/annotations/SmilesStructureType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/annotations/SmilesStructureType.java
@@ -51,5 +51,4 @@ public class SmilesStructureType extends StringType
   public StringConverter<String> getStringConverter() {
     return converter;
   }
-
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/annotations/SpectralLibraryMatchesType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/annotations/SpectralLibraryMatchesType.java
@@ -1,19 +1,19 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ *  Copyright 2006-2022 The MZmine Development Team
  *
- * This file is part of MZmine.
+ *  This file is part of MZmine.
  *
- * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
- * General Public License as published by the Free Software Foundation; either version 2 of the
- * License, or (at your option) any later version.
+ *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ *  General Public License as published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
  *
- * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License for more details.
+ *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ *  Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
- *
+ *  You should have received a copy of the GNU General Public License along with MZmine; if not,
+ *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ *  USA
  */
 
 package io.github.mzmine.datamodel.features.types.annotations;
@@ -157,7 +157,8 @@ public class SpectralLibraryMatchesType extends ListWithSubsType<SpectralDBAnnot
       } else if (reader.getLocalName().equals(FeatureAnnotation.XML_ELEMENT)
           && reader.getAttributeValue(null, FeatureAnnotation.XML_TYPE_ATTR)
           .equals(SpectralDBAnnotation.XML_ATTR)) {
-        ids.add(SpectralDBAnnotation.loadFromXML(reader, flist.getRawDataFiles()));      }
+        ids.add(SpectralDBAnnotation.loadFromXML(reader, flist.getRawDataFiles()));
+      }
     }
 
     // never return null, if this type was saved we even need empty lists.

--- a/src/main/java/io/github/mzmine/datamodel/features/types/annotations/SpectralLibraryMatchesType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/annotations/SpectralLibraryMatchesType.java
@@ -148,6 +148,7 @@ public class SpectralLibraryMatchesType extends ListWithSubsType<SpectralDBAnnot
         continue;
       }
 
+      // todo remove first branch in a few versions so we can delete SpectralDBFeatureIdentity
       if (reader.getLocalName().equals(FeatureIdentity.XML_GENERAL_IDENTITY_ELEMENT)
           && reader.getAttributeValue(null, FeatureIdentity.XML_IDENTITY_TYPE_ATTR)
           .equals(SpectralDBFeatureIdentity.XML_IDENTITY_TYPE)) {

--- a/src/main/java/io/github/mzmine/datamodel/features/types/annotations/SpectralLibraryMatchesType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/annotations/SpectralLibraryMatchesType.java
@@ -23,6 +23,7 @@ import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
+import io.github.mzmine.datamodel.features.compoundannotations.FeatureAnnotation;
 import io.github.mzmine.datamodel.features.types.DataType;
 import io.github.mzmine.datamodel.features.types.ListWithSubsType;
 import io.github.mzmine.datamodel.features.types.annotations.formula.FormulaType;
@@ -36,6 +37,7 @@ import io.github.mzmine.datamodel.features.types.numbers.PrecursorMZType;
 import io.github.mzmine.datamodel.features.types.numbers.scores.CosineScoreType;
 import io.github.mzmine.modules.io.projectload.version_3_0.CONST;
 import io.github.mzmine.util.spectraldb.entry.DBEntryField;
+import io.github.mzmine.util.spectraldb.entry.SpectralDBAnnotation;
 import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
 import java.util.ArrayList;
 import java.util.List;
@@ -52,40 +54,37 @@ import org.jetbrains.annotations.Nullable;
  *
  * @author Robin Schmid (https://github.com/robinschmid)
  */
-public class SpectralLibraryMatchesType extends
-    ListWithSubsType<SpectralDBFeatureIdentity> implements
+public class SpectralLibraryMatchesType extends ListWithSubsType<SpectralDBAnnotation> implements
     AnnotationType {
 
-  private static final Map<Class<? extends DataType>, Function<SpectralDBFeatureIdentity, Object>> mapper =
-      Map.ofEntries(
-          createEntry(SpectralLibraryMatchesType.class, match -> match),
-          createEntry(CompoundNameType.class,
-              match -> match.getEntry().getField(DBEntryField.NAME).orElse("").toString()),
-          createEntry(FormulaType.class,
-              match -> match.getEntry().getField(DBEntryField.FORMULA).orElse("").toString()),
-          createEntry(IonAdductType.class,
-              match -> match.getEntry().getField(DBEntryField.ION_TYPE).orElse("").toString()),
-          createEntry(SmilesStructureType.class,
-              match -> match.getEntry().getField(DBEntryField.SMILES).orElse("").toString()),
-          createEntry(InChIStructureType.class,
-              match -> match.getEntry().getField(DBEntryField.INCHI).orElse("").toString()),
-          createEntry(CosineScoreType.class, match -> (float) match.getSimilarity().getScore()),
-          createEntry(MatchingSignalsType.class, match -> match.getSimilarity().getOverlap()),
-          createEntry(PrecursorMZType.class,
-              match -> match.getEntry().getField(DBEntryField.MZ).orElse(null)),
-          createEntry(NeutralMassType.class,
-              match -> match.getEntry().getField(DBEntryField.EXACT_MASS).orElse(null)),
-          createEntry(CCSType.class, match -> match.getEntry().getOrElse(DBEntryField.CCS, null)),
-          createEntry(CCSRelativeErrorType.class, SpectralDBFeatureIdentity::getCCSError));
+  private static final Map<Class<? extends DataType>, Function<SpectralDBAnnotation, Object>> mapper = Map.ofEntries(
+      createEntry(SpectralLibraryMatchesType.class, match -> match),
+      createEntry(CompoundNameType.class,
+          match -> match.getEntry().getField(DBEntryField.NAME).orElse("").toString()),
+      createEntry(FormulaType.class,
+          match -> match.getEntry().getField(DBEntryField.FORMULA).orElse("").toString()),
+      createEntry(IonAdductType.class,
+          match -> match.getEntry().getField(DBEntryField.ION_TYPE).orElse("").toString()),
+      createEntry(SmilesStructureType.class,
+          match -> match.getEntry().getField(DBEntryField.SMILES).orElse("").toString()),
+      createEntry(InChIStructureType.class,
+          match -> match.getEntry().getField(DBEntryField.INCHI).orElse("").toString()),
+      createEntry(CosineScoreType.class, match -> (float) match.getSimilarity().getScore()),
+      createEntry(MatchingSignalsType.class, match -> match.getSimilarity().getOverlap()),
+      createEntry(PrecursorMZType.class,
+          match -> match.getEntry().getField(DBEntryField.MZ).orElse(null)),
+      createEntry(NeutralMassType.class,
+          match -> match.getEntry().getField(DBEntryField.EXACT_MASS).orElse(null)),
+      createEntry(CCSType.class, match -> match.getEntry().getOrElse(DBEntryField.CCS, null)),
+      createEntry(CCSRelativeErrorType.class, SpectralDBAnnotation::getCCSError));
   // Unmodifiable list of all subtypes
   private static final List<DataType> subTypes = List.of(new SpectralLibraryMatchesType(),
-      new CompoundNameType(), new IonAdductType(),
-      new FormulaType(), new SmilesStructureType(), new InChIStructureType(),
-      new PrecursorMZType(), new NeutralMassType(), new CosineScoreType(),
+      new CompoundNameType(), new IonAdductType(), new FormulaType(), new SmilesStructureType(),
+      new InChIStructureType(), new PrecursorMZType(), new NeutralMassType(), new CosineScoreType(),
       new MatchingSignalsType(), new CCSType(), new CCSRelativeErrorType());
 
   @Override
-  protected Map<Class<? extends DataType>, Function<SpectralDBFeatureIdentity, Object>> getMapper() {
+  protected Map<Class<? extends DataType>, Function<SpectralDBAnnotation, Object>> getMapper() {
     return mapper;
   }
 
@@ -117,16 +116,16 @@ public class SpectralLibraryMatchesType extends
     }
     if (!(value instanceof List<?> list)) {
       throw new IllegalArgumentException(
-          "Wrong value type for data type: " + this.getClass().getName() + " value class: " + value
-              .getClass());
+          "Wrong value type for data type: " + this.getClass().getName() + " value class: "
+              + value.getClass());
     }
 
     for (Object o : list) {
-      if (!(o instanceof SpectralDBFeatureIdentity id)) {
+      if (!(o instanceof SpectralDBAnnotation id)) {
         continue;
       }
 
-      id.saveToXML(writer);
+      id.saveToXML(writer, flist, row);
     }
   }
 
@@ -136,11 +135,11 @@ public class SpectralLibraryMatchesType extends
       @Nullable RawDataFile file) throws XMLStreamException {
 
     if (!(reader.isStartElement() && reader.getLocalName().equals(CONST.XML_DATA_TYPE_ELEMENT)
-          && reader.getAttributeValue(null, CONST.XML_DATA_TYPE_ID_ATTR).equals(getUniqueID()))) {
+        && reader.getAttributeValue(null, CONST.XML_DATA_TYPE_ID_ATTR).equals(getUniqueID()))) {
       throw new IllegalStateException("Wrong element");
     }
 
-    List<FeatureIdentity> ids = new ArrayList<>();
+    List<FeatureAnnotation> ids = new ArrayList<>();
 
     while (reader.hasNext() && !(reader.isEndElement() && reader.getLocalName()
         .equals(CONST.XML_DATA_TYPE_ELEMENT))) {
@@ -149,12 +148,15 @@ public class SpectralLibraryMatchesType extends
         continue;
       }
 
-      if (reader.getLocalName().equals(FeatureIdentity.XML_GENERAL_IDENTITY_ELEMENT) && reader
-          .getAttributeValue(null, FeatureIdentity.XML_IDENTITY_TYPE_ATTR)
+      if (reader.getLocalName().equals(FeatureIdentity.XML_GENERAL_IDENTITY_ELEMENT)
+          && reader.getAttributeValue(null, FeatureIdentity.XML_IDENTITY_TYPE_ATTR)
           .equals(SpectralDBFeatureIdentity.XML_IDENTITY_TYPE)) {
         FeatureIdentity id = FeatureIdentity.loadFromXML(reader, flist.getRawDataFiles());
-        ids.add(id);
-      }
+        ids.add(new SpectralDBAnnotation((SpectralDBFeatureIdentity) id));
+      } else if (reader.getLocalName().equals(FeatureAnnotation.XML_ELEMENT)
+          && reader.getAttributeValue(null, FeatureAnnotation.XML_TYPE_ATTR)
+          .equals(SpectralDBAnnotation.XML_ATTR)) {
+        ids.add(SpectralDBAnnotation.loadFromXML(reader, flist.getRawDataFiles()));      }
     }
 
     // never return null, if this type was saved we even need empty lists.

--- a/src/main/java/io/github/mzmine/datamodel/impl/SimpleFeatureIdentity.java
+++ b/src/main/java/io/github/mzmine/datamodel/impl/SimpleFeatureIdentity.java
@@ -27,11 +27,14 @@ import java.util.Map.Entry;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
+import org.jetbrains.annotations.ApiStatus.ScheduledForRemoval;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Simple FeatureIdentity implementation;
  */
+@Deprecated
+@ScheduledForRemoval
 public class SimpleFeatureIdentity implements FeatureIdentity {
 
   public static final String XML_IDENTITY_TYPE = "simplefeatureidentity";

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_rowsfilter/RowsFilterTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_rowsfilter/RowsFilterTask.java
@@ -44,7 +44,7 @@ import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.FormulaUtils;
 import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.RangeUtils;
-import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
+import io.github.mzmine.util.spectraldb.entry.SpectralDBAnnotation;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -290,7 +290,7 @@ public class RowsFilterTask extends AbstractTask {
         // Check identities.
         List<MatchedLipid> matchedLipids = row.get(LipidMatchListType.class);
         if (onlyIdentified) {
-          List<SpectralDBFeatureIdentity> matches = row.getSpectralLibraryMatches();
+          List<SpectralDBAnnotation> matches = row.getSpectralLibraryMatches();
           List<GNPSLibraryMatch> gnps = row.get(GNPSSpectralLibraryMatchesType.class);
 
           boolean noIdentity = (row.getPreferredFeatureIdentity() == null);
@@ -339,7 +339,7 @@ public class RowsFilterTask extends AbstractTask {
           }
           if (!foundText && row.getSpectralLibraryMatches() != null) {
             for (var id : row.getSpectralLibraryMatches()) {
-              if (id != null && id.getName().toLowerCase().trim().contains(searchText)) {
+              if (id != null && id.getCompoundName().toLowerCase().trim().contains(searchText)) {
                 foundText = true;
                 break;
               }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_onlinecompounddb/ResultWindowController.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_onlinecompounddb/ResultWindowController.java
@@ -71,7 +71,7 @@ public class ResultWindowController {
     colID.setCellValueFactory(cell -> new ReadOnlyObjectWrapper<>(
         String.valueOf(cell.getValue().getDatabaseMatchInfo())));
     colName.setCellValueFactory(
-        cell -> new ReadOnlyObjectWrapper<>(cell.getValue().getCompundName()));
+        cell -> new ReadOnlyObjectWrapper<>(cell.getValue().getCompoundName()));
     colFormula.setCellValueFactory(
         cell -> new ReadOnlyObjectWrapper<>(cell.getValue().getFormula()));
     colMassDiff.setCellValueFactory(cell -> {
@@ -164,7 +164,7 @@ public class ResultWindowController {
 
     URL url2D = compound.get2DStructureURL();
     URL url3D = compound.get3DStructureURL();
-    String name = compound.getCompundName() + " (" + compound.getDatabaseMatchInfo() + ")";
+    String name = compound.getCompoundName() + " (" + compound.getDatabaseMatchInfo() + ")";
     MolStructureViewer viewer = new MolStructureViewer(name, url2D, url3D);
     viewer.show();
   }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_spectral_library_match/RowsSpectralMatchTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_spectral_library_match/RowsSpectralMatchTask.java
@@ -32,7 +32,6 @@ import io.github.mzmine.modules.dataprocessing.id_ccscalc.CCSUtils;
 import io.github.mzmine.modules.dataprocessing.id_spectral_match_sort.SortSpectralMatchesTask;
 import io.github.mzmine.modules.visualization.spectra.simplespectra.datapointprocessing.isotopes.MassListDeisotoper;
 import io.github.mzmine.modules.visualization.spectra.simplespectra.datapointprocessing.isotopes.MassListDeisotoperParameters;
-import io.github.mzmine.modules.visualization.spectra.simplespectra.spectraidentification.spectraldatabase.SingleSpectrumLibrarySearchModule;
 import io.github.mzmine.modules.visualization.spectra.simplespectra.spectraidentification.spectraldatabase.SingleSpectrumLibrarySearchParameters;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
@@ -46,8 +45,8 @@ import io.github.mzmine.util.scans.similarity.SpectralSimilarity;
 import io.github.mzmine.util.scans.similarity.SpectralSimilarityFunction;
 import io.github.mzmine.util.scans.sorting.ScanSortMode;
 import io.github.mzmine.util.spectraldb.entry.DBEntryField;
+import io.github.mzmine.util.spectraldb.entry.SpectralDBAnnotation;
 import io.github.mzmine.util.spectraldb.entry.SpectralDBEntry;
-import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
 import io.github.mzmine.util.spectraldb.entry.SpectralLibrary;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -315,8 +314,7 @@ public class RowsSpectralMatchTask extends AbstractTask {
               precursorCCS);
 
           matches.incrementAndGet();
-          addIdentities(null, List.of(new SpectralDBFeatureIdentity(scan, entry, sim,
-              SingleSpectrumLibrarySearchModule.MODULE_NAME, ccsError)));
+          addIdentities(null, List.of(new SpectralDBAnnotation(entry, sim, scan, ccsError)));
         }
       }
     } catch (MissingMassListException e) {
@@ -376,11 +374,11 @@ public class RowsSpectralMatchTask extends AbstractTask {
       }
 
       final Float rowCCS = row.getAverageCCS();
-      List<SpectralDBFeatureIdentity> ids = null;
+      List<SpectralDBAnnotation> ids = null;
       // match against all library entries
       for (SpectralDBEntry ident : entries) {
         final Float libCCS = ident.getOrElse(DBEntryField.CCS, null);
-        SpectralDBFeatureIdentity best = null;
+        SpectralDBAnnotation best = null;
         // match all scans against this ident to find best match
         for (int i = 0; i < scans.size(); i++) {
           SpectralSimilarity sim = matchSpectrum(row.getAverageRT(), row.getAverageMZ(), rowCCS,
@@ -392,8 +390,7 @@ public class RowsSpectralMatchTask extends AbstractTask {
 
             Float ccsRelativeError = PercentTolerance.getPercentError(rowCCS, libCCS);
 
-            best = new SpectralDBFeatureIdentity(scans.get(i), ident, sim, METHOD,
-                ccsRelativeError);
+            best = new SpectralDBAnnotation(ident, sim, scans.get(i), ccsRelativeError);
           }
         }
         // has match?
@@ -557,7 +554,7 @@ public class RowsSpectralMatchTask extends AbstractTask {
     }
   }
 
-  protected void addIdentities(FeatureListRow row, List<SpectralDBFeatureIdentity> matches) {
+  protected void addIdentities(FeatureListRow row, List<SpectralDBAnnotation> matches) {
     // add new identity to the row
     if (row != null) {
       row.addSpectralLibraryMatches(matches);

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_spectral_library_match/SelectedRowsSpectralLibrarySearchTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_spectral_library_match/SelectedRowsSpectralLibrarySearchTask.java
@@ -27,7 +27,7 @@ import io.github.mzmine.modules.visualization.featurelisttable_modular.FeatureTa
 import io.github.mzmine.modules.visualization.spectra.spectralmatchresults.SpectraIdentificationResultsWindowFX;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.TaskStatus;
-import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
+import io.github.mzmine.util.spectraldb.entry.SpectralDBAnnotation;
 import java.time.Instant;
 import java.util.List;
 import java.util.logging.Logger;
@@ -86,7 +86,7 @@ public class SelectedRowsSpectralLibrarySearchTask extends RowsSpectralMatchTask
   }
 
   @Override
-  protected void addIdentities(FeatureListRow row, List<SpectralDBFeatureIdentity> matches) {
+  protected void addIdentities(FeatureListRow row, List<SpectralDBAnnotation> matches) {
     super.addIdentities(row, matches);
     // one selected row -> show in dialog
     if (resultWindow != null) {

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_spectral_match_sort/SortSpectralMatchesTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_spectral_match_sort/SortSpectralMatchesTask.java
@@ -24,7 +24,7 @@ import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
-import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
+import io.github.mzmine.util.spectraldb.entry.SpectralDBAnnotation;
 import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
@@ -76,7 +76,7 @@ public class SortSpectralMatchesTask extends AbstractTask {
   public static void sortIdentities(@NotNull FeatureListRow row, boolean filterMinSimilarity,
       double minScore) {
     // filter for SpectralDBFeatureIdentity and write to map
-    List<SpectralDBFeatureIdentity> matches = row.getSpectralLibraryMatches();
+    List<SpectralDBAnnotation> matches = row.getSpectralLibraryMatches();
     if (matches == null || matches.isEmpty()) {
       return;
     }
@@ -84,7 +84,7 @@ public class SortSpectralMatchesTask extends AbstractTask {
     // reversed order: by similarity score
     matches = matches.stream()
         .filter(m -> !filterMinSimilarity || m.getSimilarity().getScore() >= minScore)
-        .sorted(Comparator.comparingDouble(SpectralDBFeatureIdentity::getScore).reversed())
+        .sorted(Comparator.comparingDouble(SpectralDBAnnotation::getScore).reversed())
         .collect(Collectors.toList());
 
     // set sorted list

--- a/src/main/java/io/github/mzmine/modules/visualization/networking/visual/FeatureNetworkGenerator.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/networking/visual/FeatureNetworkGenerator.java
@@ -32,7 +32,7 @@ import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.dataprocessing.id_gnpsresultsimport.GNPSLibraryMatch;
 import io.github.mzmine.modules.dataprocessing.id_gnpsresultsimport.GNPSLibraryMatch.ATT;
 import io.github.mzmine.util.spectraldb.entry.DBEntryField;
-import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
+import io.github.mzmine.util.spectraldb.entry.SpectralDBAnnotation;
 import java.text.MessageFormat;
 import java.text.NumberFormat;
 import java.util.ArrayList;
@@ -445,12 +445,12 @@ public class FeatureNetworkGenerator {
       node.setAttribute(NodeAtt.NEUTRAL_MASS.toString(), mzForm.format(net.getNeutralMass()));
       node.setAttribute(NodeAtt.MAX_INTENSITY.toString(), intensityForm.format(net.getHeightSum()));
 
-      final SpectralDBFeatureIdentity bestMatch = net.keySet().stream()
+      final SpectralDBAnnotation bestMatch = net.keySet().stream()
           .map(FeatureListRow::getSpectralLibraryMatches).flatMap(List::stream).max(
               Comparator.comparingDouble(a -> a.getSimilarity().getScore())).orElse(null);
       if (bestMatch != null) {
         double score = bestMatch.getSimilarity().getScore();
-        node.setAttribute(NodeAtt.SPECTRAL_LIB_MATCH_SUMMARY.toString(), bestMatch.getName());
+        node.setAttribute(NodeAtt.SPECTRAL_LIB_MATCH_SUMMARY.toString(), bestMatch.getCompoundName());
         node.setAttribute(NodeAtt.SPECTRAL_LIB_MATCH.toString(), bestMatch.getEntry().getOrElse(
             DBEntryField.NAME, ""));
         node.setAttribute(NodeAtt.SPECTRAL_LIB_SCORE.toString(), scoreForm.format(score));
@@ -543,11 +543,11 @@ public class FeatureNetworkGenerator {
       node.setAttribute(NodeAtt.CHARGE.toString(), row.getRowCharge());
       node.setAttribute(NodeAtt.GROUP_ID.toString(), row.getGroupID());
 
-      final SpectralDBFeatureIdentity bestMatch = row.getSpectralLibraryMatches().stream().max(
+      final SpectralDBAnnotation bestMatch = row.getSpectralLibraryMatches().stream().max(
           Comparator.comparingDouble(a -> a.getSimilarity().getScore())).orElse(null);
       if (bestMatch != null) {
         double score = bestMatch.getSimilarity().getScore();
-        node.setAttribute(NodeAtt.SPECTRAL_LIB_MATCH_SUMMARY.toString(), bestMatch.getName());
+        node.setAttribute(NodeAtt.SPECTRAL_LIB_MATCH_SUMMARY.toString(), bestMatch.getCompoundName());
         node.setAttribute(NodeAtt.SPECTRAL_LIB_MATCH.toString(), bestMatch.getEntry().getOrElse(
             DBEntryField.NAME, ""));
         node.setAttribute(NodeAtt.SPECTRAL_LIB_SCORE.toString(), scoreForm.format(score));

--- a/src/main/java/io/github/mzmine/modules/visualization/networking/visual/NodeAtt.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/networking/visual/NodeAtt.java
@@ -22,7 +22,7 @@ import io.github.mzmine.datamodel.identities.iontype.IonIdentity;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.dataprocessing.id_formulaprediction.ResultFormula;
 import io.github.mzmine.util.spectraldb.entry.DBEntryField;
-import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
+import io.github.mzmine.util.spectraldb.entry.SpectralDBAnnotation;
 import java.util.List;
 
 /**
@@ -82,7 +82,7 @@ public enum NodeAtt {
       }
       case GROUP_ID -> row.getGroupID();
       case SPECTRAL_LIB_MATCH_SUMMARY -> row.getSpectralLibraryMatches().stream()
-          .map(SpectralDBFeatureIdentity::getName).findFirst().orElse(null);
+          .map(SpectralDBAnnotation::getCompoundName).findFirst().orElse(null);
       case SPECTRAL_LIB_MATCH -> row.getSpectralLibraryMatches().stream().map(
           match -> match.getEntry().getOrElse(DBEntryField.NAME, (String) null)).findFirst()
           .orElse(null);
@@ -131,7 +131,7 @@ public enum NodeAtt {
         yield i > -1 ? String.valueOf(i) : "";
       }
       case SPECTRAL_LIB_MATCH_SUMMARY -> row.getSpectralLibraryMatches().stream()
-          .map(SpectralDBFeatureIdentity::getName).findFirst()
+          .map(SpectralDBAnnotation::getCompoundName).findFirst()
           .orElse("");
       case SPECTRAL_LIB_MATCH -> row.getSpectralLibraryMatches().stream().map(
           match -> match.getEntry().getOrElse(DBEntryField.NAME, "")).findFirst().orElse("");

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/mirrorspectra/MirrorScanWindow.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/mirrorspectra/MirrorScanWindow.java
@@ -28,7 +28,7 @@ import io.github.mzmine.util.MirrorChartFactory;
 import io.github.mzmine.util.color.SimpleColorPalette;
 import io.github.mzmine.util.spectraldb.entry.DBEntryField;
 import io.github.mzmine.util.spectraldb.entry.DataPointsTag;
-import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
+import io.github.mzmine.util.spectraldb.entry.SpectralDBAnnotation;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.util.Arrays;
@@ -112,7 +112,7 @@ public class MirrorScanWindow extends JFrame {
    *
    * @param db
    */
-  public void setScans(SpectralDBFeatureIdentity db) {
+  public void setScans(SpectralDBAnnotation db) {
     Scan scan = db.getQueryScan();
     if (scan == null)
       return;
@@ -151,7 +151,7 @@ public class MirrorScanWindow extends JFrame {
     contentPane.removeAll();
     // create without data
     mirrorSpecrumPlot = MirrorChartFactory.createMirrorChartPanel(
-        "Query: " + scan.getScanDefinition(), precursorMZA, rtA, null, "Library: " + db.getName(),
+        "Query: " + scan.getScanDefinition(), precursorMZA, rtA, null, "Library: " + db.getCompoundName(),
         precursorMZB == null ? 0 : precursorMZB, rtB, null, false, true);
     mirrorSpecrumPlot.setMaximumDrawWidth(4200);
     mirrorSpecrumPlot.setMaximumDrawHeight(2500);

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/mirrorspectra/MirrorScanWindowFX.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/mirrorspectra/MirrorScanWindowFX.java
@@ -23,7 +23,7 @@ import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.gui.chartbasics.gui.javafx.EChartViewer;
 import io.github.mzmine.util.MirrorChartFactory;
 import io.github.mzmine.util.spectraldb.entry.DataPointsTag;
-import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
+import io.github.mzmine.util.spectraldb.entry.SpectralDBAnnotation;
 import javafx.scene.Scene;
 import javafx.scene.layout.BorderPane;
 import javafx.stage.Stage;
@@ -89,7 +89,7 @@ public class MirrorScanWindowFX extends Stage {
    *
    * @param db
    */
-  public void setScans(SpectralDBFeatureIdentity db) {
+  public void setScans(SpectralDBAnnotation db) {
     mirrorSpecrumPlot = MirrorChartFactory.createMirrorPlotFromSpectralDBPeakIdentity(db);
     contentPane.setCenter(mirrorSpecrumPlot);
   }

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/onlinedatabase/SpectraIdentificationOnlineDatabaseTask.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/onlinedatabase/SpectraIdentificationOnlineDatabaseTask.java
@@ -171,7 +171,7 @@ public class SpectraIdentificationOnlineDatabaseTask extends AbstractTask {
             continue;
           if (counter < 3) {
             int number = counter + 1;
-            annotation = annotation + " " + number + ". " + compound.getCompundName();
+            annotation = annotation + " " + number + ". " + compound.getCompoundName();
             counter++;
           }
         }

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SingleSpectrumLibrarySearchTask.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/spectraidentification/spectraldatabase/SingleSpectrumLibrarySearchTask.java
@@ -31,7 +31,7 @@ import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.exceptions.MissingMassListException;
 import io.github.mzmine.util.scans.ScanAlignment;
 import io.github.mzmine.util.spectraldb.entry.DBEntryField;
-import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
+import io.github.mzmine.util.spectraldb.entry.SpectralDBAnnotation;
 import java.awt.Color;
 import java.time.Instant;
 import java.util.List;
@@ -90,13 +90,13 @@ class SingleSpectrumLibrarySearchTask extends RowsSpectralMatchTask {
   }
 
   @Override
-  protected void addIdentities(FeatureListRow row, List<SpectralDBFeatureIdentity> matches) {
+  protected void addIdentities(FeatureListRow row, List<SpectralDBAnnotation> matches) {
     // we dont need row here
     addIdentities(matches);
   }
 
-  private void addIdentities(List<SpectralDBFeatureIdentity> matches) {
-    for (SpectralDBFeatureIdentity match : matches) {
+  private void addIdentities(List<SpectralDBAnnotation> matches) {
+    for (SpectralDBAnnotation match : matches) {
       try {
         // TODO put into separate method and add comments
         // get data points of matching scans

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/spectralmatchresults/SpectraIdentificationResultsModule.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/spectralmatchresults/SpectraIdentificationResultsModule.java
@@ -21,7 +21,7 @@ package io.github.mzmine.modules.visualization.spectra.spectralmatchresults;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.modules.MZmineModule;
 import io.github.mzmine.parameters.ParameterSet;
-import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
+import io.github.mzmine.util.spectraldb.entry.SpectralDBAnnotation;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
@@ -32,7 +32,7 @@ public class SpectraIdentificationResultsModule implements MZmineModule {
   public static final String MODULE_NAME = "Local spectral libraries search results";
 
   public static void showNewTab(List<ModularFeatureListRow> rows) {
-    List<SpectralDBFeatureIdentity> spectralID =
+    List<SpectralDBAnnotation> spectralID =
         rows.stream().flatMap(row -> row.getSpectralLibraryMatches().stream()).toList();
     if (!spectralID.isEmpty()) {
       SpectraIdentificationResultsWindowFX window = new SpectraIdentificationResultsWindowFX();

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/spectralmatchresults/SpectraIdentificationResultsWindowFX.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/spectralmatchresults/SpectraIdentificationResultsWindowFX.java
@@ -20,7 +20,7 @@ package io.github.mzmine.modules.visualization.spectra.spectralmatchresults;
 
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.util.ExitCode;
-import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
+import io.github.mzmine.util.spectraldb.entry.SpectralDBAnnotation;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -55,8 +55,8 @@ public class SpectraIdentificationResultsWindowFX extends Stage {
   private final Font headerFont = new Font("Dialog Bold", 16);
   private final GridPane pnGrid;
   private final javafx.scene.control.ScrollPane scrollPane;
-  private final List<SpectralDBFeatureIdentity> totalMatches;
-  private final Map<SpectralDBFeatureIdentity, SpectralMatchPanelFX> matchPanels;
+  private final List<SpectralDBAnnotation> totalMatches;
+  private final Map<SpectralDBAnnotation, SpectralMatchPanelFX> matchPanels;
   // couple y zoom (if one is changed - change the other in a mirror plot)
   private boolean isCouplingZoomY;
 
@@ -143,7 +143,7 @@ public class SpectraIdentificationResultsWindowFX extends Stage {
    *
    * @param match
    */
-  public synchronized void addMatches(SpectralDBFeatureIdentity match) {
+  public synchronized void addMatches(SpectralDBAnnotation match) {
     if (!totalMatches.contains(match)) {
       // add
       totalMatches.add(match);
@@ -165,12 +165,12 @@ public class SpectraIdentificationResultsWindowFX extends Stage {
    *
    * @param matches
    */
-  public synchronized void addMatches(List<SpectralDBFeatureIdentity> matches) {
+  public synchronized void addMatches(List<SpectralDBAnnotation> matches) {
     if (matches.isEmpty()) {
       return;
     }
     // add all
-    for (SpectralDBFeatureIdentity match : matches) {
+    for (SpectralDBAnnotation match : matches) {
       if (!totalMatches.contains(match)) {
         // add
         totalMatches.add(match);
@@ -194,7 +194,7 @@ public class SpectraIdentificationResultsWindowFX extends Stage {
 
     // reversed sorting (highest cosine first
     synchronized (totalMatches) {
-      totalMatches.sort((SpectralDBFeatureIdentity a, SpectralDBFeatureIdentity b) -> Double
+      totalMatches.sort((SpectralDBAnnotation a, SpectralDBAnnotation b) -> Double
           .compare(b.getSimilarity().getScore(), a.getSimilarity().getScore()));
     }
     // renew layout and show
@@ -217,7 +217,7 @@ public class SpectraIdentificationResultsWindowFX extends Stage {
     synchronized (totalMatches) {
       pnGrid.getChildren().clear();
       int row = 0;
-      for (SpectralDBFeatureIdentity match : totalMatches) {
+      for (SpectralDBAnnotation match : totalMatches) {
         Pane pn = matchPanels.get(match);
         if (pn != null) {
           pnGrid.add(pn, 0, row);

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/spectralmatchresults/SpectralMatchPanel.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/spectralmatchresults/SpectralMatchPanel.java
@@ -20,42 +20,7 @@ package io.github.mzmine.modules.visualization.spectra.spectralmatchresults;
 
 // import io.github.mzmine.util.swing.IconUtil;
 // import io.github.mzmine.util.swing.SwingExportUtil;
-import io.github.mzmine.util.swing.SwingExportUtil;
-import java.awt.BorderLayout;
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.GridLayout;
-import java.io.File;
-import java.text.DecimalFormat;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.JButton;
-import javax.swing.JComponent;
-import javax.swing.JFileChooser;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.ScrollPaneConstants;
-import javax.swing.SwingUtilities;
-import org.jfree.chart.axis.NumberAxis;
-import org.jfree.chart.axis.ValueAxis;
-import org.jfree.chart.plot.CombinedDomainXYPlot;
-import org.jfree.chart.plot.Plot;
-import org.jfree.chart.plot.XYPlot;
-import org.jfree.data.Range;
-import org.openscience.cdk.DefaultChemObjectBuilder;
-import org.openscience.cdk.exception.CDKException;
-import org.openscience.cdk.exception.InvalidSmilesException;
-import org.openscience.cdk.inchi.InChIGeneratorFactory;
-import org.openscience.cdk.inchi.InChIToStructure;
-import org.openscience.cdk.interfaces.IAtomContainer;
-import org.openscience.cdk.smiles.SmilesParser;
+
 import io.github.mzmine.gui.chartbasics.gui.swing.EChartPanel;
 import io.github.mzmine.gui.chartbasics.gui.wrapper.ChartViewWrapper;
 import io.github.mzmine.gui.chartbasics.listener.AxisRangeChangedListener;
@@ -71,10 +36,45 @@ import io.github.mzmine.util.color.SimpleColorPalette;
 import io.github.mzmine.util.files.FileAndPathUtil;
 import io.github.mzmine.util.javafx.FxIconUtil;
 import io.github.mzmine.util.spectraldb.entry.DBEntryField;
+import io.github.mzmine.util.spectraldb.entry.SpectralDBAnnotation;
 import io.github.mzmine.util.spectraldb.entry.SpectralDBEntry;
-import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
+import io.github.mzmine.util.swing.SwingExportUtil;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.GridLayout;
+import java.io.File;
+import java.text.DecimalFormat;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javafx.scene.image.Image;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.ScrollPaneConstants;
+import javax.swing.SwingUtilities;
 import net.miginfocom.swing.MigLayout;
+import org.jfree.chart.axis.NumberAxis;
+import org.jfree.chart.axis.ValueAxis;
+import org.jfree.chart.plot.CombinedDomainXYPlot;
+import org.jfree.chart.plot.XYPlot;
+import org.jfree.data.Range;
+import org.openscience.cdk.DefaultChemObjectBuilder;
+import org.openscience.cdk.exception.CDKException;
+import org.openscience.cdk.exception.InvalidSmilesException;
+import org.openscience.cdk.inchi.InChIGeneratorFactory;
+import org.openscience.cdk.inchi.InChIToStructure;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.smiles.SmilesParser;
 
 public class SpectralMatchPanel extends JPanel {
 
@@ -119,7 +119,7 @@ public class SpectralMatchPanel extends JPanel {
   private final JPanel metaDataPanel;
   private final JPanel boxTitlePanel;
 
-  public SpectralMatchPanel(SpectralDBFeatureIdentity hit) {
+  public SpectralMatchPanel(SpectralDBAnnotation hit) {
     JPanel panel = this;
     panel.setLayout(new BorderLayout());
 
@@ -482,7 +482,7 @@ public class SpectralMatchPanel extends JPanel {
     return pn1;
   }
 
-  private IAtomContainer parseInChi(SpectralDBFeatureIdentity hit) {
+  private IAtomContainer parseInChi(SpectralDBAnnotation hit) {
     String inchiString = hit.getEntry().getField(DBEntryField.INCHI).orElse("N/A").toString();
     InChIGeneratorFactory factory;
     IAtomContainer molecule;
@@ -504,7 +504,7 @@ public class SpectralMatchPanel extends JPanel {
     }
   }
 
-  private IAtomContainer parseSmiles(SpectralDBFeatureIdentity hit) {
+  private IAtomContainer parseSmiles(SpectralDBAnnotation hit) {
     SmilesParser smilesParser = new SmilesParser(DefaultChemObjectBuilder.getInstance());
     String smilesString = hit.getEntry().getField(DBEntryField.SMILES).orElse("N/A").toString();
     IAtomContainer molecule;

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/spectralmatchresults/SpectralMatchPanelFX.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/spectralmatchresults/SpectralMatchPanelFX.java
@@ -32,8 +32,8 @@ import io.github.mzmine.util.color.SimpleColorPalette;
 import io.github.mzmine.util.javafx.FxColorUtil;
 import io.github.mzmine.util.javafx.FxIconUtil;
 import io.github.mzmine.util.spectraldb.entry.DBEntryField;
+import io.github.mzmine.util.spectraldb.entry.SpectralDBAnnotation;
 import io.github.mzmine.util.spectraldb.entry.SpectralDBEntry;
-import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
 import java.io.File;
 import java.text.DecimalFormat;
 import java.util.logging.Level;
@@ -106,7 +106,7 @@ public class SpectralMatchPanelFX extends GridPane {
   private static Font font;
   private final Logger logger = Logger.getLogger(this.getClass().getName());
   private final EChartViewer mirrorChart;
-  private final SpectralDBFeatureIdentity hit;
+  private final SpectralDBAnnotation hit;
   private boolean setCoupleZoomY;
   private XYPlot queryPlot;
   private XYPlot libraryPlot;
@@ -120,7 +120,7 @@ public class SpectralMatchPanelFX extends GridPane {
   private EStandardChartTheme theme;
   private SpectralMatchPanel swingPanel;
 
-  public SpectralMatchPanelFX(SpectralDBFeatureIdentity hit) {
+  public SpectralMatchPanelFX(SpectralDBAnnotation hit) {
     super();
 
     this.hit = hit;
@@ -173,7 +173,7 @@ public class SpectralMatchPanelFX extends GridPane {
     pnTitle.setBackground(
         new Background(new BackgroundFill(gradientCol, CornerRadii.EMPTY, Insets.EMPTY)));
 
-    lblHit = new Label(hit.getName());
+    lblHit = new Label(hit.getCompoundName());
     lblHit.getStyleClass().add("white-larger-label");
 
     lblScore = new Label(COS_FORM.format(simScore));
@@ -337,7 +337,7 @@ public class SpectralMatchPanelFX extends GridPane {
     setCoupleZoomY = selected;
   }
 
-  private IAtomContainer parseInChi(SpectralDBFeatureIdentity hit) {
+  private IAtomContainer parseInChi(SpectralDBAnnotation hit) {
     String inchiString = hit.getEntry().getField(DBEntryField.INCHI).orElse("N/A").toString();
     InChIGeneratorFactory factory;
     IAtomContainer molecule;
@@ -359,7 +359,7 @@ public class SpectralMatchPanelFX extends GridPane {
     }
   }
 
-  private IAtomContainer parseSmiles(SpectralDBFeatureIdentity hit) {
+  private IAtomContainer parseSmiles(SpectralDBAnnotation hit) {
     SmilesParser smilesParser = new SmilesParser(DefaultChemObjectBuilder.getInstance());
     String smilesString = hit.getEntry().getField(DBEntryField.SMILES).orElse("N/A").toString();
     IAtomContainer molecule;
@@ -515,7 +515,7 @@ public class SpectralMatchPanelFX extends GridPane {
     // it works though, until we figure something out
   }
 
-  public SpectralDBFeatureIdentity getHit() {
+  public SpectralDBAnnotation getHit() {
     return hit;
   }
 

--- a/src/main/java/io/github/mzmine/util/MirrorChartFactory.java
+++ b/src/main/java/io/github/mzmine/util/MirrorChartFactory.java
@@ -36,7 +36,7 @@ import io.github.mzmine.util.color.SimpleColorPalette;
 import io.github.mzmine.util.scans.ScanUtils;
 import io.github.mzmine.util.spectraldb.entry.DBEntryField;
 import io.github.mzmine.util.spectraldb.entry.DataPointsTag;
-import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
+import io.github.mzmine.util.spectraldb.entry.SpectralDBAnnotation;
 import java.awt.Color;
 import java.text.DecimalFormat;
 import java.text.MessageFormat;
@@ -71,7 +71,7 @@ public class MirrorChartFactory {
    * @return
    */
   public static EChartViewer createMirrorPlotFromSpectralDBPeakIdentity(
-      SpectralDBFeatureIdentity db) {
+      SpectralDBAnnotation db) {
 
     Scan scan = db.getQueryScan();
     if (scan == null) {
@@ -114,7 +114,7 @@ public class MirrorChartFactory {
 
     // create without data
     EChartViewer mirrorSpecrumPlot = createMirrorChartViewer("Query: " + scan.getScanDefinition(),
-        precursorMZA, rtA, null, "Library: " + db.getName(),
+        precursorMZA, rtA, null, "Library: " + db.getCompoundName(),
         precursorMZB == null ? 0 : precursorMZB, rtB, null, false, true);
     // mirrorSpecrumPlot.setMaximumDrawWidth(4200); // TODO?
     // mirrorSpecrumPlot.setMaximumDrawHeight(2500);

--- a/src/main/java/io/github/mzmine/util/spectraldb/entry/SpectralDBAnnotation.java
+++ b/src/main/java/io/github/mzmine/util/spectraldb/entry/SpectralDBAnnotation.java
@@ -1,0 +1,241 @@
+package io.github.mzmine.util.spectraldb.entry;
+
+import io.github.mzmine.datamodel.DataPoint;
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.datamodel.features.ModularFeatureList;
+import io.github.mzmine.datamodel.features.ModularFeatureListRow;
+import io.github.mzmine.datamodel.features.compoundannotations.FeatureAnnotation;
+import io.github.mzmine.datamodel.identities.iontype.IonType;
+import io.github.mzmine.modules.io.projectload.version_3_0.CONST;
+import io.github.mzmine.util.DataPointSorter;
+import io.github.mzmine.util.ParsingUtils;
+import io.github.mzmine.util.SortingDirection;
+import io.github.mzmine.util.SortingProperty;
+import io.github.mzmine.util.scans.similarity.SpectralSimilarity;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.logging.Logger;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.XMLStreamWriter;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class SpectralDBAnnotation implements FeatureAnnotation {
+
+  public static final String XML_ATTR = "spectrallibraryannotation";
+
+  private static final Logger logger = Logger.getLogger(SpectralDBAnnotation.class.getName());
+
+  private final SpectralDBEntry entry;
+  private final SpectralSimilarity similarity;
+  private final Float ccsError;
+  @Nullable
+  private final Scan queryScan;
+
+  private static final String XML_CCS_ERROR_ELEMENT = "ccserror";
+
+  public SpectralDBAnnotation(SpectralDBEntry entry, SpectralSimilarity similarity, Scan queryScan,
+      @Nullable Float ccsError) {
+    this.queryScan = queryScan;
+    this.entry = entry;
+    this.similarity = similarity;
+    this.ccsError = ccsError;
+  }
+
+  public SpectralDBAnnotation(SpectralDBFeatureIdentity id) {
+    this(id.getEntry(), id.getSimilarity(), id.getQueryScan(), id.getCCSError());
+  }
+
+  @Override
+  public void saveToXML(@NotNull XMLStreamWriter writer, ModularFeatureList flist,
+      ModularFeatureListRow row) throws XMLStreamException {
+    writer.writeStartElement(FeatureAnnotation.XML_ELEMENT);
+    writer.writeAttribute(FeatureAnnotation.XML_TYPE_ATTR, XML_ATTR);
+
+    entry.saveToXML(writer);
+    similarity.saveToXML(writer);
+
+    writer.writeStartElement(XML_CCS_ERROR_ELEMENT);
+    writer.writeCharacters(ParsingUtils.parseNullableString(
+        this.ccsError != null ? String.valueOf(this.ccsError) : null));
+    writer.writeEndElement();
+
+    if (queryScan != null) {
+      Scan.saveScanToXML(writer, getQueryScan());
+    }
+
+    writer.writeEndElement();
+  }
+
+  public static FeatureAnnotation loadFromXML(XMLStreamReader reader,
+      Collection<RawDataFile> possibleFiles) throws XMLStreamException {
+    if (!(reader.isStartElement() && reader.getLocalName().equals(XML_ELEMENT))
+        || !reader.getAttributeValue(null, XML_TYPE_ATTR).equals(XML_ATTR)) {
+      throw new IllegalStateException("Current element is not a feature annotation element");
+    }
+
+    SpectralDBEntry entry = null;
+    SpectralSimilarity similarity = null;
+    Scan scan = null;
+    Float ccsError = null;
+
+    while (reader.hasNext() && !(reader.isEndElement() && reader.getLocalName()
+        .equals(FeatureAnnotation.XML_ELEMENT))) {
+      reader.next();
+      if (!reader.isStartElement()) {
+        continue;
+      }
+
+      switch (reader.getLocalName()) {
+        case SpectralDBEntry.XML_ELEMENT -> entry = SpectralDBEntry.loadFromXML(reader);
+        case SpectralSimilarity.XML_ELEMENT -> similarity = SpectralSimilarity.loadFromXML(reader);
+        case CONST.XML_RAW_FILE_SCAN_ELEMENT -> scan = Scan.loadScanFromXML(reader, possibleFiles);
+        case XML_CCS_ERROR_ELEMENT -> {
+          final String content = ParsingUtils.readNullableString(reader.getElementText());
+          ccsError = content != null ? Float.valueOf(content) : null;
+        }
+      }
+    }
+
+    assert entry != null && similarity != null;
+
+    SpectralDBAnnotation id = new SpectralDBAnnotation(entry, similarity, scan, ccsError);
+    return id;
+  }
+
+  @Nullable
+  public Scan getQueryScan() {
+    return queryScan;
+  }
+
+  public DataPoint[] getQueryDataPoints() {
+    if (queryScan == null || queryScan.getMassList() == null) {
+      return null;
+    }
+    return queryScan.getMassList().getDataPoints();
+  }
+
+  public DataPoint[] getLibraryDataPoints(DataPointsTag tag) {
+    switch (tag) {
+      case ORIGINAL:
+        return entry.getDataPoints();
+      case FILTERED:
+        return similarity.getLibrary();
+      case ALIGNED:
+        return similarity.getAlignedDataPoints()[0];
+      case MERGED:
+        return new DataPoint[0];
+    }
+    return new DataPoint[0];
+  }
+
+  public DataPoint[] getQueryDataPoints(DataPointsTag tag) {
+    switch (tag) {
+      case ORIGINAL:
+        DataPoint[] dp = getQueryDataPoints();
+        if (dp == null) {
+          return new DataPoint[0];
+        }
+        Arrays.sort(dp, new DataPointSorter(SortingProperty.MZ, SortingDirection.Ascending));
+        return dp;
+      case FILTERED:
+        return similarity.getQuery();
+      case ALIGNED:
+        return similarity.getAlignedDataPoints()[1];
+      case MERGED:
+        return new DataPoint[0];
+    }
+    return new DataPoint[0];
+  }
+
+  @Override
+  public @Nullable Double getPrecursorMZ() {
+    return entry.getPrecursorMZ();
+  }
+
+  @Override
+  public @Nullable String getSmiles() {
+    return entry.getOrElse(DBEntryField.SMILES, null);
+  }
+
+  @Override
+  public @Nullable String getCompoundName() {
+    return entry.getOrElse(DBEntryField.NAME, null);
+  }
+
+  @Override
+  public @Nullable String getFormula() {
+    return entry.getOrElse(DBEntryField.FORMULA, null);
+  }
+
+  @Override
+  public @Nullable IonType getAdductType() {
+    final String adduct = entry.getOrElse(DBEntryField.SMILES, null);
+    return IonType.parseFromString(adduct);
+  }
+
+  @Override
+  public @Nullable Float getMobility() {
+    return null;
+  }
+
+  @Override
+  public @Nullable Float getCCS() {
+    return entry.getOrElse(DBEntryField.CCS, null);
+  }
+
+  @Override
+  public @Nullable Float getRT() {
+    return entry.getOrElse(DBEntryField.RT, null);
+  }
+
+  @Override
+  public @Nullable String getDatabase() {
+    return null;
+  }
+
+  @Override
+  public @Nullable Float getScore() {
+    return (float) similarity.getScore();
+  }
+
+  public SpectralDBEntry getEntry() {
+    return entry;
+  }
+
+  public SpectralSimilarity getSimilarity() {
+    return similarity;
+  }
+
+  public Float getCCSError() {
+    return ccsError;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SpectralDBAnnotation that = (SpectralDBAnnotation) o;
+    return Objects.equals(getEntry(), that.getEntry()) && Objects.equals(getSimilarity(),
+        that.getSimilarity()) && Objects.equals(ccsError, that.ccsError) && Objects
+        .equals(getQueryScan().getScanNumber(), that.getQueryScan().getScanNumber())
+        && getQueryScan().getDataFile().equals(that.getQueryScan().getDataFile());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getEntry(), getSimilarity(), ccsError, getQueryScan());
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s (%.3f)", getCompoundName(), Objects.requireNonNullElse(getScore(), 0f));
+  }
+}

--- a/src/main/java/io/github/mzmine/util/spectraldb/entry/SpectralDBFeatureIdentity.java
+++ b/src/main/java/io/github/mzmine/util/spectraldb/entry/SpectralDBFeatureIdentity.java
@@ -37,8 +37,14 @@ import java.util.Objects;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
+import org.jetbrains.annotations.ApiStatus.ScheduledForRemoval;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * To be replaced by {@link SpectralDBAnnotation}.
+ */
+@Deprecated
+@ScheduledForRemoval
 public class SpectralDBFeatureIdentity extends SimpleFeatureIdentity {
 
   public static final String XML_IDENTITY_TYPE = "spectraldatabasefeatureidentity";

--- a/src/test/java/datamodel/AnnotationTypeTests.java
+++ b/src/test/java/datamodel/AnnotationTypeTests.java
@@ -278,7 +278,7 @@ public class AnnotationTypeTests {
     newIdentity.put(new MobilityType(), 0.56f);
     newIdentity.put(new IonTypeType(), ionType);
 
-    String name = newIdentity.getCompundName();
+    String name = newIdentity.getCompoundName();
 
     final CompoundDBAnnotation newIdentity2 = new SimpleCompoundDBAnnotation();
     newIdentity2.put(new CompoundNameType(), "mannose");

--- a/src/test/java/datamodel/IMSScanTypesTest.java
+++ b/src/test/java/datamodel/IMSScanTypesTest.java
@@ -49,8 +49,8 @@ import io.github.mzmine.util.scans.similarity.Weights;
 import io.github.mzmine.util.scans.similarity.impl.composite.CompositeCosineSpectralSimilarity;
 import io.github.mzmine.util.scans.similarity.impl.composite.CompositeCosineSpectralSimilarityParameters;
 import io.github.mzmine.util.spectraldb.entry.DBEntryField;
+import io.github.mzmine.util.spectraldb.entry.SpectralDBAnnotation;
 import io.github.mzmine.util.spectraldb.entry.SpectralDBEntry;
-import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -240,9 +240,9 @@ public class IMSScanTypesTest {
     SpectralSimilarity similarity = simFunc.getSimilarity(param, new MZTolerance(0.005, 15), 0,
         ScanUtils.extractDataPoints(library), ScanUtils.extractDataPoints(query));
 
-    List<SpectralDBFeatureIdentity> value = List.of(
-        new SpectralDBFeatureIdentity(query, entry, similarity, "Spectral DB matching", null),
-        new SpectralDBFeatureIdentity(query, entry, similarity, "Spectral DB matching", 0.034f));
+    List<SpectralDBAnnotation> value = List.of(
+        new SpectralDBAnnotation(entry, similarity, query, null),
+        new SpectralDBAnnotation(entry, similarity, query, 0.034f));
 
     DataTypeTestUtils.testSaveLoad(type, value, flist, row, null, null);
     DataTypeTestUtils.testSaveLoad(type, Collections.emptyList(), flist, row, null, null);

--- a/src/test/java/datamodel/RegularScanTypesTest.java
+++ b/src/test/java/datamodel/RegularScanTypesTest.java
@@ -52,8 +52,8 @@ import io.github.mzmine.util.scans.similarity.Weights;
 import io.github.mzmine.util.scans.similarity.impl.composite.CompositeCosineSpectralSimilarity;
 import io.github.mzmine.util.scans.similarity.impl.composite.CompositeCosineSpectralSimilarityParameters;
 import io.github.mzmine.util.spectraldb.entry.DBEntryField;
+import io.github.mzmine.util.spectraldb.entry.SpectralDBAnnotation;
 import io.github.mzmine.util.spectraldb.entry.SpectralDBEntry;
-import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -200,9 +200,9 @@ public class RegularScanTypesTest {
     SpectralSimilarity similarity = simFunc.getSimilarity(param, new MZTolerance(0.005, 15), 0,
         ScanUtils.extractDataPoints(library), ScanUtils.extractDataPoints(query));
 
-    List<SpectralDBFeatureIdentity> value = List.of(
-        new SpectralDBFeatureIdentity(query, entry, similarity, "Spectral DB matching", null),
-        new SpectralDBFeatureIdentity(query, entry, similarity, "Spectral DB matching", 0.043f));
+    List<SpectralDBAnnotation> value = List.of(
+        new SpectralDBAnnotation(entry, similarity, query, null),
+        new SpectralDBAnnotation(entry, similarity, query, 0.043f));
 
     DataTypeTestUtils.testSaveLoad(type, value, flist, row, null, null);
     DataTypeTestUtils.testSaveLoad(type, Collections.emptyList(), flist, row, null, null);


### PR DESCRIPTION
Big refactor to remove the SpectralDBFeatureIdentity and replace it by SpectralDBAnnotation. 
Introduced FeatureAnnotation as a super interface for SpectralDBAnnotation and CompoundDBAnnotation.

Compatibility is with the existing SpectralDBFeatureIdentity is maintained as long as it exists. (Projects can be loaded, but they a are replaced with SpectralDBAnnotations on save)