### PR TITLE
Lc-Image Aligner

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/MZmineProject.java
+++ b/src/main/java/io/github/mzmine/datamodel/MZmineProject.java
@@ -19,7 +19,6 @@
 package io.github.mzmine.datamodel;
 
 import io.github.mzmine.datamodel.features.FeatureList;
-import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.modules.io.projectload.CachedIMSRawDataFile;
 import io.github.mzmine.parameters.UserParameter;
 import io.github.mzmine.project.impl.ProjectChangeEvent.Type;
@@ -134,8 +133,7 @@ public interface MZmineProject {
 
   void removeProjectListener(ProjectChangeListener newListener);
 
-
-  void removeFeatureLists(@NotNull List<ModularFeatureList> featureLists);
+  void removeFeatureLists(@NotNull List<FeatureList> featureLists);
 
   /**
    * Returns all feature lists which contain given data file

--- a/src/main/java/io/github/mzmine/gui/mainwindow/MainMenu.fxml
+++ b/src/main/java/io/github/mzmine/gui/mainwindow/MainMenu.fxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright 2006-2021 The MZmine Development Team
+  ~ Copyright 2006-2020 The MZmine Development Team
   ~
   ~ This file is part of MZmine.
   ~
@@ -10,11 +10,12 @@
   ~ License, or (at your option) any later version.
   ~
   ~ MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
-  ~ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-  ~ General Public License for more details.
+  ~ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+  ~ Public License for more details.
   ~
   ~ You should have received a copy of the GNU General Public License along with MZmine; if not,
-  ~ write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+  ~ write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+  ~ USA
   ~
   -->
 
@@ -395,6 +396,8 @@
         userData="io.github.mzmine.modules.dataprocessing.align_hierarchical.HierarAlignerGcModule"/>
       <MenuItem text="ADAP aligner (GC)" onAction="#runModule"
         userData="io.github.mzmine.modules.dataprocessing.align_adap3.ADAP3AlignerModule"/>
+      <MenuItem text="LC-Image-Aligner" onAction="#runModule"
+        userData="io.github.mzmine.modules.dataprocessing.align_lcimage.LcImageAlignerModule"/>
     </Menu>
 
     <Menu text="Gap filling">

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_join/RowVsRowScore.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_join/RowVsRowScore.java
@@ -23,12 +23,12 @@ import io.github.mzmine.datamodel.features.FeatureListRow;
 /**
  * This class represents a score between feature list row and aligned feature list row
  */
-class RowVsRowScore implements Comparable<RowVsRowScore> {
+public class RowVsRowScore implements Comparable<RowVsRowScore> {
 
   double score;
   private FeatureListRow peakListRow, alignedRow;
 
-  RowVsRowScore(FeatureListRow peakListRow, FeatureListRow alignedRow, double mzMaxDiff,
+  public RowVsRowScore(FeatureListRow peakListRow, FeatureListRow alignedRow, double mzMaxDiff,
       double mzWeight, double rtMaxDiff, double rtWeight) {
 
     this.peakListRow = peakListRow;
@@ -43,7 +43,7 @@ class RowVsRowScore implements Comparable<RowVsRowScore> {
 
   }
 
-  RowVsRowScore(FeatureListRow peakListRow, FeatureListRow alignedRow, double mzMaxDiff,
+  public RowVsRowScore(FeatureListRow peakListRow, FeatureListRow alignedRow, double mzMaxDiff,
       double mzWeight, double rtMaxDiff, double rtWeight, double mobilityMaxDiff,
       double mobilityWeight) {
 
@@ -69,21 +69,21 @@ class RowVsRowScore implements Comparable<RowVsRowScore> {
   /**
    * This method returns the feature list row which is being aligned
    */
-  FeatureListRow getRowToAdd() {
+  public FeatureListRow getRowToAdd() {
     return peakListRow;
   }
 
   /**
    * This method returns the row of aligned feature list
    */
-  FeatureListRow getAlignedBaseRow() {
+  public FeatureListRow getAlignedBaseRow() {
     return alignedRow;
   }
 
   /**
    * This method returns score between the these two peaks (the lower score, the better match)
    */
-  double getScore() {
+  public double getScore() {
     return score;
   }
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_lcimage/LcImageAlignerModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_lcimage/LcImageAlignerModule.java
@@ -1,0 +1,46 @@
+package io.github.mzmine.modules.dataprocessing.align_lcimage;
+
+import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.modules.MZmineModuleCategory;
+import io.github.mzmine.modules.MZmineProcessingModule;
+import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.taskcontrol.Task;
+import io.github.mzmine.util.ExitCode;
+import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class LcImageAlignerModule implements MZmineProcessingModule {
+
+  @Override
+  public @NotNull String getName() {
+    return "LC-Image Aligner";
+  }
+
+  @Override
+  public @Nullable Class<? extends ParameterSet> getParameterSetClass() {
+    return LcImageAlignerParameters.class;
+  }
+
+  @Override
+  public @NotNull String getDescription() {
+    return "Aligns LC and imaging measurements based on m/z and mobility.\nImages are aligned to "
+        + "all LC features that match, only the best match is retained.";
+  }
+
+  @Override
+  public @NotNull ExitCode runModule(@NotNull MZmineProject project,
+      @NotNull ParameterSet parameters, @NotNull Collection<Task> tasks,
+      @NotNull Instant moduleCallDate) {
+    final MemoryMapStorage storage = MemoryMapStorage.forFeatureList();
+    tasks.add(new LcImageAlignerTask(storage, moduleCallDate, parameters, project));
+    return ExitCode.OK;
+  }
+
+  @Override
+  public @NotNull MZmineModuleCategory getModuleCategory() {
+    return MZmineModuleCategory.ALIGNMENT;
+  }
+}

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_lcimage/LcImageAlignerParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_lcimage/LcImageAlignerParameters.java
@@ -3,6 +3,7 @@ package io.github.mzmine.modules.dataprocessing.align_lcimage;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.datamodel.features.types.ImageType;
 import io.github.mzmine.parameters.Parameter;
+import io.github.mzmine.parameters.impl.IonMobilitySupport;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
 import io.github.mzmine.parameters.parametertypes.DoubleParameter;
 import io.github.mzmine.parameters.parametertypes.StringParameter;
@@ -13,6 +14,7 @@ import io.github.mzmine.parameters.parametertypes.tolerances.mobilitytolerance.M
 import java.text.DecimalFormat;
 import java.util.Arrays;
 import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 public class LcImageAlignerParameters extends SimpleParameterSet {
 
@@ -63,5 +65,10 @@ public class LcImageAlignerParameters extends SimpleParameterSet {
     }
 
     return superCheck && errorMessages.isEmpty();
+  }
+
+  @Override
+  public @NotNull IonMobilitySupport getIonMobilitySupport() {
+    return IonMobilitySupport.SUPPORTED;
   }
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_lcimage/LcImageAlignerParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_lcimage/LcImageAlignerParameters.java
@@ -6,6 +6,7 @@ import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.impl.IonMobilitySupport;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
 import io.github.mzmine.parameters.parametertypes.DoubleParameter;
+import io.github.mzmine.parameters.parametertypes.OptionalParameter;
 import io.github.mzmine.parameters.parametertypes.StringParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZToleranceParameter;
@@ -19,8 +20,7 @@ import org.jetbrains.annotations.NotNull;
 public class LcImageAlignerParameters extends SimpleParameterSet {
 
   public static final FeatureListsParameter flists = new FeatureListsParameter("Feature lists",
-      "Select two feature lists. The image feature list and the (pre-aligned) LC feature list.", 2,
-      2);
+      "Select two feature lists. The image feature list and the (pre-aligned) LC feature list.", 2, Integer.MAX_VALUE);
 
   public static final MZToleranceParameter mzTolerance = new MZToleranceParameter("m/z tolerance",
       "The file-to-file tolerance for two features.", 0.005, 10);
@@ -28,16 +28,16 @@ public class LcImageAlignerParameters extends SimpleParameterSet {
   public static final DoubleParameter mzWeight = new DoubleParameter("m/z weight",
       "Maximum score for a perfectly matching m/z", new DecimalFormat("0.0"), 1d);
 
-  public static final MobilityToleranceParameter mobTolerance = new MobilityToleranceParameter(
-      "Mobility tolerance",
-      "The file-to-file mobility tolerance. If the files don't contain mobility information, this parameter will be ignored.",
-      new MobilityTolerance(0.01f));
+  public static final OptionalParameter<MobilityToleranceParameter> mobTolerance = new OptionalParameter<>(
+      new MobilityToleranceParameter("Mobility tolerance",
+          "The file-to-file mobility tolerance. If the files don't contain mobility information, this parameter will be ignored.",
+          new MobilityTolerance(0.01f)), false);
 
   public static final DoubleParameter mobilityWeight = new DoubleParameter("Mobility weight",
       "Maximum score for a perfectly matching mobility", new DecimalFormat("0.0"), 1d);
 
   public static final StringParameter name = new StringParameter("Feature list name",
-      "The name of the new feature list. Use {lc} or {img} for the name of the input feature list.",
+      "The name of the new feature list. Use {lc} for the name of the input (LC/DI) feature list.",
       "{lc} img");
 
   public LcImageAlignerParameters() {
@@ -51,17 +51,15 @@ public class LcImageAlignerParameters extends SimpleParameterSet {
     final ModularFeatureList[] matchingFeatureLists = getValue(
         LcImageAlignerParameters.flists).getMatchingFeatureLists();
     final var imageList = Arrays.stream(matchingFeatureLists)
-        .filter(flist -> flist.getFeatureTypes().containsValue(new ImageType())).findAny()
-        .orElse(null);
-    final var baseList = Arrays.stream(matchingFeatureLists)
-        .filter(flist -> !flist.getFeatureTypes().containsValue(new ImageType())).findAny()
-        .orElse(null);
+        .filter(flist -> flist.getFeatureTypes().containsValue(new ImageType())).toList();
+    final var baseLists = Arrays.stream(matchingFeatureLists)
+        .filter(flist -> !flist.getFeatureTypes().containsValue(new ImageType())).toList();
 
-    if (imageList == null) {
+    if (imageList.isEmpty()) {
       errorMessages.add("No feature list with images selected.");
     }
-    if (baseList == null) {
-      errorMessages.add("No LC feature list selected.");
+    if (baseLists.size() != 1) {
+      errorMessages.add("Select a single LC/DI feature list (may be aligned).");
     }
 
     return superCheck && errorMessages.isEmpty();

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_lcimage/LcImageAlignerParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_lcimage/LcImageAlignerParameters.java
@@ -1,3 +1,21 @@
+/*
+ *  Copyright 2006-2022 The MZmine Development Team
+ *
+ *  This file is part of MZmine.
+ *
+ *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ *  General Public License as published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
+ *
+ *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ *  Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with MZmine; if not,
+ *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ *  USA
+ */
+
 package io.github.mzmine.modules.dataprocessing.align_lcimage;
 
 import io.github.mzmine.datamodel.features.ModularFeatureList;
@@ -20,7 +38,8 @@ import org.jetbrains.annotations.NotNull;
 public class LcImageAlignerParameters extends SimpleParameterSet {
 
   public static final FeatureListsParameter flists = new FeatureListsParameter("Feature lists",
-      "Select two feature lists. The image feature list and the (pre-aligned) LC feature list.", 2, Integer.MAX_VALUE);
+      "Select at least two feature lists. The image feature list(s) are aligned to a single (pre-aligned) LC feature list.",
+      2, Integer.MAX_VALUE);
 
   public static final MZToleranceParameter mzTolerance = new MZToleranceParameter("m/z tolerance",
       "The file-to-file tolerance for two features.", 0.005, 10);

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_lcimage/LcImageAlignerParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_lcimage/LcImageAlignerParameters.java
@@ -1,0 +1,67 @@
+package io.github.mzmine.modules.dataprocessing.align_lcimage;
+
+import io.github.mzmine.datamodel.features.ModularFeatureList;
+import io.github.mzmine.datamodel.features.types.ImageType;
+import io.github.mzmine.parameters.Parameter;
+import io.github.mzmine.parameters.impl.SimpleParameterSet;
+import io.github.mzmine.parameters.parametertypes.DoubleParameter;
+import io.github.mzmine.parameters.parametertypes.StringParameter;
+import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
+import io.github.mzmine.parameters.parametertypes.tolerances.MZToleranceParameter;
+import io.github.mzmine.parameters.parametertypes.tolerances.mobilitytolerance.MobilityTolerance;
+import io.github.mzmine.parameters.parametertypes.tolerances.mobilitytolerance.MobilityToleranceParameter;
+import java.text.DecimalFormat;
+import java.util.Arrays;
+import java.util.Collection;
+
+public class LcImageAlignerParameters extends SimpleParameterSet {
+
+  public static final FeatureListsParameter flists = new FeatureListsParameter("Feature lists",
+      "Select two feature lists. The image feature list and the (pre-aligned) LC feature list.", 2,
+      2);
+
+  public static final MZToleranceParameter mzTolerance = new MZToleranceParameter("m/z tolerance",
+      "The file-to-file tolerance for two features.", 0.005, 10);
+
+  public static final DoubleParameter mzWeight = new DoubleParameter("m/z weight",
+      "Maximum score for a perfectly matching m/z", new DecimalFormat("0.0"), 1d);
+
+  public static final MobilityToleranceParameter mobTolerance = new MobilityToleranceParameter(
+      "Mobility tolerance",
+      "The file-to-file mobility tolerance. If the files don't contain mobility information, this parameter will be ignored.",
+      new MobilityTolerance(0.01f));
+
+  public static final DoubleParameter mobilityWeight = new DoubleParameter("Mobility weight",
+      "Maximum score for a perfectly matching mobility", new DecimalFormat("0.0"), 1d);
+
+  public static final StringParameter name = new StringParameter("Feature list name",
+      "The name of the new feature list. Use {lc} or {img} for the name of the input feature list.",
+      "{lc} img");
+
+  public LcImageAlignerParameters() {
+    super(new Parameter[]{flists, mzTolerance, mzWeight, mobTolerance, mobilityWeight, name});
+  }
+
+  @Override
+  public boolean checkParameterValues(Collection<String> errorMessages) {
+    final boolean superCheck = super.checkParameterValues(errorMessages);
+
+    final ModularFeatureList[] matchingFeatureLists = getValue(
+        LcImageAlignerParameters.flists).getMatchingFeatureLists();
+    final var imageList = Arrays.stream(matchingFeatureLists)
+        .filter(flist -> flist.getFeatureTypes().containsValue(new ImageType())).findAny()
+        .orElse(null);
+    final var baseList = Arrays.stream(matchingFeatureLists)
+        .filter(flist -> !flist.getFeatureTypes().containsValue(new ImageType())).findAny()
+        .orElse(null);
+
+    if (imageList == null) {
+      errorMessages.add("No feature list with images selected.");
+    }
+    if (baseList == null) {
+      errorMessages.add("No LC feature list selected.");
+    }
+
+    return superCheck && errorMessages.isEmpty();
+  }
+}

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_lcimage/LcImageAlignerTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_lcimage/LcImageAlignerTask.java
@@ -1,0 +1,196 @@
+package io.github.mzmine.modules.dataprocessing.align_lcimage;
+
+import com.google.common.collect.Range;
+import com.google.common.util.concurrent.AtomicDouble;
+import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.features.Feature;
+import io.github.mzmine.datamodel.features.FeatureList;
+import io.github.mzmine.datamodel.features.FeatureListRow;
+import io.github.mzmine.datamodel.features.ModularFeature;
+import io.github.mzmine.datamodel.features.ModularFeatureList;
+import io.github.mzmine.datamodel.features.ModularFeatureListRow;
+import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
+import io.github.mzmine.datamodel.features.types.ImageType;
+import io.github.mzmine.modules.dataprocessing.align_join.RowVsRowScore;
+import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
+import io.github.mzmine.parameters.parametertypes.tolerances.mobilitytolerance.MobilityTolerance;
+import io.github.mzmine.taskcontrol.AbstractTask;
+import io.github.mzmine.taskcontrol.TaskStatus;
+import io.github.mzmine.util.FeatureListRowSorter;
+import io.github.mzmine.util.FeatureListUtils;
+import io.github.mzmine.util.MemoryMapStorage;
+import io.github.mzmine.util.RangeUtils;
+import io.github.mzmine.util.SortingDirection;
+import io.github.mzmine.util.SortingProperty;
+import it.unimi.dsi.fastutil.objects.Object2BooleanOpenHashMap;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class LcImageAlignerTask extends AbstractTask {
+
+  private static final Logger logger = Logger.getLogger(LcImageAlignerTask.class.getName());
+
+  private String description;
+  private double totalRows;
+
+  private final double mobWeight;
+  private final double mzWeight;
+  private final AtomicDouble progress = new AtomicDouble(0);
+  private final AtomicInteger scoredRows = new AtomicInteger(0);
+  private final AtomicInteger processedScores = new AtomicInteger(0);
+  private final AtomicInteger totalScores = new AtomicInteger(1);
+  private final ParameterSet parameters;
+  private final MZmineProject project;
+  private final FeatureList lcFeatureList;
+  private final FeatureList imageList;
+  private final MZTolerance mzTol;
+  private final MobilityTolerance mobTol;
+
+  public LcImageAlignerTask(@Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate,
+      @NotNull final ParameterSet parameters, @NotNull MZmineProject project) {
+    super(storage, moduleCallDate);
+
+    this.parameters = parameters;
+    this.project = project;
+
+    final ModularFeatureList[] matchingFeatureLists = parameters.getValue(
+        LcImageAlignerParameters.flists).getMatchingFeatureLists();
+
+    // checked in setup dialog
+    imageList = Arrays.stream(matchingFeatureLists)
+        .filter(flist -> flist.getFeatureTypes().containsValue(new ImageType())).findAny()
+        .orElse(null);
+    lcFeatureList = Arrays.stream(matchingFeatureLists)
+        .filter(flist -> !flist.getFeatureTypes().containsValue(new ImageType())).findAny()
+        .orElse(null);
+
+    totalRows = imageList.getNumberOfRows();
+    mzTol = parameters.getValue(LcImageAlignerParameters.mzTolerance);
+    mobTol = parameters.getValue(LcImageAlignerParameters.mobTolerance);
+    mzWeight = parameters.getValue(LcImageAlignerParameters.mzWeight);
+    mobWeight = parameters.getValue(LcImageAlignerParameters.mobilityWeight);
+    description =
+        "Aligning images from " + imageList.getName() + " on LC feature list " + lcFeatureList.getName();
+  }
+
+  @Override
+  public String getTaskDescription() {
+    return null;
+  }
+
+  @Override
+  public double getFinishedPercentage() {
+    return scoredRows.get() / totalRows * 0.8d
+        + processedScores.get() / (double) totalScores.get() * 0.2d;
+  }
+
+  @Override
+  public void run() {
+    setStatus(TaskStatus.PROCESSING);
+
+    // align images to all possible base list rows
+    final ConcurrentLinkedDeque<RowVsRowScore> scores = new ConcurrentLinkedDeque<>();
+
+    final List<FeatureList> sourceLists = List.of(lcFeatureList, imageList);
+    final List<RawDataFile> allDataFiles = FeatureListUtils.getAllDataFiles(sourceLists);
+    final ModularFeatureList alignedFlist = new ModularFeatureList(this.lcFeatureList.getName() + " img",
+        getMemoryMapStorage(), allDataFiles);
+    FeatureListUtils.transferRowTypes(alignedFlist, sourceLists);
+    FeatureListUtils.transferSelectedScans(alignedFlist, sourceLists);
+
+    final List<FeatureListRow> lcRows = this.lcFeatureList.getRows().stream().map(
+            row -> (FeatureListRow) new ModularFeatureListRow(alignedFlist, (ModularFeatureListRow) row,
+                true)).sorted(new FeatureListRowSorter(SortingProperty.MZ, SortingDirection.Ascending))
+        .toList();
+
+    // score all rows (parallel)
+    imageList.parallelStream().forEach(imageRow -> {
+      if (isCanceled()) {
+        return;
+      }
+
+      final Range<Double> mzRange = mzTol.getToleranceRange(imageRow.getAverageMZ());
+      final double maxMzDiff = RangeUtils.rangeLength(mzRange) / 2;
+      final Float mobility = imageRow.getAverageMobility();
+      final Range<Float> mobRange =
+          mobility != null ? mobTol.getToleranceRange(mobility) : Range.all();
+      final double maxMobDiff = mobRange.equals(Range.all()) ? Double.POSITIVE_INFINITY
+          : RangeUtils.rangeLength(mobRange);
+
+      final List<FeatureListRow> matchingLcRows = FeatureListUtils.getRows(lcRows, Range.all(),
+          mzRange, mobRange, true);
+      for (FeatureListRow lcRow : matchingLcRows) {
+        final RowVsRowScore score = new RowVsRowScore(imageRow, lcRow, maxMzDiff, mzWeight,
+            Double.POSITIVE_INFINITY, 0, maxMobDiff, mobWeight);
+        scores.add(score);
+      }
+      scoredRows.getAndIncrement();
+    });
+
+    if (isCanceled()) {
+      return;
+    }
+
+    final RowVsRowScore[] sortedScores = scores.stream().sorted(Comparator.reverseOrder())
+        .toArray(RowVsRowScore[]::new);
+    totalScores.set(scores.size());
+    addFeaturesBasedOnScores(sortedScores, alignedFlist);
+
+    lcRows.forEach(alignedFlist::addRow);
+
+    alignedFlist.getAppliedMethods().addAll(lcFeatureList.getAppliedMethods());
+    alignedFlist.getAppliedMethods().addAll(
+        new SimpleFeatureListAppliedMethod(LcImageAlignerModule.class, parameters,
+            getModuleCallDate()));
+
+    if (isCanceled()) {
+      return;
+    }
+
+    project.addFeatureList(alignedFlist);
+
+    setStatus(TaskStatus.FINISHED);
+  }
+
+  /**
+   * Copied from the join aligner, with the difference that we don't use the alignedRowsMap here, to
+   * keep track of the candidate (=image) rows that we align on the base feature list. Instead, an
+   * image feature may be present more than once in the resulting aligned feature list.
+   *
+   * @param scores Sorted descending 1 -> 0
+   */
+  @NotNull
+  private Object2BooleanOpenHashMap<FeatureListRow> addFeaturesBasedOnScores(RowVsRowScore[] scores,
+      ModularFeatureList alignedList) {
+    final Object2BooleanOpenHashMap<FeatureListRow> alignedRowsMap = new Object2BooleanOpenHashMap<>(
+        scores.length);
+
+    for (RowVsRowScore score : scores) {
+      final FeatureListRow alignedRow = score.getAlignedBaseRow(); // lc row = aligned row
+      final FeatureListRow row = score.getRowToAdd();
+      if (alignedRowsMap.getOrDefault(row, false)) {
+        logger.finest(() -> "Will align feature " + row.getID() + " multiple times");
+        // in join aligner we would stop here
+      }
+      for (Feature feature : row.getFeatures()) {
+        final RawDataFile dataFile = feature.getRawDataFile();
+        if (!alignedRow.hasFeature(
+            dataFile)) { // only add the best fit. If there is a fit already, don't align.
+          alignedRow.addFeature(dataFile, new ModularFeature(alignedList, feature), false);
+          alignedRowsMap.put(row, true);
+        }
+      }
+    }
+
+    return alignedRowsMap;
+  }
+}

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/FeatureListsParameter.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/FeatureListsParameter.java
@@ -31,11 +31,14 @@ import org.w3c.dom.NodeList;
 
 public class FeatureListsParameter implements UserParameter<FeatureListsSelection, FeatureListsComponent> {
 
+  private static final String DEFAULT_DESC = "Feature lists that this module will take as its input.";
+
   private String name = "Feature lists";
   private int minCount, maxCount;
 
   private @NotNull
   FeatureListsSelection value = new FeatureListsSelection();
+  private final String description;
 
   public FeatureListsParameter() {
     this(1, Integer.MAX_VALUE);
@@ -48,12 +51,21 @@ public class FeatureListsParameter implements UserParameter<FeatureListsSelectio
   public FeatureListsParameter(int minCount, int maxCount) {
     this.minCount = minCount;
     this.maxCount = maxCount;
+    description = DEFAULT_DESC;
   }
 
   public FeatureListsParameter(String name, int minCount, int maxCount) {
     this.name = name;
     this.minCount = minCount;
     this.maxCount = maxCount;
+    description = DEFAULT_DESC;
+  }
+
+  public FeatureListsParameter(String name, String description, int minCount, int maxCount) {
+    this.name = name;
+    this.minCount = minCount;
+    this.maxCount = maxCount;
+    this.description = description;
   }
 
   @Override
@@ -94,7 +106,7 @@ public class FeatureListsParameter implements UserParameter<FeatureListsSelectio
 
   @Override
   public String getDescription() {
-    return "Feature lists that this module will take as its input.";
+    return description;
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/project/impl/MZmineProjectImpl.java
+++ b/src/main/java/io/github/mzmine/project/impl/MZmineProjectImpl.java
@@ -285,7 +285,7 @@ public class MZmineProjectImpl implements MZmineProject {
 
 
   @Override
-  public void removeFeatureLists(@NotNull List<ModularFeatureList> featureLists) {
+  public void removeFeatureLists(@NotNull List<FeatureList> featureLists) {
     try {
       featureLock.writeLock().lock();
 


### PR DESCRIPTION
added a module to properly allow alignment of an (aligned) LC feature list and an image feature list.

Compared to the Join aligner, RT tolerance is removed and one image can be aligned to multiple LC features (since we miss one dimension of separation)
