### PR TITLE
Options for TaskManager position

### DIFF
--- a/src/main/java/io/github/mzmine/gui/WindowLocation.java
+++ b/src/main/java/io/github/mzmine/gui/WindowLocation.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2006-2022 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+package io.github.mzmine.gui;
+
+/**
+ * Location of main elements e.g. the TaskViewer
+ */
+public enum WindowLocation {
+  MAIN, TAB, EXTERNAL, HIDDEN
+}

--- a/src/main/java/io/github/mzmine/gui/mainwindow/MainMenu.fxml
+++ b/src/main/java/io/github/mzmine/gui/mainwindow/MainMenu.fxml
@@ -562,16 +562,18 @@
   </Menu>
 
   <!-- WINDOWS -->
-  <WindowsMenu/>
+  <WindowsMenu>
+    <Menu text="Task manager">
+      <MenuItem text="Hide" onAction="#hideTaskViewer"/>
+      <MenuItem text="Main window" onAction="#setTaskViewerBottom"/>
+      <MenuItem text="External window" onAction="#setTaskViewerExternal"/>
+      <MenuItem text="Tab" onAction="#setTaskViewerTab"/>
+    </Menu>
+    <SeparatorMenuItem/>
+  </WindowsMenu>
 
   <!-- HELP -->
   <Menu text="Help">
-    <Menu text="Task manager">
-      <MenuItem text="Hide" onAction="#hideTaskViewer"/>
-      <MenuItem text="Bottom" onAction="#setTaskViewerBottom"/>
-      <MenuItem text="External" onAction="#setTaskViewerExternal"/>
-      <MenuItem text="Tab" onAction="#setTaskViewerTab"/>
-    </Menu>
     <MenuItem text="About MZmine" onAction="#showAbout"/>
     <MenuItem text="Open documentation (MZmine 3)" onAction="#openLink"
       userData="https://mzmine.github.io/mzmine_documentation/"/>

--- a/src/main/java/io/github/mzmine/gui/mainwindow/MainMenu.fxml
+++ b/src/main/java/io/github/mzmine/gui/mainwindow/MainMenu.fxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright 2006-2020 The MZmine Development Team
+  ~ Copyright 2006-2022 The MZmine Development Team
   ~
   ~ This file is part of MZmine.
   ~
@@ -10,12 +10,11 @@
   ~ License, or (at your option) any later version.
   ~
   ~ MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
-  ~ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
-  ~ Public License for more details.
+  ~ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
   ~
   ~ You should have received a copy of the GNU General Public License along with MZmine; if not,
-  ~ write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
-  ~ USA
+  ~ write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
   ~
   -->
 
@@ -567,6 +566,12 @@
 
   <!-- HELP -->
   <Menu text="Help">
+    <Menu text="Task manager">
+      <MenuItem text="Hide" onAction="#hideTaskViewer"/>
+      <MenuItem text="Bottom" onAction="#setTaskViewerBottom"/>
+      <MenuItem text="External" onAction="#setTaskViewerExternal"/>
+      <MenuItem text="Tab" onAction="#setTaskViewerTab"/>
+    </Menu>
     <MenuItem text="About MZmine" onAction="#showAbout"/>
     <MenuItem text="Open documentation (MZmine 3)" onAction="#openLink"
       userData="https://mzmine.github.io/mzmine_documentation/"/>

--- a/src/main/java/io/github/mzmine/gui/mainwindow/MainMenuController.java
+++ b/src/main/java/io/github/mzmine/gui/mainwindow/MainMenuController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ * Copyright 2006-2022 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -22,6 +22,7 @@ import io.github.mzmine.gui.Desktop;
 import io.github.mzmine.gui.MZmineGUI;
 import io.github.mzmine.gui.NewVersionCheck;
 import io.github.mzmine.gui.NewVersionCheck.CheckType;
