### PR TITLE
Spectral library search in wizard

### DIFF
--- a/src/main/java/io/github/mzmine/modules/tools/batchwizard/BatchWizard.fxml
+++ b/src/main/java/io/github/mzmine/modules/tools/batchwizard/BatchWizard.fxml
@@ -21,6 +21,7 @@
 <?import javafx.geometry.*?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
+<?import javafx.scene.text.*?>
 
 <ScrollPane fitToHeight="true" fitToWidth="true" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1" fx:controller="io.github.mzmine.modules.tools.batchwizard.BatchWizardController">
   <BorderPane>
@@ -81,7 +82,10 @@
           </VBox>
           <VBox fx:id="rightMenu" alignment="TOP_RIGHT" spacing="5.0" GridPane.rowIndex="2">
             <FlowPane>
-              <Button alignment="TOP_RIGHT" mnemonicParsing="false" onAction="#onRunPressed" text="Build batch" />
+              <Button alignment="TOP_RIGHT" mnemonicParsing="false" onAction="#onRunPressed" text="Build batch">
+                        <font>
+                           <Font name="System Bold" size="14.0" />
+                        </font></Button>
             </FlowPane>
             <padding>
               <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />

--- a/src/main/java/io/github/mzmine/modules/tools/batchwizard/BatchWizard.fxml
+++ b/src/main/java/io/github/mzmine/modules/tools/batchwizard/BatchWizard.fxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright 2006-2021 The MZmine Development Team
+  ~ Copyright 2006-2022 The MZmine Development Team
   ~
   ~ This file is part of MZmine.
   ~
@@ -18,98 +18,85 @@
   ~
   -->
 
+<?import javafx.geometry.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
 
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.CheckBox?>
-<?import javafx.scene.control.ComboBox?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.RadioButton?>
-<?import javafx.scene.control.ScrollPane?>
-<?import javafx.scene.control.SplitPane?>
-<?import javafx.scene.control.ToggleGroup?>
-<?import javafx.scene.layout.BorderPane?>
-<?import javafx.scene.layout.ColumnConstraints?>
-<?import javafx.scene.layout.FlowPane?>
-<?import javafx.scene.layout.GridPane?>
-<?import javafx.scene.layout.RowConstraints?>
-<?import javafx.scene.layout.VBox?>
-<ScrollPane xmlns="http://javafx.com/javafx/11.0.2"
-  xmlns:fx="http://javafx.com/fxml/1"
-  fx:controller="io.github.mzmine.modules.tools.batchwizard.BatchWizardController"
-  fitToHeight="true" fitToWidth="true">
+<ScrollPane fitToHeight="true" fitToWidth="true" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1" fx:controller="io.github.mzmine.modules.tools.batchwizard.BatchWizardController">
   <BorderPane>
     <center>
       <SplitPane dividerPositions="0.5" BorderPane.alignment="CENTER">
