### PR TITLE
fix mz calc in MzRangeFormulaCalculatorModule

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/IonizationType.java
+++ b/src/main/java/io/github/mzmine/datamodel/IonizationType.java
@@ -1,171 +1,190 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ *  Copyright 2006-2022 The MZmine Development Team
  *
- * This file is part of MZmine.
+ *  This file is part of MZmine.
  *
- * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
- * General Public License as published by the Free Software Foundation; either version 2 of the
- * License, or (at your option) any later version.
+ *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ *  General Public License as published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
  *
- * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License for more details.
+ *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ *  Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
- *
+ *  You should have received a copy of the GNU General Public License along with MZmine; if not,
+ *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ *  USA
  */
 
 package io.github.mzmine.datamodel;
 
+import io.github.mzmine.util.FormulaUtils;
+import java.util.Objects;
+import org.jetbrains.annotations.NotNull;
+import org.openscience.cdk.interfaces.IMolecularFormula;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
+import org.openscience.cdk.tools.manipulator.MolecularFormulaManipulator;
+
 public enum IonizationType {
 
-  NO_IONIZATION("No ionization", "", 0, PolarityType.NEUTRAL,-6,0,0), //
+  NO_IONIZATION("No ionization", "", "", PolarityType.NEUTRAL, -6, 0, 0), //
 
-  POSITIVE("[M]+", "+", -0.00054857990946, PolarityType.POSITIVE,-6,1,1), //
+  POSITIVE("[M]+", "", "", PolarityType.POSITIVE, -6, 1, 1), //
 
-  POSITIVE_HYDROGEN("[M+H]+", "H",1.007276,PolarityType.POSITIVE,-0.268998651917666,1,1), //
+  POSITIVE_HYDROGEN("[M+H]+", "H", "", PolarityType.POSITIVE, -0.268998651917666, 1, 1), //
 
-  SODIUM("[M+Na]+", "Na",22.989218,PolarityType.POSITIVE,-0.963288182616102,1,1), //
+  SODIUM("[M+Na]+", "Na", "", PolarityType.POSITIVE, -0.963288182616102, 1, 1), //
 
-  POTASSIUM("[M+K]+", "K", 38.963158,PolarityType.POSITIVE,-2.41599440912713,1,1), //
+  POTASSIUM("[M+K]+", "K", "", PolarityType.POSITIVE, -2.41599440912713, 1, 1), //
 
-  LITHIUM("[M+Li]+", "Li", 7.01546, PolarityType.POSITIVE,-6,1,1), //
+  LITHIUM("[M+Li]+", "Li", "", PolarityType.POSITIVE, -6, 1, 1), //
 
-  AMMONIUM("[M+NH4]+", "NH4",18.033823,PolarityType.POSITIVE,-2.49171512306525,1,1), //
+  AMMONIUM("[M+NH4]+", "NH4", "", PolarityType.POSITIVE, -2.49171512306525, 1, 1), //
 
-  NAME1("[M+2H-NH3]2+","H2",-15.0120166,PolarityType.POSITIVE,-3.51290442213519,1,2),//
+//  NAME1("[M+2H-NH3]2+", "H2", "NH3", -15.0120166, PolarityType.POSITIVE, -3.51290442213519, 1, 2),//
 
-  NAME2("[M]3+","",-0.001645737,PolarityType.POSITIVE,-3.51290442213519,1,3),//
+  NAME2("[M]3+", "", "", PolarityType.POSITIVE, -3.51290442213519, 1, 3),//
 
-  NAME3("[M]2+","",-0.0010404,PolarityType.POSITIVE,-3.51290442213519,1,2),//
+  NAME3("[M]2+", "", "", PolarityType.POSITIVE, -3.51290442213519, 1, 2),//
 
-  NAME4("[M+H]2+","H",1.006178842,PolarityType.POSITIVE,-3.33681316307951,1,2),//
+  NAME4("[M+H]2+", "H", "", PolarityType.POSITIVE, -3.33681316307951, 1, 2),//
 
-  NAME5("[M+2H]2+","H2",2.014552,PolarityType.POSITIVE,-1.81393441779917,1,2),//
+  NAME5("[M+2H]2+", "H2", "", PolarityType.POSITIVE, -1.81393441779917, 1, 2),//
 
-  NAME6("[M+H+Na]2+","NaH",23.996494,PolarityType.POSITIVE,-2.69999106549233,1,2),//
+  NAME6("[M+H+Na]2+", "NaH", "", PolarityType.POSITIVE, -2.69999106549233, 1, 2),//
 
-  NAME7("[M+2H+Na]3+","NaH2",25.0037736,PolarityType.POSITIVE,-3.81393441779917,1,3),//
+  NAME7("[M+2H+Na]3+", "NaH2", "", PolarityType.POSITIVE, -3.81393441779917, 1, 3),//
 
-  NAME8("[M+H+K]2+","KH",39.970434,PolarityType.POSITIVE,-2.23415082118236,1,2),//
+  NAME8("[M+H+K]2+", "KH", "", PolarityType.POSITIVE, -2.23415082118236, 1, 2),//
 
-  NAME9("[M+2Na]2+","Na2",45.978436,PolarityType.POSITIVE,-2.66780638212093,1,2),//
+  NAME9("[M+2Na]2+", "Na2", "", PolarityType.POSITIVE, -2.66780638212093, 1, 2),//
 
-  NAME10("[M+H+2Na]3+","Na2H",46.98573,PolarityType.POSITIVE,-3.51290442213519,1,3),//
+  NAME10("[M+H+2Na]3+", "Na2H", "", PolarityType.POSITIVE, -3.51290442213519, 1, 3),//
 
-  NAME11("[M+3Na]3+","Na3",68.967654,PolarityType.POSITIVE,-3.51290442213519,1,3),//
+  NAME11("[M+3Na]3+", "Na3", "", PolarityType.POSITIVE, -3.51290442213519, 1, 3),//
 
-  NAME13("[M+H-H2O]+","H",-17.0032778,PolarityType.POSITIVE,-0.747608492437131,1,1),//
+  NAME13("[M+H-H2O]+", "H", "H2O", PolarityType.POSITIVE, -0.747608492437131, 1, 1),//
 
-  NAME15("[M+H-NH3]+","H",-16.01927432,PolarityType.POSITIVE,-1.58862513607331,1,1),//
+  NAME15("[M+H-NH3]+", "H", "NH3", PolarityType.POSITIVE, -1.58862513607331, 1, 1),//
 
-  NAME16("[M-H+2Na]+","Na2",44.97116444,PolarityType.POSITIVE,-1.85969190835984,1,1),//
+  NAME16("[M-H+2Na]+", "Na2", "H", PolarityType.POSITIVE, -1.85969190835984, 1, 1),//
 
-  NAME18("[M-2H+3Na]+","Na3",66.9530814,PolarityType.POSITIVE,-1.91084443080722,1,1),//
+  NAME18("[M-2H+3Na]+", "Na3", "H2", PolarityType.POSITIVE, -1.91084443080722, 1, 1),//
 
-  NAME19("[M+H+H2O]+","H2OH",19.01786821,PolarityType.POSITIVE,-2.3225727239649,1,1),//
+  NAME19("[M+H+H2O]+", "H2OH", "", PolarityType.POSITIVE, -2.3225727239649, 1, 1),//
 
-  NAME22("[M-H+2K]+","K2",76.91904,PolarityType.POSITIVE,-3.11496441346315,1,1),//
+  NAME22("[M-H+2K]+", "K2", "H", PolarityType.POSITIVE, -3.11496441346315, 1, 1),//
 
-  NAME23("[M+H2O]+","H2O",18.010011,PolarityType.POSITIVE,-3.21187442647121,1,1),//
+  NAME23("[M+H2O]+", "H2O", "", PolarityType.POSITIVE, -3.21187442647121, 1, 1),//
 
-  NAME24("[M+H-OH]+","H",-15.99548193,PolarityType.POSITIVE,-3.21187442647121,1,1),//
+  NAME24("[M+H-OH]+", "H", "OH", PolarityType.POSITIVE, -3.21187442647121, 1, 1),//
 
-  NAME25("[M-H2O]+","",-18.0110879,PolarityType.POSITIVE,-3.51290442213519,1,1),//
+  NAME25("[M-H2O]+", "", "H2O", PolarityType.POSITIVE, -3.51290442213519, 1, 1),//
 
-  NAME26("[M-H]+","",-1.0083404,PolarityType.POSITIVE,-3.51290442213519,1,1),//
+  NAME26("[M-H]+", "", "H", PolarityType.POSITIVE, -3.51290442213519, 1, 1),//
 
-  NAME27("[M+Na-H2O]+","Na",4.978142219,PolarityType.POSITIVE,-3.51290442213519,1,1),//
+  NAME27("[M+Na-H2O]+", "Na", "H2O", PolarityType.POSITIVE, -3.51290442213519, 1, 1),//
 
-  NAME28("[M-2H+3K]+","K3",114.8748814,PolarityType.POSITIVE,-3.51290442213519,1,1),//
+  NAME28("[M-2H+3K]+", "K3", "H2", PolarityType.POSITIVE, -3.51290442213519, 1, 1),//
 
-  NAME29("[M+K-H2O]+","K",20.95204222,PolarityType.POSITIVE,-3.81393441779917,1,1),//
+  NAME29("[M+K-H2O]+", "K", "H2O", PolarityType.POSITIVE, -3.81393441779917, 1, 1),//
 
-  NAME30("[M-CO2H+H]+","H",-43.98986378,PolarityType.POSITIVE,-4.81393441779917,1,1),//
+  NAME30("[M-CO2H+H]+", "H", "CO2H", PolarityType.POSITIVE, -4.81393441779917, 1, 1),//
 
-  NAME32("[2M+H]+","H",1.007276,PolarityType.POSITIVE,-1.22398481647346,2,1),//
+  NAME32("[2M+H]+", "H", "", PolarityType.POSITIVE, -1.22398481647346, 2, 1),//
 
-  NAME37("[2M+Na]+","Na",22.989218,PolarityType.POSITIVE,-2.96883637778491,2,1),//
+  NAME37("[2M+Na]+", "Na", "", PolarityType.POSITIVE, -2.96883637778491, 2, 1),//
 
-  NAME34("[2M+Na-H2O]+","Na",4.978142219,PolarityType.POSITIVE,-3.81393441779917,2,1),//
+  NAME34("[2M+Na-H2O]+", "Na", "H2O", PolarityType.POSITIVE, -3.81393441779917, 2, 1),//
 
-  NAME35("[2M+K-H2O]+","K",20.95204222,PolarityType.POSITIVE,-3.81393441779917,2,1),//
+  NAME35("[2M+K-H2O]+", "K", "H2O", PolarityType.POSITIVE, -3.81393441779917, 2, 1),//
 
-  NAME38("[2M+K]+","K",38.96314222,PolarityType.POSITIVE,-3.81393441779917,2,1),//
+  NAME38("[2M+K]+", "K", "", PolarityType.POSITIVE, -3.81393441779917, 2, 1),//
 
-  NAME33("[3M+H]+","H",1.007276,PolarityType.POSITIVE,-2.26986637344889,3,1),//
+  NAME33("[3M+H]+", "H", "", PolarityType.POSITIVE, -2.26986637344889, 3, 1),//
 
-  NAME39("[3M+K]+","K",38.96314222,PolarityType.POSITIVE,-3.81393441779917,3,1),//
+  NAME39("[3M+K]+", "K", "", PolarityType.POSITIVE, -3.81393441779917, 3, 1),//
 
-  NAME36("[3M+K-H2O]+","K",20.95204222,PolarityType.POSITIVE,-4.81393441779917,3,1),//
+  NAME36("[3M+K-H2O]+", "K", "H2O", PolarityType.POSITIVE, -4.81393441779917, 3, 1),//
 
-  NAME31("[3M+H-H2O]+","H",-17.0032778,PolarityType.POSITIVE,-4.81393441779917,3,1),//
+  NAME31("[3M+H-H2O]+", "H", "H2O", PolarityType.POSITIVE, -4.81393441779917, 3, 1),//
 
-  NEGATIVE("[M]-", "-", 0.00054857990946, PolarityType.NEGATIVE,-6,1,-1), //
+  NEGATIVE("[M]-", "", "", PolarityType.NEGATIVE, -6, 1, -1), //
 
-  NEGATIVE_HYDROGEN("[M-H]-", "H",-1.007276,PolarityType.NEGATIVE,-0.172110574929576,1,-1), //
+  NEGATIVE_HYDROGEN("[M-H]-", "", "H", PolarityType.NEGATIVE, -0.172110574929576, 1, -1), //
 
-  NAME_2("[M+Na-3H]2-","Na",19.96739,PolarityType.NEGATIVE,-4.24802233641235,1,-2),//
+  NAME_2("[M+Na-3H]2-", "Na", "H3", PolarityType.NEGATIVE, -4.24802233641235, 1, -2),//
 
-  CARBONATE("[M+CO3]-", "CO3", 59.98529, PolarityType.NEGATIVE,-6,1,-1), //
+  CARBONATE("[M+CO3]-", "CO3", "", PolarityType.NEGATIVE, -6, 1, -1), //
 
-  FORMATE("[M+HCOO]-", "HCOO", 44.998201, PolarityType.NEGATIVE,-1,1,-1), //
+  FORMATE("[M+HCOO]-", "HCOO", "", PolarityType.NEGATIVE, -1, 1, -1), //
 
-  PHOSPHATE("[M+H2PO4]-", "H2PO4", 96.96962, PolarityType.NEGATIVE,-6,1,-1), //
+  PHOSPHATE("[M+H2PO4]-", "H2PO4", "", PolarityType.NEGATIVE, -6, 1, -1), //
 
-  ACETATE("[M+CH3COO]-", "CH3COO", 59.013851, PolarityType.NEGATIVE,-6,1,-1), //
+  ACETATE("[M+CH3COO]-", "CH3COO", "", PolarityType.NEGATIVE, -6, 1, -1), //
 
-  TRIFLUORACETATE("[M+CF3COO]-", "CF3COO", 112.985586, PolarityType.NEGATIVE,-6,1,-1), //
+  TRIFLUORACETATE("[M+CF3COO]-", "CF3COO", "", PolarityType.NEGATIVE, -6, 1, -1), //
 
-  CHLORIDE("[M+Cl]-", "Cl", 34.969402, PolarityType.NEGATIVE,-6,1,-1), //
+  CHLORIDE("[M+Cl]-", "Cl", "", PolarityType.NEGATIVE, -6, 1, -1), //
 
-  BROMIDE("[M+Br]-", "Br", 78.918885, PolarityType.NEGATIVE,-6,1,-1), //
+  BROMIDE("[M+Br]-", "Br", "", PolarityType.NEGATIVE, -6, 1, -1), //
 
-  NAME_1("[M-2H]2-","2H",-2.014552,PolarityType.NEGATIVE,-1.4029242963981,1,-2),//
+  NAME_1("[M-2H]2-", "", "H2", PolarityType.NEGATIVE, -1.4029242963981, 1, -2),//
 
-  NAME_4("[M-H-H2O]-","",-19.01839,PolarityType.NEGATIVE,-0.819887542383565,1,-1),//
+  NAME_4("[M-H-H2O]-", "", "H3O", PolarityType.NEGATIVE, -0.819887542383565, 1, -1),//
 
-  NAME_5("[M-H-NH3]-","",-18.03381516,PolarityType.NEGATIVE,-1.94699234074837,1,-1),//
+  NAME_5("[M-H-NH3]-", "", "NH4", PolarityType.NEGATIVE, -1.94699234074837, 1, -1),//
 
-  NAME_6("[M-H+H2O]-","H2O",17.003275,PolarityType.NEGATIVE,-2.13407898410552,1,-1),//
+  NAME_6("[M-H+H2O]-", "H2O", "H", PolarityType.NEGATIVE, -2.13407898410552, 1, -1),//
 
-  NAME_7("[M-2H]-","",-2.01506,PolarityType.NEGATIVE,-2.77090108169269,1,-1),//
+  NAME_7("[M-2H]-", "", "H2", PolarityType.NEGATIVE, -2.77090108169269, 1, -1),//
 
-  NAME_8("[M+K-2H]-","K",36.9486306,PolarityType.NEGATIVE,-3.24802233641235,1,-1),//
+  NAME_8("[M+K-2H]-", "K", "H2", PolarityType.NEGATIVE, -3.24802233641235, 1, -1),//
 
-  NAME_9("[M+Na-2H]-","Na",20.974666,PolarityType.NEGATIVE,-4.24802233641235,1,-1),//
+  NAME_9("[M+Na-2H]-", "Na", "H2", PolarityType.NEGATIVE, -4.24802233641235, 1, -1),//
 
-  NAME_10("[2M-H]-","",-1.007276,PolarityType.NEGATIVE,-0.978509392194437,2,-1),//
+  NAME_10("[2M-H]-", "", "H", PolarityType.NEGATIVE, -0.978509392194437, 2, -1),//
 
-  NAME_11("[3M-H]-","",-1.007276,PolarityType.NEGATIVE,-1.99274983130905,3,-1);
+  NAME_11("[3M-H]-", "", "H", PolarityType.NEGATIVE, -1.99274983130905, 3, -1);
 
   // log10freq records log base 10 observed frequency of adducts and fragments from available LC-MS1
   // spectra for pure compounds available in the NIST database introduced in CliqueMS algorithm. The
   // compounds whose frequency is not yet observed is given a minimum log frequency value of -6.0 .
 
-  private final String name, adductFormula;
+  private final String name;
+  private final IMolecularFormula addedFormula;
+  private final IMolecularFormula removedFormula;
   private final PolarityType polarity;
-  private final double addedMass, log10freq;
-  private final int numMol, charge;
+  private final double addedMass;
+  private final double log10freq;
+  private final int numMol;
+  private final int charge;
 
-  IonizationType(String name, String adductFormula, double addedMass, PolarityType polarity, double log10freq, int numMol, int charge) {
-
+  IonizationType(String name, @NotNull String addedFormula, @NotNull String removedFormula,
+      PolarityType polarity, double log10freq, int numMol, int charge) {
     this.name = name;
-    this.adductFormula = adductFormula;
-    this.addedMass = addedMass;
     this.log10freq = log10freq;
     this.polarity = polarity;
     this.numMol = numMol;
     this.charge = charge;
+    this.addedFormula =
+        !addedFormula.isBlank() ? MolecularFormulaManipulator.getMolecularFormula(addedFormula,
+            SilentChemObjectBuilder.getInstance()) : null;
+    this.removedFormula =
+        !removedFormula.isBlank() ? MolecularFormulaManipulator.getMolecularFormula(removedFormula,
+            SilentChemObjectBuilder.getInstance()) : null;
+
+    var added = this.addedFormula != null ? MolecularFormulaManipulator.getMass(this.addedFormula,
+        MolecularFormulaManipulator.MonoIsotopic) : 0d;
+    var removed =
+        this.removedFormula != null ? MolecularFormulaManipulator.getMass(this.removedFormula,
+            MolecularFormulaManipulator.MonoIsotopic) : 0d;
+
+    this.addedMass = (added - removed - charge * FormulaUtils.electronMass);
   }
 
   public String getAdductName() {
     return name;
-  }
-
-  public String getAdductFormula() {
-    return adductFormula;
   }
 
   public double getAddedMass() {
@@ -176,15 +195,15 @@ public enum IonizationType {
     return polarity;
   }
 
-  public double getLog10freq(){
+  public double getLog10freq() {
     return log10freq;
   }
 
-  public int getNumMol(){
+  public int getNumMol() {
     return numMol;
   }
 
-  public int getCharge(){
+  public int getCharge() {
     return charge;
   }
 
@@ -193,4 +212,34 @@ public enum IonizationType {
     return name;
   }
 
+  /**
+   * Ionizes the given formula. If a charged formula is given, the charges will be added together.
+   * See {@link FormulaUtils#getNeutralFormula(IMolecularFormula)} for formula neutralisation.
+   *
+   * @param formula The input formula.
+   * @return The ionized formula.
+   */
+  public IMolecularFormula ionizeFormula(@NotNull String formula) {
+    final IMolecularFormula form = MolecularFormulaManipulator.getMolecularFormula(formula,
+        SilentChemObjectBuilder.getInstance());
+    ionizeFormula(form);
+    return form;
+  }
+
+  /**
+   * Ionizes the given formula. If a charged formula is given, the charges will be added together.
+   * See {@link FormulaUtils#getNeutralFormula(IMolecularFormula)} for formula neutralisation.
+   *
+   * @param form The input formula.
+   */
+  public void ionizeFormula(IMolecularFormula form) {
+    if (addedFormula != null) {
+      form.add(addedFormula);
+    }
+    if (removedFormula != null) {
+      FormulaUtils.subtractFormula(form, removedFormula);
+    }
+    final int c = Objects.requireNonNullElse(form.getCharge(), 0);
+    form.setCharge(c + this.charge);
+  }
 }

--- a/src/main/java/io/github/mzmine/datamodel/IonizationType.java
+++ b/src/main/java/io/github/mzmine/datamodel/IonizationType.java
@@ -46,7 +46,7 @@ public enum IonizationType {
 
   NAME6("[M+H+Na]2+","NaH",23.996494,PolarityType.POSITIVE,-2.69999106549233,1,2),//
 
-  NAME7("[M+2H+Na]3+","NaH2",25.00377,PolarityType.POSITIVE,-3.81393441779917,1,3),//
+  NAME7("[M+2H+Na]3+","NaH2",25.0037736,PolarityType.POSITIVE,-3.81393441779917,1,3),//
 
   NAME8("[M+H+K]2+","KH",39.970434,PolarityType.POSITIVE,-2.23415082118236,1,2),//
 
@@ -139,7 +139,6 @@ public enum IonizationType {
   NAME_10("[2M-H]-","",-1.007276,PolarityType.NEGATIVE,-0.978509392194437,2,-1),//
 
   NAME_11("[3M-H]-","",-1.007276,PolarityType.NEGATIVE,-1.99274983130905,3,-1);
-
 
   // log10freq records log base 10 observed frequency of adducts and fragments from available LC-MS1
   // spectra for pure compounds available in the NIST database introduced in CliqueMS algorithm. The

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_formulaprediction/SingleRowPredictionTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_formulaprediction/SingleRowPredictionTask.java
@@ -1,19 +1,19 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ *  Copyright 2006-2022 The MZmine Development Team
  *
- * This file is part of MZmine.
+ *  This file is part of MZmine.
  *
- * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
- * General Public License as published by the Free Software Foundation; either version 2 of the
- * License, or (at your option) any later version.
+ *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ *  General Public License as published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
  *
- * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License for more details.
+ *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ *  Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
- *
+ *  You should have received a copy of the GNU General Public License along with MZmine; if not,
+ *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ *  USA
  */
 
 package io.github.mzmine.modules.dataprocessing.id_formulaprediction;
@@ -53,7 +53,6 @@ import org.openscience.cdk.formula.MolecularFormulaRange;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.interfaces.IMolecularFormula;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
-import org.openscience.cdk.tools.manipulator.MolecularFormulaManipulator;
 
 public class SingleRowPredictionTask extends AbstractTask {
 
@@ -250,15 +249,14 @@ public class SingleRowPredictionTask extends AbstractTask {
     // Calculate isotope similarity score
     final IsotopePattern detectedPattern = peakListRow.getBestIsotopePattern();
 
-    final String stringFormula = MolecularFormulaManipulator.getString(cdkFormula);
-
-    final String adjustedFormula = FormulaUtils.ionizeFormula(stringFormula, ionType, charge);
+    final IMolecularFormula clonedFormula = FormulaUtils.cloneFormula(cdkFormula);
+    ionType.ionizeFormula(clonedFormula);
 
     // Fixed min abundance
     final double minPredictedAbundance = 0.00001;
 
     final IsotopePattern predictedIsotopePattern = IsotopePatternCalculator
-        .calculateIsotopePattern(adjustedFormula, minPredictedAbundance, charge,
+        .calculateIsotopePattern(clonedFormula, minPredictedAbundance, charge,
             ionType.getPolarity());
 
     Float isotopeScore = null;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_formulapredictionfeaturelist/FormulaPredictionFeatureListTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_formulapredictionfeaturelist/FormulaPredictionFeatureListTask.java
@@ -1,19 +1,19 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ *  Copyright 2006-2022 The MZmine Development Team
  *
- * This file is part of MZmine.
+ *  This file is part of MZmine.
  *
- * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
- * General Public License as published by the Free Software Foundation; either version 2 of the
- * License, or (at your option) any later version.
+ *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ *  General Public License as published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
  *
- * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License for more details.
+ *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ *  Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
- *
+ *  You should have received a copy of the GNU General Public License along with MZmine; if not,
+ *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ *  USA
  */
 package io.github.mzmine.modules.dataprocessing.id_formulapredictionfeaturelist;
 
@@ -55,7 +55,6 @@ import org.openscience.cdk.formula.MolecularFormulaRange;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.interfaces.IMolecularFormula;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
-import org.openscience.cdk.tools.manipulator.MolecularFormulaManipulator;
 
 public class FormulaPredictionFeatureListTask extends AbstractTask {
 
@@ -288,16 +287,14 @@ public class FormulaPredictionFeatureListTask extends AbstractTask {
     Float isotopeScore = null;
     if ((checkIsotopes) && (detectedPattern != null)) {
 
-      String stringFormula = MolecularFormulaManipulator.getString(cdkFormula);
-
-      String adjustedFormula = FormulaUtils.ionizeFormula(stringFormula, ionType, charge);
+      final IMolecularFormula clonedFormula = FormulaUtils.cloneFormula(cdkFormula);
+      ionType.ionizeFormula(clonedFormula);
 
       final double detectedPatternHeight = detectedPattern.getBasePeakIntensity();
-
       final double minPredictedAbundance = isotopeNoiseLevel / detectedPatternHeight;
 
       predictedIsotopePattern = IsotopePatternCalculator
-          .calculateIsotopePattern(adjustedFormula, minPredictedAbundance, charge,
+          .calculateIsotopePattern(clonedFormula, minPredictedAbundance, charge,
               ionType.getPolarity());
 
       isotopeScore = IsotopePatternScoreCalculator

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_lipididentification/lipididentificationtools/MSMSLipidTools.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_lipididentification/lipididentificationtools/MSMSLipidTools.java
@@ -1,32 +1,23 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ *  Copyright 2006-2022 The MZmine Development Team
  *
- * This file is part of MZmine.
+ *  This file is part of MZmine.
  *
- * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
- * General Public License as published by the Free Software Foundation; either version 2 of the
- * License, or (at your option) any later version.
+ *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ *  General Public License as published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
  *
- * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License for more details.
+ *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ *  Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
- *
+ *  You should have received a copy of the GNU General Public License along with MZmine; if not,
+ *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ *  USA
  */
 
 package io.github.mzmine.modules.dataprocessing.id_lipididentification.lipididentificationtools;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
-import org.openscience.cdk.tools.manipulator.MolecularFormulaManipulator;
 import com.google.common.collect.Range;
 import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.IonizationType;
@@ -44,6 +35,15 @@ import io.github.mzmine.modules.dataprocessing.id_lipididentification.lipidutils
 import io.github.mzmine.modules.dataprocessing.id_lipididentification.lipidutils.MatchedLipid;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.util.FormulaUtils;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
+import org.openscience.cdk.tools.manipulator.MolecularFormulaManipulator;
 
 /**
  * This class contains methods for MS/MS lipid identifications
@@ -216,7 +216,8 @@ public class MSMSLipidTools {
       Double mzFragmentExact = FormulaUtils.calculateExactMass(fragmentFormula);
       List<String> fattyAcidFormulas = CHAIN_TOOLS.calculateFattyAcidFormulas();
       for (String fattyAcidFormula : fattyAcidFormulas) {
-        FormulaUtils.ionizeFormula(fattyAcidFormula, IonizationType.NEGATIVE_HYDROGEN, 1);
+//        @Ansgar the result is not used and the method itself is buggy as hell - please write a test
+//        FormulaUtils.ionizeFormula(fattyAcidFormula, IonizationType.NEGATIVE_HYDROGEN, 1);
         Double mzExact = FormulaUtils.calculateExactMass(fattyAcidFormula) - mzFragmentExact;
         if (mzTolRangeMSMS.contains(mzExact)) {
           int chainLength = CHAIN_TOOLS.getChainLengthFromFormula(fattyAcidFormula);

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_onlinecompounddb/PeakListIdentificationTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_onlinecompounddb/PeakListIdentificationTask.java
@@ -1,19 +1,19 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ *  Copyright 2006-2022 The MZmine Development Team
  *
- * This file is part of MZmine.
+ *  This file is part of MZmine.
  *
- * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
- * General Public License as published by the Free Software Foundation; either version 2 of the
- * License, or (at your option) any later version.
+ *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ *  General Public License as published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
  *
- * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License for more details.
+ *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ *  Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
- *
+ *  You should have received a copy of the GNU General Public License along with MZmine; if not,
+ *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ *  USA
  */
 
 package io.github.mzmine.modules.dataprocessing.id_onlinecompounddb;
@@ -36,7 +36,6 @@ import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.ExceptionUtils;
 import io.github.mzmine.util.FeatureListRowSorter;
-import io.github.mzmine.util.FormulaUtils;
 import io.github.mzmine.util.SortingDirection;
 import io.github.mzmine.util.SortingProperty;
 import java.io.IOException;
@@ -45,6 +44,7 @@ import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.openscience.cdk.interfaces.IMolecularFormula;
 
 public class PeakListIdentificationTask extends AbstractTask {
 
@@ -211,15 +211,15 @@ public class PeakListIdentificationTask extends AbstractTask {
       if (isotopeFilter && rowIsotopePattern != null && formula != null) {
 
         // First modify the formula according to ionization.
-        final String adjustedFormula = FormulaUtils.ionizeFormula(formula, ionType, charge);
+        final IMolecularFormula ionizedFormula = ionType.ionizeFormula(formula);
 
         logger.finest(
             "Calculating isotope pattern for compound formula " + formula + " adjusted to "
-            + adjustedFormula);
+            + ionizedFormula);
 
         // Generate IsotopePattern for this compound
         final IsotopePattern compoundIsotopePattern = IsotopePatternCalculator
-            .calculateIsotopePattern(adjustedFormula, MIN_ABUNDANCE, charge, ionType.getPolarity());
+            .calculateIsotopePattern(ionizedFormula, MIN_ABUNDANCE, charge, ionType.getPolarity());
 
         // Check isotope pattern match
         boolean check = IsotopePatternScoreCalculator

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_onlinecompounddb/SingleRowIdentificationTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_onlinecompounddb/SingleRowIdentificationTask.java
@@ -1,19 +1,19 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ *  Copyright 2006-2022 The MZmine Development Team
  *
- * This file is part of MZmine.
+ *  This file is part of MZmine.
  *
- * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
- * General Public License as published by the Free Software Foundation; either version 2 of the
- * License, or (at your option) any later version.
+ *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ *  General Public License as published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
  *
- * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License for more details.
+ *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ *  Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
- *
+ *  You should have received a copy of the GNU General Public License along with MZmine; if not,
+ *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ *  USA
  */
 
 package io.github.mzmine.modules.dataprocessing.id_onlinecompounddb;
@@ -40,13 +40,14 @@ import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.ExceptionUtils;
-import io.github.mzmine.util.FormulaUtils;
 import java.text.NumberFormat;
 import java.time.Instant;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.application.Platform;
 import org.jetbrains.annotations.NotNull;
+import org.openscience.cdk.interfaces.IMolecularFormula;
+import org.openscience.cdk.tools.manipulator.MolecularFormulaManipulator;
 
 
 public class SingleRowIdentificationTask extends AbstractTask {
@@ -178,15 +179,15 @@ public class SingleRowIdentificationTask extends AbstractTask {
         if (formula != null) {
 
           // First modify the formula according to the ionization
-          String adjustedFormula = FormulaUtils.ionizeFormula(formula, ionType, charge);
+          final IMolecularFormula ionizedFormula = ionType.ionizeFormula(formula);
 
           logger.finest(
               "Calculating isotope pattern for compound formula " + formula + " adjusted to "
-              + adjustedFormula);
+              + MolecularFormulaManipulator.getString(ionizedFormula));
 
           // Generate IsotopePattern for this compound
           IsotopePattern compoundIsotopePattern = IsotopePatternCalculator
-              .calculateIsotopePattern(adjustedFormula, 0.001, charge, ionType.getPolarity());
+              .calculateIsotopePattern(ionizedFormula, 0.001, charge, ionType.getPolarity());
 
           compound.put(IsotopePatternType.class, compoundIsotopePattern);
 

--- a/src/main/java/io/github/mzmine/modules/tools/kovats/KovatsIndexExtractionDialog.java
+++ b/src/main/java/io/github/mzmine/modules/tools/kovats/KovatsIndexExtractionDialog.java
@@ -302,7 +302,7 @@ public class KovatsIndexExtractionDialog extends ParameterSetupDialog {
     lbCurrentAlkane.setText(formula);
     // set mz
     Range<Double> mzRange = MzRangeFormulaCalculatorModule.getMzRangeFromFormula(formula,
-        IonizationType.POSITIVE, new MZTolerance(0.75, 0), 1);
+        IonizationType.POSITIVE, new MZTolerance(0.75, 0));
     ((MZRangeComponent) getComponentForParameter(KovatsIndexExtractionParameters.mzRange))
         .setValue(mzRange);
   }

--- a/src/main/java/io/github/mzmine/modules/tools/mzrangecalculator/MzRangeFormulaCalculatorModule.java
+++ b/src/main/java/io/github/mzmine/modules/tools/mzrangecalculator/MzRangeFormulaCalculatorModule.java
@@ -1,19 +1,19 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ *  Copyright 2006-2022 The MZmine Development Team
  *
- * This file is part of MZmine.
+ *  This file is part of MZmine.
  *
- * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
- * General Public License as published by the Free Software Foundation; either version 2 of the
- * License, or (at your option) any later version.
+ *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ *  General Public License as published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
  *
- * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License for more details.
+ *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ *  Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
- *
+ *  You should have received a copy of the GNU General Public License along with MZmine; if not,
+ *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ *  USA
  */
 
 package io.github.mzmine.modules.tools.mzrangecalculator;
@@ -29,7 +29,6 @@ import io.github.mzmine.util.FormulaUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.openscience.cdk.interfaces.IMolecularFormula;
-import org.openscience.cdk.tools.manipulator.MolecularFormulaManipulator;
 
 /**
  * m/z range calculator module. Calculates m/z range from a given chemical formula and m/z
@@ -90,15 +89,8 @@ public class MzRangeFormulaCalculatorModule implements MZmineModule {
       return null;
     }
 
-    @Nullable IMolecularFormula neutralFormula = FormulaUtils.getNeutralFormula(formula);
-    if (neutralFormula == null) {
-      return Range.closed(0d, 1000d);
-    }
-
-    final double neutralMass = MolecularFormulaManipulator.getMass(neutralFormula,
-        MolecularFormulaManipulator.MonoIsotopic);
-    final double ionizedMass =
-        (ionType.getAddedMass() + neutralMass) / Math.abs(ionType.getCharge());
+    final IMolecularFormula iMolecularFormula = ionType.ionizeFormula(formula);
+    final double ionizedMass = FormulaUtils.calculateMzRatio(iMolecularFormula);
 
     return mzTolerance.getToleranceRange(ionizedMass);
   }

--- a/src/main/java/io/github/mzmine/modules/tools/mzrangecalculator/MzRangeFormulaCalculatorParameters.java
+++ b/src/main/java/io/github/mzmine/modules/tools/mzrangecalculator/MzRangeFormulaCalculatorParameters.java
@@ -23,7 +23,6 @@ import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
 import io.github.mzmine.parameters.parametertypes.ComboParameter;
 import io.github.mzmine.parameters.parametertypes.FormulaParameter;
-import io.github.mzmine.parameters.parametertypes.IntegerParameter;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZToleranceParameter;
 
 public class MzRangeFormulaCalculatorParameters extends SimpleParameterSet {
@@ -34,13 +33,10 @@ public class MzRangeFormulaCalculatorParameters extends SimpleParameterSet {
       new ComboParameter<IonizationType>("Ionization type",
           "Please choose the type of ion to produce from the formula", IonizationType.values());
 
-  static final IntegerParameter charge =
-      new IntegerParameter("Charge", "Charge of the ion", 1, 1, null);
-
   static final MZToleranceParameter mzTolerance = new MZToleranceParameter();
 
   public MzRangeFormulaCalculatorParameters() {
-    super(new Parameter[] {formula, ionType, charge, mzTolerance});
+    super(new Parameter[] {formula, ionType, mzTolerance});
   }
 
 }

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/datapointprocessing/identification/sumformulaprediction/DPPSumFormulaPredictionTask.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/simplespectra/datapointprocessing/identification/sumformulaprediction/DPPSumFormulaPredictionTask.java
@@ -1,19 +1,19 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ *  Copyright 2006-2022 The MZmine Development Team
  *
- * This file is part of MZmine.
+ *  This file is part of MZmine.
  *
- * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
- * General Public License as published by the Free Software Foundation; either version 2 of the
- * License, or (at your option) any later version.
+ *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ *  General Public License as published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
  *
- * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License for more details.
+ *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ *  Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with MZmine; if not,
- * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
- *
+ *  You should have received a copy of the GNU General Public License along with MZmine; if not,
+ *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ *  USA
  */
 
 package io.github.mzmine.modules.visualization.spectra.simplespectra.datapointprocessing.identification.sumformulaprediction;
@@ -307,9 +307,8 @@ public class DPPSumFormulaPredictionTask extends DataPointProcessingTask {
       IsotopePattern detectedPattern) {
 
     IsotopePattern predictedIsotopePattern = null;
-    String stringFormula = MolecularFormulaManipulator.getString(cdkFormula);
-
-    String adjustedFormula = FormulaUtils.ionizeFormula(stringFormula, ionType, charge);
+    final IMolecularFormula clonedFormula = FormulaUtils.cloneFormula(cdkFormula);
+    ionType.ionizeFormula(clonedFormula);
 
     Integer isotopeBasePeak = detectedPattern.getBasePeakIndex();
     if (isotopeBasePeak == null) {
@@ -320,7 +319,7 @@ public class DPPSumFormulaPredictionTask extends DataPointProcessingTask {
     final double minPredictedAbundance = isotopeNoiseLevel / detectedPatternHeight;
 
     predictedIsotopePattern = IsotopePatternCalculator
-        .calculateIsotopePattern(adjustedFormula, minPredictedAbundance, charge,
+        .calculateIsotopePattern(clonedFormula, minPredictedAbundance, charge,
             ionType.getPolarity());
 
     return IsotopePatternScoreCalculator

--- a/src/main/java/io/github/mzmine/util/FormulaUtils.java
+++ b/src/main/java/io/github/mzmine/util/FormulaUtils.java
@@ -19,7 +19,6 @@ package io.github.mzmine.util;
 
 import io.github.mzmine.datamodel.IonizationType;
 import io.github.mzmine.datamodel.identities.MolecularFormulaIdentity;
-import io.github.mzmine.datamodel.identities.iontype.IonType;
 import java.io.IOException;
 import java.util.Hashtable;
 import java.util.List;
@@ -249,7 +248,8 @@ public class FormulaUtils {
 
   /**
    * Modifies the formula according to the ionization type
-   */
+   @deprecated Does not work properly.
+   @Deprecated
   public static String ionizeFormula(String formula, IonType ionType, int charge) {
     StringBuilder combinedFormula = new StringBuilder();
     combinedFormula.append(formula);
@@ -259,11 +259,13 @@ public class FormulaUtils {
 
     Map<String, Integer> parsedFormula = parseFormula(combinedFormula.toString());
     return formatFormula(parsedFormula);
-  }
+  }*/
 
   /**
-   * Modifies the formula according to the ionization type
+   * Modifies the formula according to the ionization type.
+   * @deprecated Does not work properly.
    */
+  @Deprecated
   public static String ionizeFormula(String formula, IonizationType ionType, int charge) {
 
     // No ionization

--- a/src/test/java/modules/MzRangeFormulaCalculatorModuleTest.java
+++ b/src/test/java/modules/MzRangeFormulaCalculatorModuleTest.java
@@ -1,3 +1,21 @@
+/*
+ *  Copyright 2006-2022 The MZmine Development Team
+ *
+ *  This file is part of MZmine.
+ *
+ *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ *  General Public License as published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
+ *
+ *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ *  Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with MZmine; if not,
+ *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ *  USA
+ */
+
 package modules;
 
 import com.google.common.collect.Range;
@@ -13,22 +31,22 @@ public class MzRangeFormulaCalculatorModuleTest {
   void getMzRangeFromFormula() {
 
     final MZTolerance tol = new MZTolerance(0.01, 5);
-    Assertions.assertEquals(Range.closed(16.020751548090537, 16.04075154809054),
+    Assertions.assertEquals(Range.closed(16.02075154809093, 16.040751548090935),
         MzRangeFormulaCalculatorModule.getMzRangeFromFormula("CH4", IonizationType.POSITIVE, tol));
-    Assertions.assertEquals(Range.closed(16.021848707909456, 16.04184870790946),
+    Assertions.assertEquals(Range.closed(16.02184870790906, 16.041848707909065),
         MzRangeFormulaCalculatorModule.getMzRangeFromFormula("CH4", IonizationType.NEGATIVE, tol));
-    Assertions.assertEquals(Range.closed(17.028576127999997, 17.048576128),
+    Assertions.assertEquals(Range.closed(17.02857658009093, 17.048576580090934),
         MzRangeFormulaCalculatorModule.getMzRangeFromFormula("CH4",
             IonizationType.POSITIVE_HYDROGEN, tol));
-    Assertions.assertEquals(Range.closed(15.014024127999997, 15.034024127999997),
+    Assertions.assertEquals(Range.closed(15.014023675909064, 15.034023675909063),
         MzRangeFormulaCalculatorModule.getMzRangeFromFormula("CH4",
             IonizationType.NEGATIVE_HYDROGEN, tol));
-    Assertions.assertEquals(Range.closed(129.00688612800002, 129.026886128),
+    Assertions.assertEquals(Range.closed(129.00688760790908, 129.02688760790906),
         MzRangeFormulaCalculatorModule.getMzRangeFromFormula("CH4", IonizationType.TRIFLUORACETATE,
             tol));
-    Assertions.assertEquals(Range.closed(6.998374063999999, 7.018374063999999),
+    Assertions.assertEquals(Range.closed(6.998373611909065, 7.018373611909064),
         MzRangeFormulaCalculatorModule.getMzRangeFromFormula("CH4", IonizationType.NAME_1, tol));
-    Assertions.assertEquals(Range.closed(13.668357909333334, 13.688357909333334),
+    Assertions.assertEquals(Range.closed(13.668357910757603, 13.688357910757603),
         MzRangeFormulaCalculatorModule.getMzRangeFromFormula("CH4", IonizationType.NAME7, tol));
   }
 }

--- a/src/test/java/modules/MzRangeFormulaCalculatorModuleTest.java
+++ b/src/test/java/modules/MzRangeFormulaCalculatorModuleTest.java
@@ -1,0 +1,34 @@
+package modules;
+
+import com.google.common.collect.Range;
+import io.github.mzmine.datamodel.IonizationType;
+import io.github.mzmine.modules.tools.mzrangecalculator.MzRangeFormulaCalculatorModule;
+import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class MzRangeFormulaCalculatorModuleTest {
+
+  @Test
+  void getMzRangeFromFormula() {
+
+    final MZTolerance tol = new MZTolerance(0.01, 5);
+    Assertions.assertEquals(Range.closed(16.020751548090537, 16.04075154809054),
+        MzRangeFormulaCalculatorModule.getMzRangeFromFormula("CH4", IonizationType.POSITIVE, tol));
+    Assertions.assertEquals(Range.closed(16.021848707909456, 16.04184870790946),
+        MzRangeFormulaCalculatorModule.getMzRangeFromFormula("CH4", IonizationType.NEGATIVE, tol));
+    Assertions.assertEquals(Range.closed(17.028576127999997, 17.048576128),
+        MzRangeFormulaCalculatorModule.getMzRangeFromFormula("CH4",
+            IonizationType.POSITIVE_HYDROGEN, tol));
+    Assertions.assertEquals(Range.closed(15.014024127999997, 15.034024127999997),
+        MzRangeFormulaCalculatorModule.getMzRangeFromFormula("CH4",
+            IonizationType.NEGATIVE_HYDROGEN, tol));
+    Assertions.assertEquals(Range.closed(129.00688612800002, 129.026886128),
+        MzRangeFormulaCalculatorModule.getMzRangeFromFormula("CH4", IonizationType.TRIFLUORACETATE,
+            tol));
+    Assertions.assertEquals(Range.closed(6.998374063999999, 7.018374063999999),
+        MzRangeFormulaCalculatorModule.getMzRangeFromFormula("CH4", IonizationType.NAME_1, tol));
+    Assertions.assertEquals(Range.closed(13.668357909333334, 13.688357909333334),
+        MzRangeFormulaCalculatorModule.getMzRangeFromFormula("CH4", IonizationType.NAME7, tol));
+  }
+}

--- a/src/test/java/modules/MzRangeFormulaCalculatorModuleTest.java
+++ b/src/test/java/modules/MzRangeFormulaCalculatorModuleTest.java
@@ -38,7 +38,7 @@ public class MzRangeFormulaCalculatorModuleTest {
     Assertions.assertEquals(Range.closed(17.02857658009093, 17.048576580090934),
         MzRangeFormulaCalculatorModule.getMzRangeFromFormula("CH4",
             IonizationType.POSITIVE_HYDROGEN, tol));
-    Assertions.assertEquals(Range.closed(15.014023675909064, 15.034023675909063),
+    Assertions.assertEquals(Range.closed(15.014023675909066, 15.034023675909065),
         MzRangeFormulaCalculatorModule.getMzRangeFromFormula("CH4",
             IonizationType.NEGATIVE_HYDROGEN, tol));
     Assertions.assertEquals(Range.closed(129.00688760790908, 129.02688760790906),

--- a/src/test/java/util/FormulaUtilsTest.java
+++ b/src/test/java/util/FormulaUtilsTest.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright 2006-2022 The MZmine Development Team
+ *
+ *  This file is part of MZmine.
+ *
+ *  MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ *  General Public License as published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
+ *
+ *  MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ *  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ *  Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with MZmine; if not,
+ *  write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+ *  USA
+ */
+
+package util;
+
+import io.github.mzmine.datamodel.IonizationType;
+import io.github.mzmine.util.FormulaUtils;
+import java.util.logging.Logger;
+import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.openscience.cdk.interfaces.IMolecularFormula;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
+import org.openscience.cdk.tools.manipulator.MolecularFormulaManipulator;
+
+public class FormulaUtilsTest {
+
+  private static final Logger logger = Logger.getLogger(FormulaUtilsTest.class.getName());
+
+  @Test
+  void testIonizationType() {
+    final String nacetylglucosamine = "C8H15NO6";
+    final double neutralMass = MolecularFormulaManipulator.getMass(
+        MolecularFormulaManipulator.getMolecularFormula(nacetylglucosamine,
+            SilentChemObjectBuilder.getInstance()), MolecularFormulaManipulator.MonoIsotopic);
+    for (IonizationType it : IonizationType.values()) {
+      if (it == IonizationType.NO_IONIZATION) {
+        continue;
+      }
+      final IMolecularFormula glucose = MolecularFormulaManipulator.getMolecularFormula(
+          nacetylglucosamine, SilentChemObjectBuilder.getInstance());
+
+      it.ionizeFormula(glucose);
+
+      logger.info(it.toString() + " " + MolecularFormulaManipulator.getString(glucose));
+      Assert.assertEquals(Math.abs((neutralMass + it.getAddedMass()) / it.getCharge()),
+          FormulaUtils.calculateMzRatio(glucose), 0.0000001d);
+    }
+  }
+
+  @Test
+  void testNeutralizeFormula() {
+    final IMolecularFormula neutralGlucose = MolecularFormulaManipulator.getMolecularFormula(
+        "C6H12O6", SilentChemObjectBuilder.getInstance());
+
+    final IMolecularFormula n1 = FormulaUtils.getNeutralFormula("C6H12O6");
+    final IMolecularFormula n2 = FormulaUtils.getNeutralFormula("C6H13O6+");
+    final IMolecularFormula n3 = FormulaUtils.getNeutralFormula("C6H11O6-");
+
+    Assertions.assertEquals(MolecularFormulaManipulator.getString(neutralGlucose), MolecularFormulaManipulator.getString(n1));
+    Assertions.assertEquals(MolecularFormulaManipulator.getString(neutralGlucose), MolecularFormulaManipulator.getString(n2));
+    Assertions.assertEquals(MolecularFormulaManipulator.getString(neutralGlucose), MolecularFormulaManipulator.getString(n3));
+
+    final IMolecularFormula n4 = FormulaUtils.getNeutralFormula(FormulaUtils.getFomulaFromSmiles("OC(O1)C(O)C(O)C(O)C1CO"));
+    final IMolecularFormula n5 = FormulaUtils.getNeutralFormula(FormulaUtils.getFomulaFromSmiles("OC(O1)C(O)C(O)C([OH2+])C1CO"));
+    final IMolecularFormula n6 = FormulaUtils.getNeutralFormula(FormulaUtils.getFomulaFromSmiles("OC(O1)C(O)C(O)C([O-])C1CO"));
+
+    Assertions.assertEquals(MolecularFormulaManipulator.getString(neutralGlucose), MolecularFormulaManipulator.getString(n4));
+    Assertions.assertEquals(MolecularFormulaManipulator.getString(neutralGlucose), MolecularFormulaManipulator.getString(n5));
+    Assertions.assertEquals(MolecularFormulaManipulator.getString(neutralGlucose), MolecularFormulaManipulator.getString(n6));
+  }
+}

--- a/src/test/java/util/FormulaUtilsTest.java
+++ b/src/test/java/util/FormulaUtilsTest.java
@@ -74,4 +74,13 @@ public class FormulaUtilsTest {
     Assertions.assertEquals(MolecularFormulaManipulator.getString(neutralGlucose), MolecularFormulaManipulator.getString(n5));
     Assertions.assertEquals(MolecularFormulaManipulator.getString(neutralGlucose), MolecularFormulaManipulator.getString(n6));
   }
+
+  @Test
+  void testCalcMz() {
+    // M - H + 2Na
+    final IMolecularFormula molecularFormula = MolecularFormulaManipulator.getMolecularFormula(
+        "[C6H11O6Na2]+", SilentChemObjectBuilder.getInstance());
+
+    Assertions.assertEquals((float) 225.0345531, (float)FormulaUtils.calculateMzRatio(molecularFormula));
+  }
 }


### PR DESCRIPTION
FormulaUtils is full of bugs and without clear documentation what some functions do. 
`public static String ionizeFormula(String formula, IonizationType ionType, int charge)`
does not work at all with IonizationType, the [M-2H+Na] is just added as a String and does a ton of garbage, because it does not work in conjunction with FormulaUtils.parseFormula. These functions need to be removed ASAP and replaced with actually working ones.