### PR TITLE
Isofinder remove redundant rows

### DIFF
--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_isotopefinder/IsotopeFinderParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_isotopefinder/IsotopeFinderParameters.java
@@ -21,6 +21,7 @@ package io.github.mzmine.modules.dataprocessing.filter_isotopefinder;
 import io.github.mzmine.parameters.UserParameter;
 import io.github.mzmine.parameters.dialogs.ParameterSetupDialog;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
+import io.github.mzmine.parameters.parametertypes.BooleanParameter;
 import io.github.mzmine.parameters.parametertypes.ComboParameter;
 import io.github.mzmine.parameters.parametertypes.IntegerParameter;
 import io.github.mzmine.parameters.parametertypes.elements.ElementsParameter;
@@ -49,8 +50,14 @@ public class IsotopeFinderParameters extends SimpleParameterSet {
           + " or within all scans in full-width at half maximum range.", ScanRange.values(),
       ScanRange.SINGLE_MOST_INTENSE);
 
+  public static final BooleanParameter removeRedundantRows = new BooleanParameter(
+      "Remove redundant",
+      "Removes features that are not the most intense or the monoisotopic peak in an isotope pattern.",
+      false);
+
   public IsotopeFinderParameters() {
-    super(new UserParameter[]{featureLists, elements, isotopeMzTolerance, maxCharge, scanRange},
+    super(new UserParameter[]{featureLists, elements, isotopeMzTolerance, maxCharge, scanRange,
+            removeRedundantRows},
         "https://mzmine.github.io/mzmine_documentation/module_docs/filter_isotope_finder/isotope_finder.html");
   }
 

--- a/src/main/java/io/github/mzmine/util/IsotopesUtils.java
+++ b/src/main/java/io/github/mzmine/util/IsotopesUtils.java
@@ -240,7 +240,7 @@ public class IsotopesUtils {
           for (int j = i + 1; j < abundantIsotopes.size(); j++) {
             final double deltaMZ =
                 (abundantIsotopes.get(j).getExactMass() - abundantIsotopes.get(i).getExactMass())
-                / charge;
+                    / charge;
             currentChargeDiffs.add(deltaMZ);
           }
         }
@@ -423,8 +423,12 @@ public class IsotopesUtils {
     int dp = spectrum.getNumberOfDataPoints() - 1;
 
     List<DataPoint> candidates = new ArrayList<>();
-    candidates.add(target);
-    double mz = target.getMZ();
+    // add the actual data point in the scan so we don't end up with duplicates.
+    final int targetIndex = spectrum.binarySearch(target.getMZ(), true);
+    candidates.add(new SimpleDataPoint(spectrum.getMzValue(targetIndex),
+        spectrum.getIntensityValue(targetIndex)));
+
+    double mz = spectrum.getMzValue(targetIndex);
     double lastMZ = mz;
 
     // first try to find preceeding isotope signals
@@ -443,7 +447,7 @@ public class IsotopesUtils {
     // sort list of candidates
     candidates.sort(mzSorter);
 
-    mz = target.getMZ();
+    mz = spectrum.getMzValue(targetIndex);
     double maxMZ = mz;
     // find all isotopes in + range
     // start at last dp spot
@@ -454,7 +458,7 @@ public class IsotopesUtils {
         final var dataPoint = new SimpleDataPoint(mz, spectrum.getIntensityValue(dp));
         if (mz > maxMZ) {
           candidates.add(dataPoint);
-          maxMZ = mz;
+          maxMZ = Math.max(mz, maxMZ);
         } else {
           // insert sort
           insertIfNew(candidates, dataPoint);


### PR DESCRIPTION
includes #769 

adds the option to remove rows that are not the most intense or the first peak in an isotope pattern (useful for deisotoping a feature list with more than 13C)