+import io.github.mzmine.gui.WindowLocation;
 import io.github.mzmine.gui.mainwindow.introductiontab.MZmineIntroductionTab;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.MZmineModule;
@@ -228,6 +229,22 @@ public class MainMenuController {
 
   public void showMSnTreeTab(ActionEvent actionEvent) {
     MSnTreeVisualizerModule.showNewTab();
+  }
+
+  public void setTaskViewerBottom(ActionEvent e) {
+    MZmineGUI.handleTaskManagerLocationChange(WindowLocation.MAIN);
+  }
+
+  public void setTaskViewerTab(ActionEvent e) {
+    MZmineGUI.handleTaskManagerLocationChange(WindowLocation.TAB);
+  }
+
+  public void setTaskViewerExternal(ActionEvent e) {
+    MZmineGUI.handleTaskManagerLocationChange(WindowLocation.EXTERNAL);
+  }
+
+  public void hideTaskViewer(ActionEvent e) {
+    MZmineGUI.handleTaskManagerLocationChange(WindowLocation.HIDDEN);
   }
 }
 

--- a/src/main/java/io/github/mzmine/gui/mainwindow/MainWindow.fxml
+++ b/src/main/java/io/github/mzmine/gui/mainwindow/MainWindow.fxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright 2006-2020 The MZmine Development Team
+  ~ Copyright 2006-2022 The MZmine Development Team
   ~
   ~ This file is part of MZmine.
   ~
@@ -10,12 +10,11 @@
   ~ License, or (at your option) any later version.
   ~
   ~ MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
-  ~ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
-  ~ Public License for more details.
+  ~ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
   ~
   ~ You should have received a copy of the GNU General Public License along with MZmine; if not,
-  ~ write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
-  ~ USA
+  ~ write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
   ~
   -->
 
@@ -187,7 +186,7 @@
       </SplitPane>
     </center>
     <bottom>
-      <VBox>
+      <VBox fx:id="bottomBox">
         <TableView fx:id="tasksView" minHeight="100" prefHeight="100.0">
           <columnResizePolicy>
             <TableView fx:constant="CONSTRAINED_RESIZE_POLICY"/>

