### PR TITLE
Column widths in scan table

### DIFF
--- a/src/main/java/io/github/mzmine/modules/visualization/rawdataoverview/RawDataFileInfoPane.fxml
+++ b/src/main/java/io/github/mzmine/modules/visualization/rawdataoverview/RawDataFileInfoPane.fxml
@@ -107,8 +107,8 @@
           text="Precursor m/z"/>
         <TableColumn fx:id="mzRangeColumn" editable="false" prefWidth="115" text="m/z range"/>
         <TableColumn fx:id="scanTypeColumn" editable="false" prefWidth="95.0" text="Scan type"/>
-        <TableColumn fx:id="polarityColumn" editable="false" prefWidth="58.0" text="Polarity"/>
-        <TableColumn fx:id="definitionColumn" minWidth="0.0"  prefWidth="125.0"
+        <TableColumn fx:id="polarityColumn" editable="false" prefWidth="62.0" text="Polarity"/>
+        <TableColumn fx:id="definitionColumn" minWidth="15"  prefWidth="125.0"
           text="Scan definition" editable="false"/>
       </columns>
     </TableView>

--- a/src/main/java/io/github/mzmine/modules/visualization/rawdataoverview/RawDataFileInfoPane.fxml
+++ b/src/main/java/io/github/mzmine/modules/visualization/rawdataoverview/RawDataFileInfoPane.fxml
@@ -6,7 +6,7 @@
 <?import javafx.geometry.Insets?>
 
 <!--
-  ~ Copyright 2006-2021 The MZmine Development Team
+  ~ Copyright 2006-2022 The MZmine Development Team
   ~
   ~ This file is part of MZmine.
   ~
@@ -94,21 +94,21 @@
   <center>
     <TableView fx:id="rawDataTableView" BorderPane.alignment="CENTER">
       <columnResizePolicy>
-        <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
+<!--        <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />-->
 	  </columnResizePolicy>
       <columns>
-        <TableColumn fx:id="scanColumn" editable="false" prefWidth="75.0" text="Scan #"/>
-        <TableColumn fx:id="rtColumn" editable="false" prefWidth="75.0" text="Retention time"/>
-        <TableColumn fx:id="basePeakColumn" editable="false" prefWidth="75.0" text="Base peak"/>
-        <TableColumn fx:id="basePeakIntensityColumn" editable="false" prefWidth="75.0"
-          text="Base peak intenstity"/>
-        <TableColumn fx:id="msLevelColumn" editable="false" prefWidth="60.0" text="MS level"/>
-        <TableColumn fx:id="precursorMzColumn" editable="false" prefWidth="75.0"
+        <TableColumn fx:id="scanColumn" editable="false" prefWidth="35" text="Scan"/>
+        <TableColumn fx:id="rtColumn" editable="false" prefWidth="35" text="RT"/>
+        <TableColumn fx:id="basePeakColumn" editable="false" prefWidth="80" text="Base peak"/>
+        <TableColumn fx:id="basePeakIntensityColumn" editable="false" prefWidth="55"
+          text="BP intensity"/>
+        <TableColumn fx:id="msLevelColumn" editable="false" prefWidth="42" text="MSn"/>
+        <TableColumn fx:id="precursorMzColumn" editable="false" prefWidth="80"
           text="Precursor m/z"/>
-        <TableColumn fx:id="mzRangeColumn" editable="false" prefWidth="75.0" text="m/z range"/>
-        <TableColumn fx:id="scanTypeColumn" editable="false" prefWidth="65.0" text="Scan type"/>
-        <TableColumn fx:id="polarityColumn" editable="false" prefWidth="60.0" text="Polarity"/>
-        <TableColumn fx:id="definitionColumn" minWidth="0.0" prefWidth="65.0"
+        <TableColumn fx:id="mzRangeColumn" editable="false" prefWidth="115" text="m/z range"/>
+        <TableColumn fx:id="scanTypeColumn" editable="false" prefWidth="95.0" text="Scan type"/>
+        <TableColumn fx:id="polarityColumn" editable="false" prefWidth="58.0" text="Polarity"/>
+        <TableColumn fx:id="definitionColumn" minWidth="0.0"  prefWidth="125.0"
           text="Scan definition" editable="false"/>
       </columns>
     </TableView>

--- a/src/main/java/io/github/mzmine/modules/visualization/rawdataoverview/RawDataFileInfoPaneController.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/rawdataoverview/RawDataFileInfoPaneController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ * Copyright 2006-2022 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -28,6 +28,7 @@ import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.taskcontrol.TaskPriority;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.javafx.StringToDoubleComparator;
+import io.github.mzmine.util.javafx.TableViewUitls;
 import java.text.NumberFormat;
 import java.util.List;
 import java.util.logging.Logger;
