### PR TITLE
bump to jdk18

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,8 +17,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
-          distribution: adopt
-          java-version: 17.0.2
+          distribution: temurin
+          java-version: 18.0.1
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2

--- a/build.gradle
+++ b/build.gradle
@@ -41,8 +41,8 @@ semver {
 group = "io.github.mzmine"
 description = "MZmine"
 
-sourceCompatibility = "17"
-targetCompatibility = "17"
+sourceCompatibility = "18"
+targetCompatibility = "18"
 defaultTasks "test", "jpackage"
 
 // Check the OS


### PR DESCRIPTION
changed the build actions on GitHub to temurin JDK which is the successor of adopt.
Also bumped to jdk18.0.1

https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/
https://adoptium.net/