-        <GridPane fx:id="pnParametersMS" hgap="5.0" vgap="5.0">
-          <Label styleClass="bold-title-label" text="MS data files" GridPane.rowIndex="2"/>
-          <VBox spacing="4.0">
-            <FlowPane hgap="5.0">
-              <RadioButton fx:id="rbOrbitrap" mnemonicParsing="false" text="Orbitrap">
-                <toggleGroup>
-                  <ToggleGroup fx:id="massSpec"/>
-                </toggleGroup>
-              </RadioButton>
-              <RadioButton fx:id="rbTOF" mnemonicParsing="false" text="TOF"
-                toggleGroup="$massSpec"/>
-              <ComboBox fx:id="cbPolarity" prefWidth="150.0"/>
-              <Button fx:id="btnSetMsDefaults" mnemonicParsing="false" onAction="#onSetMsDefaults"
-                text="Set defaults"/>
-            </FlowPane>
-            <FlowPane hgap="5.0">
-              <CheckBox fx:id="cbIonMobility" mnemonicParsing="false" text="Ion mobility"/>
-              <ComboBox fx:id="cbMobilityType" prefWidth="150.0"/>
-            </FlowPane>
-            <Label styleClass="bold-title-label" text="Mass spectrometer presets"/>
-          </VBox>
-          <columnConstraints>
-            <ColumnConstraints hgrow="ALWAYS" minWidth="10.0"/>
-          </columnConstraints>
-          <padding>
-            <Insets bottom="5.0" left="5.0" right="5.0" top="5.0"/>
-          </padding>
-          <rowConstraints>
-            <RowConstraints vgrow="NEVER"/>
-            <RowConstraints minHeight="40.0" vgrow="NEVER"/>
-            <RowConstraints minHeight="10.0" vgrow="NEVER"/>
-            <RowConstraints minHeight="40.0" vgrow="ALWAYS"/>
-          </rowConstraints>
-        </GridPane>
+            <ScrollPane fitToWidth="true">
+               <content>
+              <GridPane fx:id="pnParametersMS" hgap="5.0" vgap="5.0">
+                <Label styleClass="bold-title-label" text="MS data files" GridPane.rowIndex="2" />
+                <VBox spacing="4.0">
+                  <FlowPane hgap="5.0">
+                    <RadioButton fx:id="rbOrbitrap" mnemonicParsing="false" text="Orbitrap">
+                      <toggleGroup>
+                        <ToggleGroup fx:id="massSpec" />
+                      </toggleGroup>
+                    </RadioButton>
+                    <RadioButton fx:id="rbTOF" mnemonicParsing="false" text="TOF" toggleGroup="$massSpec" />
+                    <ComboBox fx:id="cbPolarity" prefWidth="150.0" />
+                    <Button fx:id="btnSetMsDefaults" mnemonicParsing="false" onAction="#onSetMsDefaults" text="Set defaults" />
+                  </FlowPane>
+                  <FlowPane hgap="5.0">
+                    <CheckBox fx:id="cbIonMobility" mnemonicParsing="false" text="Ion mobility" />
+                    <ComboBox fx:id="cbMobilityType" prefWidth="150.0" />
+                  </FlowPane>
+                  <Label styleClass="bold-title-label" text="Mass spectrometer presets" />
+                </VBox>
+                     <Label layoutX="15.0" layoutY="141.0" styleClass="bold-title-label" text="Spectral libraries" GridPane.rowIndex="4" />
+                <columnConstraints>
+                  <ColumnConstraints hgrow="ALWAYS" minWidth="10.0" />
+                </columnConstraints>
+                <padding>
+                  <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                </padding>
+                <rowConstraints>
+                  <RowConstraints vgrow="NEVER" />
+                  <RowConstraints minHeight="40.0" vgrow="NEVER" />
+                  <RowConstraints minHeight="10.0" vgrow="NEVER" />
+                  <RowConstraints minHeight="40.0" vgrow="ALWAYS" />
+                        <RowConstraints vgrow="ALWAYS" />
+                        <RowConstraints minHeight="60.0" />
+                </rowConstraints>
+              </GridPane>
+               </content>
+            </ScrollPane>
         <GridPane fx:id="pnParametersLC" hgap="5.0" vgap="5.0">
           <VBox spacing="4.0">
             <FlowPane hgap="5.0" vgap="5.0">
               <RadioButton fx:id="rbHPLC" mnemonicParsing="false" text="HPLC">
                 <toggleGroup>
-                  <ToggleGroup fx:id="hplc"/>
+                  <ToggleGroup fx:id="hplc" />
                 </toggleGroup>
               </RadioButton>
               <!--              <RadioButton mnemonicParsing="false" text="GC" toggleGroup="$hplc" fx:id="rbGC"/>-->
-              <RadioButton fx:id="rbUHPLC" mnemonicParsing="false" text="UHPLC"
-                toggleGroup="$hplc"/>
-              <Button fx:id="btnSetLcDefaults" alignment="TOP_CENTER" mnemonicParsing="false"
-                onAction="#onSetLcDefaults" text="Set defaults"/>
+              <RadioButton fx:id="rbUHPLC" mnemonicParsing="false" text="UHPLC" toggleGroup="$hplc" />
+              <Button fx:id="btnSetLcDefaults" alignment="TOP_CENTER" mnemonicParsing="false" onAction="#onSetLcDefaults" text="Set defaults" />
             </FlowPane>
-            <Label styleClass="bold-title-label" text="HPLC presets"/>
+            <Label styleClass="bold-title-label" text="HPLC presets" />
           </VBox>
           <VBox fx:id="rightMenu" alignment="TOP_RIGHT" spacing="5.0" GridPane.rowIndex="2">
             <FlowPane>
-              <Button alignment="TOP_RIGHT" mnemonicParsing="false" onAction="#onRunPressed"
-                text="Build batch"/>
+              <Button alignment="TOP_RIGHT" mnemonicParsing="false" onAction="#onRunPressed" text="Build batch" />
             </FlowPane>
             <padding>
-              <Insets bottom="5.0" left="5.0" right="5.0" top="5.0"/>
+              <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
             </padding>
           </VBox>
           <columnConstraints>
-            <ColumnConstraints hgrow="ALWAYS" minWidth="10.0"/>
+            <ColumnConstraints hgrow="ALWAYS" minWidth="10.0" />
           </columnConstraints>
           <padding>
-            <Insets bottom="5.0" left="5.0" right="5.0" top="5.0"/>
+            <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
           </padding>
           <rowConstraints>
-            <RowConstraints minHeight="10.0" vgrow="NEVER"/>
-            <RowConstraints minHeight="10.0" vgrow="NEVER"/>
-            <RowConstraints minHeight="10.0" vgrow="NEVER"/>
+            <RowConstraints minHeight="10.0" vgrow="NEVER" />
+            <RowConstraints minHeight="10.0" vgrow="NEVER" />
+            <RowConstraints minHeight="10.0" vgrow="NEVER" />
           </rowConstraints>
         </GridPane>
       </SplitPane>