@@ -102,6 +103,11 @@ public class RawDataFileInfoPaneController {
   @FXML
   private GridPane metaDataGridPane;
 
+  @FXML
+  public void initialize() {
+    TableViewUitls.autoFitLastColumn(rawDataTableView);
+  }
+
   /**
    * Only populate the table if it gets selected. This is called by a listener in
    * {@link RawDataOverviewWindowController}.
@@ -127,8 +133,9 @@ public class RawDataFileInfoPaneController {
     String scansMSLevel = "Total scans (" + rawDataFile.getNumOfScans() + ") ";
     for (int i = 0; i < rawDataFile.getMSLevels().length; i++) {
       int level = rawDataFile.getMSLevels()[i];
-      scansMSLevel = scansMSLevel + "MS" + level + " level ("
-          + rawDataFile.getScanNumbers(level).size() + ") ";
+      scansMSLevel =
+          scansMSLevel + "MS" + level + " level (" + rawDataFile.getScanNumbers(level).size()
+              + ") ";
       lblNumScans.setText(scansMSLevel);
     }
 
@@ -136,10 +143,9 @@ public class RawDataFileInfoPaneController {
     for (int i = 0; i < rawDataFile.getMSLevels().length; i++) {
       rtRangeMSLevel = rtRangeMSLevel + "MS" + rawDataFile.getMSLevels()[i] + " level "
           + MZminePreferences.rtFormat.getValue()
-              .format(rawDataFile.getDataRTRange(i + 1).lowerEndpoint())
-          + "-" + MZminePreferences.rtFormat.getValue()
-              .format(rawDataFile.getDataRTRange(i + 1).upperEndpoint())
-          + " [min] ";
+          .format(rawDataFile.getDataRTRange(i + 1).lowerEndpoint()) + "-"
+          + MZminePreferences.rtFormat.getValue()
+          .format(rawDataFile.getDataRTRange(i + 1).upperEndpoint()) + " [min] ";
       lblRtRange.setText(rtRangeMSLevel);
     }
 
@@ -147,10 +153,9 @@ public class RawDataFileInfoPaneController {
     for (int i = 0; i < rawDataFile.getMSLevels().length; i++) {
       mzRangeMSLevel = mzRangeMSLevel + "MS" + rawDataFile.getMSLevels()[i] + " level "
           + MZminePreferences.mzFormat.getValue()
-              .format(rawDataFile.getDataMZRange(i + 1).lowerEndpoint())
-          + "-" + MZminePreferences.mzFormat.getValue()
-              .format(rawDataFile.getDataMZRange(i + 1).upperEndpoint())
-          + " ";
+          .format(rawDataFile.getDataMZRange(i + 1).lowerEndpoint()) + "-"
+          + MZminePreferences.mzFormat.getValue()
+          .format(rawDataFile.getDataMZRange(i + 1).upperEndpoint()) + " ";
       lblMzRange.setText(mzRangeMSLevel);
     }
 
@@ -216,12 +221,12 @@ public class RawDataFileInfoPaneController {
 
   private class PopulateTask implements Task {
 
-    private ObservableList<ScanDescription> tableData = FXCollections.observableArrayList();
+    private final ObservableList<ScanDescription> tableData = FXCollections.observableArrayList();
 
     private double perc = 0;
     private TaskStatus status;
     private boolean isCanceled;
-    private RawDataFile rawDataFile;
+    private final RawDataFile rawDataFile;
 
     public PopulateTask(RawDataFile rawDataFile) {
       perc = 0;
@@ -270,8 +275,8 @@ public class RawDataFileInfoPaneController {
 
         String mzRangeStr = "";
         if (mzRange != null) {
-          mzRangeStr = mzFormat.format(mzRange.lowerEndpoint()) + "-"
-              + mzFormat.format(mzRange.upperEndpoint());
+          mzRangeStr = mzFormat.format(mzRange.lowerEndpoint()) + "-" + mzFormat.format(
+              mzRange.upperEndpoint());
         }
 
         String basePeakMZ = "-";
@@ -283,7 +288,7 @@ public class RawDataFileInfoPaneController {
         }
 
         tableData.add(new ScanDescription(scan, Integer.toString(scan.getScanNumber()), // scan
-                                                                                        // number
+            // number
             rtFormat.format(scan.getRetentionTime()), // rt
             Integer.toString(scan.getMSLevel()), // MS level
             precursor, // precursor mz
@@ -304,6 +309,7 @@ public class RawDataFileInfoPaneController {
 
       Platform.runLater(() -> {
         rawDataTableView.setItems(tableData);
+
         // rawDataTableView.getSelectionModel().select(0);
       });
 

--- a/src/main/java/io/github/mzmine/util/javafx/TableViewUitls.java
+++ b/src/main/java/io/github/mzmine/util/javafx/TableViewUitls.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2006-2022 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+package io.github.mzmine.util.javafx;
+
+import javafx.beans.binding.DoubleExpression;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
+
+/**
+ * Options to manipulate table views and maybe treetableviews
+ *
+ * @author Robin Schmid (https://github.com/robinschmid)
+ */
+public class TableViewUitls {
+
+  public static void autoFitLastColumn(TableView<?> table) {
+    autoFitLastColumn(table, table.widthProperty().subtract(10));
+  }
+
+  public static void autoFitLastColumn(TableView<?> table, DoubleExpression tableWidth) {
+    var cols = table.getColumns();
+    if (cols.size() < 2) {
+      throw new IllegalArgumentException("Table must contain 2 or more columns");
+    }
+    // target column to resize
+    TableColumn<?, ?> lastCol = cols.get(cols.size() - 1);
+    // subtract all widths from the table width
+    DoubleExpression remainingWidth = tableWidth;
+    for (var col : cols) {
+      if (col != lastCol) {
+        remainingWidth = remainingWidth.subtract(col.widthProperty());
+      }
+    }
+    lastCol.prefWidthProperty().bind(remainingWidth);
+  }
+}


### PR DESCRIPTION
Before all columns had the same width. Now the last column is autosized as it is the definition.
the other columns have fixed size
![image](https://user-images.githubusercontent.com/10366914/171419017-ec7382e4-e1c4-4c8d-a128-f03d0fb4ef10.png)
