### PR TITLE
add MissingMassListException to MobilityScanStorage

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/impl/MobilityScanStorage.java
+++ b/src/main/java/io/github/mzmine/datamodel/impl/MobilityScanStorage.java
@@ -29,6 +29,7 @@ import io.github.mzmine.modules.dataprocessing.featdet_massdetection.centroid.Ce
 import io.github.mzmine.modules.dataprocessing.featdet_massdetection.centroid.CentroidMassDetectorParameters;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.util.MemoryMapStorage;
+import io.github.mzmine.util.exceptions.MissingMassListException;
 import java.nio.DoubleBuffer;
 import java.nio.IntBuffer;
 import java.util.ArrayList;
@@ -37,6 +38,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Memory efficient storage of {@link MobilityScan}s. Methods return an instance of {@link
+ * StoredMobilityScan} or {@link StoredMobilityScanMassList} which is garbage collected if not used
+ * anymore.
+ *
+ * @author https://github.com/steffenheu
+ */
 public class MobilityScanStorage {
 
   // raw data
@@ -268,6 +276,11 @@ public class MobilityScanStorage {
 
   // mass list
   public int getNumberOfMassListDatapoints(int index) {
+    if (massListStorageOffsets == null) {
+      throw new MissingMassListException(
+          "No mass list present for mobility scans. Run mass detection for scan type \"Mobility scans\" prior.",
+          null);
+    }
     assert index < getNumberOfMobilityScans();
     if (index < massListStorageOffsets.capacity() - 1) {
       return massListStorageOffsets.get(index + 1) - massListStorageOffsets.get(index);
@@ -281,6 +294,11 @@ public class MobilityScanStorage {
    * @return The storage offset (where data points of this mass list start)
    */
   public int getMassListStorageOffset(int index) {
+    if (massListStorageOffsets == null) {
+      throw new MissingMassListException(
+          "No mass list present for mobility scans. Run mass detection for scan type \"Mobility scans\" prior.",
+          null);
+    }
     return massListStorageOffsets.get(index);
   }
 
@@ -289,6 +307,11 @@ public class MobilityScanStorage {
    * @return The base peak index (may be -1 if no base peak was detected).
    */
   public int getMassListBasePeakIndex(int index) {
+    if (massListBasePeakIndices == null) {
+      throw new MissingMassListException(
+          "No mass list present for mobility scans. Run mass detection for scan type \"Mobility scans\" prior.",
+          null);
+    }
     return massListBasePeakIndices.get(index);
   }
 
@@ -296,6 +319,11 @@ public class MobilityScanStorage {
    * @return The maximum number of points in a mass list.
    */
   public int getMassListMaxNumPoints() {
+    if (massListMaxNumPoints == -1) {
+      throw new MissingMassListException(
+          "No mass list present for mobility scans. Run mass detection for scan type \"Mobility scans\" prior.",
+          null);
+    }
     return massListMaxNumPoints;
   }
 
@@ -303,36 +331,71 @@ public class MobilityScanStorage {
    * @return The total number of data points in all mobility scan-mass lists of this frame.
    */
   public int getMassListTotalNumPoints() {
+    if (massListIntensityValues == null) {
+      throw new MissingMassListException(
+          "No mass list present for mobility scans. Run mass detection for scan type \"Mobility scans\" prior.",
+          null);
+    }
     return massListIntensityValues.capacity();
   }
 
   public void getMassListMzValues(int mobilityScanIndex, double[] dst, int offset) {
+    if (massListMzValues == null) {
+      throw new MissingMassListException(
+          "No mass list present for mobility scans. Run mass detection for scan type \"Mobility scans\" prior.",
+          null);
+    }
     assert getNumberOfMassListDatapoints(mobilityScanIndex) + offset <= dst.length;
     massListMzValues.get(getMassListStorageOffset(mobilityScanIndex), dst, offset,
         getNumberOfMassListDatapoints(mobilityScanIndex));
   }
 
   public void getAllMassListMzValues(double[] dst) {
+    if (massListMzValues == null) {
+      throw new MissingMassListException(
+          "No mass list present for mobility scans. Run mass detection for scan type \"Mobility scans\" prior.",
+          null);
+    }
     assert dst.length >= getMassListTotalNumPoints();
     massListMzValues.get(0, dst, 0, getMassListTotalNumPoints());
   }
 
   public void getMassListIntensityValues(int mobilityScanIndex, double[] dst, int offset) {
+    if (massListIntensityValues == null) {
+      throw new MissingMassListException(
+          "No mass list present for mobility scans. Run mass detection for scan type \"Mobility scans\" prior.",
+          null);
+    }
     assert getNumberOfMassListDatapoints(mobilityScanIndex) + offset <= dst.length;
     massListIntensityValues.get(getMassListStorageOffset(mobilityScanIndex), dst, offset,
         getNumberOfMassListDatapoints(mobilityScanIndex));
   }
 
   public void getAllMassListIntensityValues(double[] dst) {
+    if (massListIntensityValues == null) {
+      throw new MissingMassListException(
+          "No mass list present for mobility scans. Run mass detection for scan type \"Mobility scans\" prior.",
+          null);
+    }
     assert dst.length >= getMassListTotalNumPoints();
     massListIntensityValues.get(0, dst, 0, getMassListTotalNumPoints());
   }
 
   public double getMassListMzValue(int mobilityScanIndex, int index) {
+    if (massListMzValues == null) {
+      throw new MissingMassListException(
+          "No mass list present for mobility scans. Run mass detection for scan type \"Mobility scans\" prior.",
+          null);
+    }
     return massListMzValues.get(getMassListStorageOffset(mobilityScanIndex) + index);
   }
 
   public double getMassListIntensityValue(int mobilityScanIndex, int index) {
+    if (massListIntensityValues == null) {
+      throw new MissingMassListException(
+          "No mass list present for mobility scans. Run mass detection for scan type \"Mobility scans\" prior.",
+          null);
+    }
     return massListIntensityValues.get(getMassListStorageOffset(mobilityScanIndex) + index);
   }
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ModularADAPChromatogramBuilderTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ModularADAPChromatogramBuilderTask.java
@@ -22,6 +22,7 @@ package io.github.mzmine.modules.dataprocessing.featdet_adapchromatogrambuilder;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeMap;
 import com.google.common.collect.TreeRangeMap;
+import io.github.mzmine.datamodel.IMSRawDataFile;
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.Scan;
@@ -129,7 +130,7 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
     if (scans.length == 0) {
       setStatus(TaskStatus.ERROR);
       setErrorMessage("There are no scans satisfying filtering values. Consider updating filters "
-                      + "with \"Set filters\" in the \"Scans\" parameter.");
+          + "with \"Set filters\" in the \"Scans\" parameter.");
       return;
     }
 
@@ -143,9 +144,9 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
       if (s.getRetentionTime() < prevRT) {
         setStatus(TaskStatus.ERROR);
         final String msg = "Retention time of scan #" + s.getScanNumber()
-                           + " is smaller then the retention time of the previous scan."
-                           + " Please make sure you only use scans with increasing retention times."
-                           + " You can restrict the scan numbers in the parameters, or you can use the Crop filter module";
+            + " is smaller then the retention time of the previous scan."
+            + " Please make sure you only use scans with increasing retention times."
+            + " You can restrict the scan numbers in the parameters, or you can use the Crop filter module";
         setErrorMessage(msg);
         return;
       }
@@ -158,8 +159,8 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
       if (level != scans[i].getMSLevel()) {
         MZmineCore.getDesktop().displayMessage(null,
             "MZmine thinks that you are running ADAP Chromatogram builder on both MS1- and MS2-scans. "
-            + "This will likely produce wrong results. "
-            + "Please, set the scan filter parameter to a specific MS level");
+                + "This will likely produce wrong results. "
+                + "Please, set the scan filter parameter to a specific MS level");
       }
     }
 
@@ -189,9 +190,16 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
         scan = scanData.nextScan();
       } catch (MissingMassListException e) {
         setStatus(TaskStatus.ERROR);
-        setErrorMessage(
-            "Scan #" + scanData.getCurrentScan().getScanNumber() + " from " + dataFile.getName()
-            + " does not have a mass list. Pleas run \"Raw data methods\" -> \"Mass detection\".");
+        StringBuilder b = new StringBuilder("Scan #");
+        b.append(scanData.getCurrentScan().getScanNumber()).append(" from ");
+        b.append(dataFile.getName());
+        b.append(
+            " does not have a mass list. Please run \"Raw data methods\" -> \"Mass detection\"");
+        if (dataFile instanceof IMSRawDataFile) {
+          b.append("\nIMS files require mass detection on the frame level (Scan type = \"Frames ");
+          b.append("only\" or \"All scan types\"");
+        }
+        setErrorMessage(b.toString());
         e.printStackTrace();
         return;
       }

--- a/src/main/java/io/github/mzmine/util/exceptions/MissingMassListException.java
+++ b/src/main/java/io/github/mzmine/util/exceptions/MissingMassListException.java
@@ -30,4 +30,14 @@ public class MissingMassListException extends RuntimeException {
     super("Missing mass list in scan " + ScanUtils.scanToString(scan, true) + ". " + message);
   }
 
+  /**
+   * This constructor is only to be used when no direct scan object is present. (e.g., {@link
+   * io.github.mzmine.datamodel.impl.MobilityScanStorage}) Use other constructors by default.
+   *
+   * @param message Error message
+   */
+  public MissingMassListException(String message) {
+    super(message);
+  }
+
 }


### PR DESCRIPTION
During gap filling just a NPE was shown if no mass detection was run. Exception added to MobilityScanStorage to show a more descriptive error message.