--- a/src/main/java/io/github/mzmine/gui/mainwindow/MainWindowController.java
+++ b/src/main/java/io/github/mzmine/gui/mainwindow/MainWindowController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ * Copyright 2006-2022 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -123,10 +123,10 @@ import org.controlsfx.control.StatusBar;
 
 public class MainWindowController {
 
-  private static final Image featureListSingleIcon = FxIconUtil
-      .loadImageFromResources("icons/peaklisticon_single.png");
-  private static final Image featureListAlignedIcon = FxIconUtil
-      .loadImageFromResources("icons/peaklisticon_aligned.png");
+  private static final Image featureListSingleIcon = FxIconUtil.loadImageFromResources(
+      "icons/peaklisticon_single.png");
+  private static final Image featureListAlignedIcon = FxIconUtil.loadImageFromResources(
+      "icons/peaklisticon_aligned.png");
   private static final NumberFormat percentFormat = NumberFormat.getPercentInstance();
   private final Logger logger = Logger.getLogger(this.getClass().getName());
   @FXML
@@ -157,6 +157,8 @@ public class MainWindowController {
   public ColorPickerMenuItem rawDataFileColorPicker;
   @FXML
   private Scene mainScene;
+  @FXML
+  public VBox bottomBox;
   @FXML
   private GroupableListView<RawDataFile> rawDataList;
   @FXML
@@ -223,8 +225,8 @@ public class MainWindowController {
     spectralLibraryList.setEditable(false);
     spectralLibraryList.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
 
-    rawDataList
-        .setCellFactory(rawDataListView -> new GroupableListViewCell<>(rawDataGroupMenuItem) {
+    rawDataList.setCellFactory(
+        rawDataListView -> new GroupableListViewCell<>(rawDataGroupMenuItem) {
 
           @Override
           protected void updateItem(GroupableListViewEntity item, boolean empty) {
@@ -260,8 +262,8 @@ public class MainWindowController {
               return;
             }
 
-            RawDataFileRenameModule
-                .renameFile(((ValueEntity<RawDataFile>) item).getValue(), getText());
+            RawDataFileRenameModule.renameFile(((ValueEntity<RawDataFile>) item).getValue(),
+                getText());
           }
         });
 
@@ -350,9 +352,9 @@ public class MainWindowController {
         change.next();
 
         for (Tab tab : MZmineCore.getDesktop().getAllTabs()) {
-          if (tab instanceof MZmineTab && tab.isSelected() && ((MZmineTab) tab)
-              .isUpdateOnSelection() && !(CollectionUtils
-              .isEqualCollection(((MZmineTab) tab).getRawDataFiles(), change.getList()))) {
+          if (tab instanceof MZmineTab && tab.isSelected()
+              && ((MZmineTab) tab).isUpdateOnSelection() && !(CollectionUtils.isEqualCollection(
+              ((MZmineTab) tab).getRawDataFiles(), change.getList()))) {
             ((MZmineTab) tab).onRawDataFileSelectionChanged(change.getList());
           }
         }
@@ -363,9 +365,9 @@ public class MainWindowController {
       MZmineCore.runLater(() -> {
         change.next();
         for (Tab tab : MZmineCore.getDesktop().getAllTabs()) {
-          if (tab instanceof MZmineTab && tab.isSelected() && ((MZmineTab) tab)
-              .isUpdateOnSelection() && !(CollectionUtils
-              .isEqualCollection(((MZmineTab) tab).getFeatureLists(), change.getList()))) {
+          if (tab instanceof MZmineTab && tab.isSelected()
+              && ((MZmineTab) tab).isUpdateOnSelection() && !(CollectionUtils.isEqualCollection(
+              ((MZmineTab) tab).getFeatureLists(), change.getList()))) {
             ((MZmineTab) tab).onFeatureListSelectionChanged(change.getList());
           }
         }
@@ -465,11 +467,7 @@ public class MainWindowController {
             }
 
             // Setting color should be enabled only if files are selected
-            if (rawDataList.getSelectedValues().size() > 0) {
-              rawDataSetColorMenu.setDisable(false);
-            } else {
-              rawDataSetColorMenu.setDisable(true);
-            }
+            rawDataSetColorMenu.setDisable(rawDataList.getSelectedValues().size() <= 0);
 
             if (rawDataList.getSelectedValues().size() == 1) {
               rawDataRemoveMenuItem.setText("Remove file");
@@ -855,7 +853,7 @@ public class MainWindowController {
 
   @FXML
   public void handleRemoveFeatureList(Event event) {
-    FeatureList selectedFeatureLists[] = MZmineCore.getDesktop().getSelectedPeakLists();
+    FeatureList[] selectedFeatureLists = MZmineCore.getDesktop().getSelectedPeakLists();
     for (FeatureList fl : selectedFeatureLists) {
       MZmineCore.getProjectManager().getCurrentProject().removeFeatureList(fl);
     }
@@ -926,6 +924,15 @@ public class MainWindowController {
     return FXCollections.unmodifiableObservableList(getMainTabPane().getTabs());
   }
 
+  /**
+   * Remove tab with matching title
+   *
+   * @param title the matching title
+   */
+  public void removeTab(String title) {
+    getMainTabPane().getTabs().removeIf(t -> title.equals(t.getText()));
+  }
+
   public void addTab(Tab tab) {
     if (tab instanceof MZmineTab) {
       ((MZmineTab) tab).updateOnSelectionProperty().addListener(((obs, old, val) -> {
@@ -943,10 +950,8 @@ public class MainWindowController {
       }));
     }
 
-    if (getMainTabPane().getTabs().contains(tab)) {
-      // sometimes we have duplicate tabs, which leads to exceptions. This is a dirty fix for now.
-      getMainTabPane().getTabs().remove(tab);
-    }
+    // sometimes we have duplicate tabs, which leads to exceptions. This is a dirty fix for now.
+    getMainTabPane().getTabs().remove(tab);
     getMainTabPane().getTabs().add(tab);
     getMainTabPane().getSelectionModel().select(tab);
   }
@@ -1016,4 +1021,7 @@ public class MainWindowController {
     }
   }
 
+  public VBox getBottomBox() {
+    return bottomBox;
+  }
 }

--- a/src/main/java/io/github/mzmine/util/dialogs/SimpleWindow.java
+++ b/src/main/java/io/github/mzmine/util/dialogs/SimpleWindow.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2006-2022 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+package io.github.mzmine.util.dialogs;
+
+import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.util.javafx.WindowsMenu;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.layout.BorderPane;
+import javafx.stage.Stage;
+
+/**
+ * A simple window that shows one entity.
+ *
+ * @author Robin Schmid (https://github.com/robinschmid)
+ */
+public class SimpleWindow extends Stage {
+
+  private final Scene mainScene;
+  private final BorderPane mainPane;
+
+  public SimpleWindow(String title, Node content) {
+    setTitle(title);
+    mainPane = new BorderPane(content);
+    mainScene = new Scene(mainPane);
+
+    // Use main CSS
+    mainScene.getStylesheets()
+        .addAll(MZmineCore.getDesktop().getMainWindow().getScene().getStylesheets());
+    setScene(mainScene);
+
+    // Add the Windows menu
+    WindowsMenu.addWindowsMenu(mainScene);
+    this.show();
+  }
+}

--- a/src/main/java/io/github/mzmine/util/javafx/WindowsMenu.java
+++ b/src/main/java/io/github/mzmine/util/javafx/WindowsMenu.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ * Copyright 2006-2022 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -34,7 +34,6 @@ import javafx.stage.Window;
 
 /**
  * Dynamically-built Windows menu.
- *
  */
 public class WindowsMenu extends Menu {
 
@@ -55,7 +54,7 @@ public class WindowsMenu extends Menu {
 
     // If the menu has <= 3 items, it means only the main MZmine window is showing
     itemsProperty = new SimpleListProperty<>(getItems());
-    closeAllMenuItem.disableProperty().bind(itemsProperty.sizeProperty().lessThanOrEqualTo(3));
+    closeAllMenuItem.disableProperty().bind(itemsProperty.sizeProperty().lessThanOrEqualTo(5));
 
     getItems().addAll(closeAllMenuItem, new SeparatorMenuItem());
 
@@ -78,8 +77,9 @@ public class WindowsMenu extends Menu {
   }
 
   private void fillWindowsMenu() {
-    while (getItems().size() > 2)
-      getItems().remove(2);
+    while (getItems().size() > 4) {
+      getItems().remove(4);
+    }
     for (Window win : Window.getWindows()) {
       if (win instanceof Stage) {
         Stage stage = (Stage) win;
@@ -96,8 +96,9 @@ public class WindowsMenu extends Menu {
     // Close all JavaFX Windows
     final var allWindows = ImmutableList.copyOf(Stage.getWindows());
     for (Window window : allWindows) {
-      if (window == MZmineCore.getDesktop().getMainWindow())
+      if (window == MZmineCore.getDesktop().getMainWindow()) {
         continue;
+      }
       logger.finest("Closing window " + window);
       window.hide();
     }


### PR DESCRIPTION
Options to show task manager in
- hide
- main
- tab
- external window

That fixes two things:
- you can actually see more tasks at the same time
- You can better see the raw data overview


See examples of the task manager in a tab or window: 
![image](https://user-images.githubusercontent.com/10366914/171236126-1d9b7b76-835b-448a-947a-a37442f1edf6.png)

![image](https://user-images.githubusercontent.com/10366914/171236242-87639cfa-5467-4eab-af87-9a809bdc92ba.png)