--- a/src/main/java/io/github/mzmine/modules/tools/batchwizard/BatchWizardDataInputParameters.java
+++ b/src/main/java/io/github/mzmine/modules/tools/batchwizard/BatchWizardDataInputParameters.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2006-2022 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+package io.github.mzmine.modules.tools.batchwizard;
+
+import io.github.mzmine.modules.io.import_rawdata_all.AllSpectralDataImportParameters;
+import io.github.mzmine.modules.io.import_spectral_library.SpectralLibraryImportParameters;
+import io.github.mzmine.parameters.Parameter;
+import io.github.mzmine.parameters.impl.SimpleParameterSet;
+
+/**
+ * Reuses the filenames and spectral library files parameters of
+ * {@link AllSpectralDataImportParameters} and {@link SpectralLibraryImportParameters}
+ *
+ * @author Robin Schmid <a href="https://github.com/robinschmid">https://github.com/robinschmid</a>
+ */
+public class BatchWizardDataInputParameters extends SimpleParameterSet {
+
+  public BatchWizardDataInputParameters() {
+    super(new Parameter[]{AllSpectralDataImportParameters.fileNames,
+        SpectralLibraryImportParameters.dataBaseFiles});
+  }
+}

--- a/src/main/java/io/github/mzmine/modules/tools/batchwizard/BatchWizardParameters.java
+++ b/src/main/java/io/github/mzmine/modules/tools/batchwizard/BatchWizardParameters.java
@@ -33,13 +33,16 @@ public class BatchWizardParameters extends SimpleParameterSet {
   public static final ParameterSetParameter hplcParams = new ParameterSetParameter(
       "(U)HPLC parameters", "", new BatchWizardHPLCParameters());
 
+  public static final ParameterSetParameter dataInputParams = new ParameterSetParameter(
+      "Data input", "Data files and spectral library files", new BatchWizardDataInputParameters());
+
   public static final OptionalParameter<FileNameParameter> exportPath = new OptionalParameter<>(
       new FileNameParameter("Export path",
           "If checked, export results for different tools, e.g., GNPS IIMN, SIRIUS, ...",
           FileSelectionType.SAVE, false), false);
 
   public BatchWizardParameters() {
-    super(new Parameter[]{msParams, hplcParams, exportPath});
+    super(new Parameter[]{msParams, hplcParams, dataInputParams, exportPath});
   }
 
 }

--- a/src/main/java/io/github/mzmine/modules/tools/batchwizard/BatchWizardParameters.java
+++ b/src/main/java/io/github/mzmine/modules/tools/batchwizard/BatchWizardParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ * Copyright 2006-2022 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -41,4 +41,5 @@ public class BatchWizardParameters extends SimpleParameterSet {
   public BatchWizardParameters() {
     super(new Parameter[]{msParams, hplcParams, exportPath});
   }
+
 }

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/SpectralLibrarySelectionComponent.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/SpectralLibrarySelectionComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ * Copyright 2006-2022 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -78,7 +78,8 @@ public class SpectralLibrarySelectionComponent extends GridPane {
   }
 
   public SpectralLibrarySelection getValue() {
-    return new SpectralLibrarySelection(typeCombo.getValue(), List.of(specificFiles));
+    return new SpectralLibrarySelection(typeCombo.getValue(),
+        specificFiles == null ? List.of() : List.of(specificFiles));
   }
 
   void setValue(SpectralLibrarySelection newValue) {

--- a/src/main/resources/themes/MZmine_default.css
+++ b/src/main/resources/themes/MZmine_default.css
@@ -106,11 +106,11 @@
 }
 
 .title-label {
-  -fx-font-size: 16.0pt;
+  -fx-font-size: 14.0pt;
 }
 
 .bold-title-label {
-  -fx-font-size: 16.0pt;
+  -fx-font-size: 14.0pt;
   -fx-font-weight: bold;
 }
 


### PR DESCRIPTION
- Adds import of libraries
- spectral library search for LC-MS2 
- improves layout

Only need to specify some libraries and the spectral library matching is added - without additional parameter.


Creates this batch
<img width="576" alt="image" src="https://user-images.githubusercontent.com/10366914/173870659-717234df-62e6-4a4a-bbf7-4baaaaa033a8.png">

On large display
<img width="1703" alt="image" src="https://user-images.githubusercontent.com/10366914/173870362-80a5a461-9209-4b48-8098-e8a0a3398473.png">

On smaller display
<img width="808" alt="image" src="https://user-images.githubusercontent.com/10366914/173870471-f561860b-f51c-491d-9b3c-0fbf27a6afde.png">
