### PR TITLE
New Module Request: Diagnostic FeatureList Builder (DFBuilder)

### DIFF
--- a/src/main/java/io/github/mzmine/gui/mainwindow/MainMenu.fxml
+++ b/src/main/java/io/github/mzmine/gui/mainwindow/MainMenu.fxml
@@ -233,6 +233,9 @@
       <MenuItem onAction="#runModule"
         text="MSn feature list builder"
         userData="io.github.mzmine.modules.dataprocessing.featdet_msn.MsnFeatureDetectionModule"/>
+      <MenuItem onAction="#runModule"
+        text="Diagnostic FeatureList Builder (DFBuilder)"
+        userData="io.github.mzmine.modules.dataprocessing.featdet_dfbuilder.DiagnosticFilterModule"/>
     </Menu>
     <Menu text="SRM">
       <MenuItem onAction="#runModule"

--- a/src/main/java/io/github/mzmine/modules/batchmode/BatchModeModulesList.java
+++ b/src/main/java/io/github/mzmine/modules/batchmode/BatchModeModulesList.java
@@ -42,6 +42,7 @@ import io.github.mzmine.modules.dataprocessing.featdet_masscalibration.MassCalib
 import io.github.mzmine.modules.dataprocessing.featdet_massdetection.MassDetectionModule;
 import io.github.mzmine.modules.dataprocessing.featdet_mobilityscanmerger.MobilityScanMergerModule;
 import io.github.mzmine.modules.dataprocessing.featdet_msn.MsnFeatureDetectionModule;
+import io.github.mzmine.modules.dataprocessing.featdet_dfbuilder.DiagnosticFilterModule;
 import io.github.mzmine.modules.dataprocessing.featdet_recursiveimsbuilder.RecursiveIMSBuilderModule;
 import io.github.mzmine.modules.dataprocessing.featdet_shoulderpeaksfilter.ShoulderPeaksFilterModule;
 import io.github.mzmine.modules.dataprocessing.featdet_smoothing.SmoothingModule;
@@ -204,6 +205,7 @@ public class BatchModeModulesList {
       RecursiveIMSBuilderModule.class, //
       ImageBuilderModule.class, //
       MsnFeatureDetectionModule.class, //
+      DiagnosticFilterModule.class, //
       TargetedFeatureDetectionModule.class, //
       ADAPHierarchicalClusteringModule.class, //
       ADAPMultivariateCurveResolutionModule.class, //

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_dfbuilder/DiagnosticFilterModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_dfbuilder/DiagnosticFilterModule.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2006-2021 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+package io.github.mzmine.modules.dataprocessing.featdet_dfbuilder;
+
+import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.modules.MZmineModuleCategory;
+import io.github.mzmine.modules.MZmineProcessingModule;
+import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.taskcontrol.Task;
+import io.github.mzmine.util.ExitCode;
+import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
+
+public class DiagnosticFilterModule implements MZmineProcessingModule {
+
+  private static final String MODULE_NAME = "Diagnostic FeatureList Builder (DFBuilder)";
+  private static final String MODULE_DESCRIPTION =
+      "This module filters MSn scans based on fragment ion/neutral loss combinations and builds"
+          + "targeted feature chromatograms for precursors of interest in corresponding RT region";
+
+  @Override
+  public @NotNull String getName() {
+    return MODULE_NAME;
+  }
+
+  @Override
+  public @NotNull String getDescription() {
+    return MODULE_DESCRIPTION;
+  }
+
+  @Override
+  @NotNull
+  public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
+
+    RawDataFile[] dataFiles = parameters.getParameter(DiagnosticFilterParameters.dataFiles).getValue()
+        .getMatchingRawDataFiles();
+    final MemoryMapStorage storage = MemoryMapStorage.forFeatureList();
+    for (RawDataFile dataFile : dataFiles) {
+      Task newTask = new DiagnosticFilterTask(project, dataFile, parameters, storage, moduleCallDate);
+      tasks.add(newTask);
+    }
+
+    return ExitCode.OK;
+
+  }
+
+  @Override
+  public @NotNull MZmineModuleCategory getModuleCategory() {
+    return MZmineModuleCategory.EIC_DETECTION;
+  }
+
+  @Override
+  public @NotNull Class<? extends ParameterSet> getParameterSetClass() {
+    return DiagnosticFilterParameters.class;
+  }
+
+}

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_dfbuilder/DiagnosticFilterParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_dfbuilder/DiagnosticFilterParameters.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2006-2021 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package io.github.mzmine.modules.dataprocessing.featdet_dfbuilder;
+
+import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.parameters.Parameter;
+import io.github.mzmine.parameters.impl.SimpleParameterSet;
+import io.github.mzmine.parameters.parametertypes.DoubleParameter;
+import io.github.mzmine.parameters.parametertypes.IntegerParameter;
+import io.github.mzmine.parameters.parametertypes.OptionalParameter;
+import io.github.mzmine.parameters.parametertypes.filenames.FileNameParameter;
+import io.github.mzmine.parameters.parametertypes.filenames.FileSelectionType;
+import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesParameter;
+import io.github.mzmine.parameters.parametertypes.selectors.ScanSelection;
+import io.github.mzmine.parameters.parametertypes.selectors.ScanSelectionParameter;
+import io.github.mzmine.parameters.parametertypes.tolerances.MZToleranceParameter;
+import io.github.mzmine.parameters.parametertypes.tolerances.RTToleranceParameter;
+import java.util.List;
+import javafx.stage.FileChooser.ExtensionFilter;
+import weka.core.pmml.jaxbbindings.True;
+
+public class DiagnosticFilterParameters extends SimpleParameterSet {
+
+  public static final RawDataFilesParameter dataFiles = new RawDataFilesParameter();
+
+  /**
+   * Scan selection. MSn level must be set through MS Level field. Default MS2.
+   */
+  public static final ScanSelectionParameter scanSelection =
+      new ScanSelectionParameter(new ScanSelection(2));
+
+  /**
+   * MZ tolerance for precursor chromatogram building.
+   */
+  public static final MZToleranceParameter mzDifference = new MZToleranceParameter();
+
+  /**
+   * RT tolerance for precursor chromatogram building.
+   */
+  public static final RTToleranceParameter rtTolerance = new RTToleranceParameter();
+
+  /**
+   * CSV extension for file import and export
+   */
+  private static final List<ExtensionFilter> extensions = List.of( //
+      new ExtensionFilter("comma-separated values", "*.csv") //
+  );
+
+  /**
+   * Import path of diagnostic filters table.
+   */
+  public static final FileNameParameter diagnosticFile = new FileNameParameter("Diagnostic feature list file",
+      "CSV file containing diagnostic filter targets. See Help for more info.",
+      extensions,
+      FileSelectionType.OPEN);
+
+  /**
+   * Import path of exclusion list. Optional parameter.
+   */
+  public static final OptionalParameter<FileNameParameter> exclusionFile =
+      new OptionalParameter<>(new FileNameParameter("(Optional) Exclusion feature list file",
+          "Optional CSV file of mass-RT combinations to exclude. See Help for more info.",
+          extensions,
+          FileSelectionType.OPEN));
+
+  /**
+   * Export path of detected scans. Optional parameter.
+   */
+  public static final OptionalParameter<FileNameParameter> exportFile =
+      new OptionalParameter<>(new FileNameParameter("(Optional) Export detected precursor list",
+          "Optional export of precursor hits of interest. See Help for more info.",
+          extensions,
+          FileSelectionType.SAVE));
+
+  /**
+   * Fragment ion tolerance formatted as percent of base peak.
+   */
+  public static final DoubleParameter basePeakPercent = new DoubleParameter(
+      "Minimum ion intensity (% base peak)",
+      "Minimum ion intensity for screening, scaled to base peak. Will choose non-zero maximum between %base peak and relative abundance.",
+      MZmineCore.getConfiguration().getRTFormat(), 1.0, 0.0, 100.0);
+
+  public DiagnosticFilterParameters() {
+    super(new Parameter[] {dataFiles, scanSelection, mzDifference,
+        diagnosticFile, basePeakPercent, rtTolerance,
+        exclusionFile, exportFile});
+  }
+}

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_dfbuilder/DiagnosticFilterTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_dfbuilder/DiagnosticFilterTask.java
@@ -1,0 +1,560 @@
+/*
+ * Copyright 2006-2021 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package io.github.mzmine.modules.dataprocessing.featdet_dfbuilder;
+
+import io.github.mzmine.datamodel.data_access.EfficientDataAccess;
+import io.github.mzmine.datamodel.data_access.EfficientDataAccess.ScanDataType;
+import io.github.mzmine.datamodel.data_access.ScanDataAccess;
+import io.github.mzmine.datamodel.impl.MSnInfoImpl;
+import io.github.mzmine.modules.dataprocessing.featdet_adapchromatogrambuilder.ModularADAPChromatogramBuilderModule;
+import io.github.mzmine.util.FeatureListUtils;
+import io.github.mzmine.util.FeatureUtils;
+import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import com.Ostermiller.util.CSVParser;
+import com.google.common.collect.Range;
+
+import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.DataPoint;
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.datamodel.features.ModularFeature;
+import io.github.mzmine.datamodel.features.ModularFeatureList;
+import io.github.mzmine.datamodel.features.ModularFeatureListRow;
+import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
+import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
+import io.github.mzmine.parameters.parametertypes.tolerances.RTTolerance;
+import io.github.mzmine.parameters.parametertypes.selectors.ScanSelection;
+import io.github.mzmine.taskcontrol.AbstractTask;
+import io.github.mzmine.taskcontrol.TaskPriority;
+import io.github.mzmine.taskcontrol.TaskStatus;
+import io.github.mzmine.util.scans.ScanUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class DiagnosticFilterTask extends AbstractTask {
+
+  private final MZmineProject project;
+  private final Logger logger = Logger.getLogger(this.getClass().getName());
+
+  // User Parameters
+  private final ParameterSet parameters;
+  private final ScanSelection scanSelection;
+  private final File diagnosticFile;
+  private final Boolean useExclusion;
+  private final File exclusionFile;
+  private final MZTolerance mzDifference;
+  private final Boolean exportFile;
+  private final File fileName;
+  private final Double basePeakPercent;
+  private final RTTolerance rtTolerance;
+  private final RawDataFile rawDataFile;
+
+  private final ModularFeatureList targetPeakList;
+
+  private int totalScans, processedScans;
+  private int finishedLines = 0;
+  private int rowID = 1;
+
+  public DiagnosticFilterTask(MZmineProject project, RawDataFile dataFile, ParameterSet parameters,
+      @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
+    super(storage, moduleCallDate);
+
+    this.project = project;
+    this.parameters = parameters;
+    this.rawDataFile = dataFile;
+
+    this.scanSelection = parameters.getParameter(DiagnosticFilterParameters.scanSelection)
+        .getValue();
+    this.diagnosticFile = parameters.getParameter(DiagnosticFilterParameters.diagnosticFile)
+        .getValue();
+    this.useExclusion = parameters.getParameter(DiagnosticFilterParameters.exclusionFile)
+        .getValue();
+    this.exclusionFile = !useExclusion ? null
+        : parameters.getParameter(DiagnosticFilterParameters.exclusionFile).getEmbeddedParameter()
+            .getValue();
+    this.mzDifference = parameters.getParameter(DiagnosticFilterParameters.mzDifference).getValue();
+    this.basePeakPercent =
+        parameters.getParameter(DiagnosticFilterParameters.basePeakPercent).getValue() / 100;
+    this.rtTolerance = parameters.getParameter(DiagnosticFilterParameters.rtTolerance).getValue();
+    this.exportFile = parameters.getParameter(DiagnosticFilterParameters.exportFile).getValue();
+    this.fileName = !exportFile ? null
+        : parameters.getParameter(DiagnosticFilterParameters.exportFile).getEmbeddedParameter()
+            .getValue();
+    this.targetPeakList = new ModularFeatureList(rawDataFile.getName() + " targetChromatograms",
+        getMemoryMapStorage(), rawDataFile);
+  }
+
+  public void run() {
+
+    setStatus(TaskStatus.PROCESSING);
+
+    logger.info("Started diagnostic filtering on " + rawDataFile);
+
+    ScanDataAccess scans = EfficientDataAccess.of(rawDataFile, ScanDataType.CENTROID, scanSelection);
+    totalScans = scans.getNumberOfScans();
+
+    List<DiagnosticInformation> targetList = this.readDiagnostic();
+    List<ExclusionInformation> exclusionList = !useExclusion ? null : this.readExclusion();
+
+    // ExportList that will contain output m/z values, RT, and scan number for
+    // ID for export to a CSV. Not used if not selected.
+    List<String> exportList = new ArrayList<>();
+
+    // Error catch - no scans in selection.
+    if(totalScans == 0){
+      setStatus(TaskStatus.ERROR);
+      final String msg = "No scans detected in selection range for " + rawDataFile.getName();
+      setErrorMessage(msg);
+      return;
+    }
+
+    // Error catch - no diagnostic filters in import.
+    if(targetList.size() == 0){
+      setStatus(TaskStatus.ERROR);
+      final String msg = "No diagnostic filters detected in "+ diagnosticFile;
+      setErrorMessage(msg);
+      return;
+    }
+
+    // Error catch - Fragmentation filtering cannot be done on full scan.
+    if(scanSelection.getMsLevel() != null){
+      if(scanSelection.getMsLevel() == 1){
+        setStatus(TaskStatus.ERROR);
+        final String msg = "MS Level cannot be 1. Please update Scan Selection Field.";
+        setErrorMessage(msg);
+        return;
+      }
+    }
+
+    /*
+      Loop through each scan in selection. Search MSn scans for neutral losses and/or product ions
+      specified in target list. If all specified fragmentation detected, build chromatogram for
+      full scan precursor ion in specified MZ and RT ranges.
+     */
+    while(scans.hasNextScan()){
+
+      scans.nextScan();
+      Scan scan = scans.getCurrentScan();
+      assert scan != null;
+
+      // Canceled?
+      if (isCanceled()) {
+        return;
+      }
+
+      /*
+        Get full scan precursor mass. If MS Level > 2, get from associated MS2 scan.
+        If MS Level unspecifed, skip full scans.
+       */
+      double precursorMZ;
+      if (scan.getMSLevel() == 2) {
+        precursorMZ = scan.getPrecursorMz();
+      } else if (scan.getMsMsInfo() instanceof MSnInfoImpl msn) {
+        precursorMZ = msn.getMS2PrecursorMz();
+      } else {
+        processedScans++;
+        continue;
+      }
+
+      // Check if scan precursor MZ and RT in exclusion list.
+      if (useExclusion) {
+
+        boolean exclude = false;
+
+        for (ExclusionInformation target : exclusionList) {
+          Double mz = target.getMZ();
+          Range<Double> rtRange = target.getRTRange();
+          if (mzDifference.checkWithinTolerance(mz, precursorMZ)) {
+            if (rtRange.contains((double) scan.getRetentionTime())) {
+              exclude = true;
+            }
+          }
+        }
+        if (exclude) {
+          processedScans++;
+          continue;
+        }
+      }
+
+      // Get noise threshold relative to scan base peak intensity.
+      double noiseThreshold;
+      noiseThreshold = scan.getBasePeakIntensity() * basePeakPercent;
+
+      // Get data point of scan. Keep only those above threshold.
+      // TODO - evaluate efficient methods for scan value access.
+      DataPoint[] dp = ScanUtils.extractDataPoints(scan);
+      dp = ScanUtils.getFiltered(dp, noiseThreshold);
+
+      // If no data points meet threshold, skip scan
+      if (dp.length == 0) {
+        processedScans++;
+        continue;
+      }
+
+      // Get Product Ions
+      List<Double> fragmentIon = new ArrayList<>();
+      for (DataPoint dataPoint : dp) {
+        fragmentIon.add(dataPoint.getMZ());
+      }
+
+      // Target information
+      HashMap<String, Boolean> targetMap = new HashMap<>();
+
+      /*
+        Search scan data points for all neutral loss and product ions. Determine if all
+        combinations are found for each target.
+       */
+      for (DiagnosticInformation target : targetList) {
+
+        String targetName = target.getName();
+        double[] targetedMZ = target.getMZList();
+        double[] targetedNF = target.getNFList();
+
+        List<Boolean> foundMZ = new ArrayList<>();
+        List<Boolean> foundNF = new ArrayList<>();
+
+        // Check if fragment ion in scan
+        // If no fragment ions to be searched, return true
+        if (targetedMZ[0] != 0) {
+          for (double key : targetedMZ) {
+
+            List<Boolean> check = new ArrayList<>();
+            for (double MZ : fragmentIon) {
+
+              check.add(mzDifference.getToleranceRange(key).contains(MZ));
+            }
+            foundMZ.add(check.contains(true));
+          }
+        } else {
+          foundMZ.add(true);
+        }
+
+        // Check if neutral loss in scan
+        // If no neutral loss to be searched, return true
+        if (targetedNF[0] != 0) {
+          for (double key : targetedNF) {
+            List<Boolean> check = new ArrayList<>();
+
+            // Neutral loss calculated from scan precursors. Important for MSn > 2 scans.
+            double targetNL = scan.getPrecursorMz() - key;
+
+            for (double MZ : fragmentIon) {
+
+              check.add(mzDifference.getToleranceRange(targetNL).contains(MZ));
+            }
+            foundNF.add(check.contains(true));
+          }
+        } else {
+          foundNF.add(true);
+        }
+
+        // If all fragment ions and neutral losses found, add target
+        if (!foundMZ.contains(false) && !foundNF.contains(false)) {
+          targetMap.put(targetName, true);
+        } else {
+          targetMap.put(targetName, false);
+        }
+      }
+
+      // If target found, build chromatogram in RT range
+      if (targetMap.containsValue(true)) {
+
+        // Get target info
+        Range<Double> mzRange = mzDifference.getToleranceRange(precursorMZ);
+        Range<Float> rtRange = rtTolerance.getToleranceRange(scan.getRetentionTime());
+        StringBuilder comment = new StringBuilder();
+
+        // Format all diagnostic targets names detected.
+        for (Map.Entry<String, Boolean> entry : targetMap.entrySet()) {
+          if (entry.getValue()) {
+            comment.append("target=").append(entry.getKey()).append(';');
+          }
+        }
+
+        // Remove tailing semi-colon
+        comment = new StringBuilder(comment.substring(0, comment.length() - 1));
+
+        // Build simple feature for precursor in ranges.
+        ModularFeature newFeature = FeatureUtils
+            .buildSimpleModularFeature(targetPeakList, rawDataFile, rtRange, mzRange);
+
+        // Add feature to feature list.
+        if (newFeature != null) {
+
+          ModularFeatureListRow newFeatureListRow = new ModularFeatureListRow(targetPeakList,
+              rowID, newFeature);
+
+          newFeatureListRow.setComment(comment.toString());
+
+          targetPeakList.addRow(newFeatureListRow);
+          rowID++;
+        }
+
+        if (exportFile) {
+
+          // Add scan MZ, RT, detected targets, scan number, and raw data file name to export.
+          String dataMZ = Double.toString(scan.getPrecursorMz());
+          String dataRT = Double.toString(scan.getRetentionTime());
+
+          StringBuilder temp = new StringBuilder(dataMZ + "," + dataRT + ",");
+
+          for (Map.Entry<String, Boolean> entry : targetMap.entrySet()) {
+            if (entry.getValue()) {
+              temp.append("target=").append(entry.getKey()).append(';');
+            }
+          }
+          temp = new StringBuilder(temp.substring(0, temp.length() - 1));
+
+          temp.append(",").append(scan.getScanNumber()).append(',').append(rawDataFile.getName());
+
+          exportList.add(temp.toString());
+        }
+      }
+
+      processedScans++;
+    }
+
+    // No MSn features detected in range.
+    if (targetPeakList.isEmpty()) {
+      setStatus(TaskStatus.ERROR);
+      final String msg =
+          "No MSn precursor features detected in selected range for " + rawDataFile.getName();
+      setErrorMessage(msg);
+      return;
+    }
+
+    if (exportFile) {
+      writeDiagnostic(exportList);
+    }
+
+    // sort and reset IDs here to ahve the same sorting for every feature list
+    FeatureListUtils.sortByDefaultRT(targetPeakList, true);
+
+    // Explicitly get scans for full scan (msLevel = 1).
+    List<Scan> scan;
+    if(scanSelection.getScanRTRange() == null){
+      scan = rawDataFile.getScanNumbers(1);
+    } else {
+      scan = Arrays.asList(rawDataFile.getScanNumbers(1, scanSelection.getScanRTRange()));
+    }
+
+    targetPeakList.setSelectedScans(rawDataFile, scan);
+
+    rawDataFile.getAppliedMethods().forEach(m -> targetPeakList.getAppliedMethods().add(m));
+    // Add new feature list to the project
+    targetPeakList.getAppliedMethods().add(
+        new SimpleFeatureListAppliedMethod(ModularADAPChromatogramBuilderModule.class, parameters,
+            getModuleCallDate()));
+    project.addFeatureList(targetPeakList);
+
+    logger.log(Level.INFO, "Finished diagnostic fragmentation screening on {0}", this.rawDataFile);
+    setStatus(TaskStatus.FINISHED);
+  }
+
+  /**
+   * @see org.jfree.data.general.AbstractSeriesDataset#getSeriesKey(int)
+   */
+  public Comparable<Integer> getSeriesKey(int series) {
+    return series;
+  }
+
+  public void cancel() {
+    setStatus(TaskStatus.CANCELED);
+  }
+
+  public double getFinishedPercentage() {
+    if (totalScans == 0) {
+      return 0;
+    } else {
+      return ((double) processedScans / totalScans);
+    }
+  }
+
+  public String getTaskDescription() {
+    return "Screening for fragment patterns in " + rawDataFile;
+  }
+
+  @Override
+  public TaskPriority getTaskPriority() {
+    return TaskPriority.NORMAL;
+  }
+
+  /**
+   * Read CSV file containing diagnostic targets to be searched for.
+   * File is 3 column CSV file containing the target name, product ion masses, and neutral loss
+   * masses with no headers. If multiple masses specified for product ion or neutral loss fields
+   * they are separated by a semi-colon (';').
+   */
+  public List<DiagnosticInformation> readDiagnostic() {
+
+    FileReader dbFileReader;
+    try {
+      List<DiagnosticInformation> list = new ArrayList<>();
+      dbFileReader = new FileReader(diagnosticFile);
+
+      String[][] diagnosticListValue = CSVParser.parse(dbFileReader, ',');
+
+      for (; finishedLines < diagnosticListValue.length; finishedLines++) {
+        try {
+
+          String name;
+          String mzString;
+          String nlString = "";
+
+          name = diagnosticListValue[finishedLines][0].trim();
+
+          // Remove FEFF character from CSV
+          mzString = diagnosticListValue[finishedLines][1].replace("\uFEFF", "").trim();
+
+          // If no neutral loss specified, file will not have a third column to parse.
+          try {
+            nlString = diagnosticListValue[finishedLines][2].replace("\uFEFF", "").trim();
+          } catch (Exception e) {
+            e.printStackTrace();
+          }
+
+          double[] mz = {0};
+          double[] nl = {0};
+
+          if (!mzString.isEmpty()) {
+            mz = Stream.of(mzString.split(";")).mapToDouble(Double::parseDouble).toArray();
+          }
+
+          if (!nlString.isEmpty()) {
+            nl = Stream.of(nlString.split(";")).mapToDouble(Double::parseDouble).toArray();
+          }
+
+          list.add(new DiagnosticInformation(name, mz, nl));
+        } catch (Exception e) {
+          e.printStackTrace();
+        }
+      }
+
+      dbFileReader.close();
+      return list;
+
+    } catch (Exception e) {
+      e.printStackTrace();
+      logger.log(Level.WARNING, "Could not read file " + diagnosticFile, e);
+      setStatus(TaskStatus.ERROR);
+      setErrorMessage(e.toString());
+      return null;
+    }
+
+  }
+
+  /**
+   * Read CSV file containing ions to exclude from the run. File is a 3 column table with no
+   * headers. The first column contains the MZ values, The second the start RT for exclusion.
+   * The third the end RT for exclusion.
+   */
+  public List<ExclusionInformation> readExclusion() {
+
+    FileReader dbFileReader;
+    try {
+      List<ExclusionInformation> list = new ArrayList<>();
+      dbFileReader = new FileReader(exclusionFile);
+
+      String[][] exclusionListValue = CSVParser.parse(dbFileReader, ',');
+
+      for (; finishedLines < exclusionListValue.length; finishedLines++) {
+        try {
+
+          // Remove FEFF character from CSV
+          String mzString = exclusionListValue[finishedLines][0].replace("\uFEFF", "").trim();
+          String rtStart = exclusionListValue[finishedLines][1].replace("\uFEFF", "").trim();
+          String rtEnd = exclusionListValue[finishedLines][2].replace("\uFEFF", "").trim();
+
+          Double mz = Double.parseDouble(mzString);
+          Range<Double> rtRange = Range
+              .closed(Double.parseDouble(rtStart), Double.parseDouble(rtEnd));
+
+          list.add(new ExclusionInformation(mz, rtRange));
+        } catch (Exception e) {
+          e.printStackTrace();
+        }
+      }
+
+      dbFileReader.close();
+      return list;
+    } catch (Exception e) {
+      e.printStackTrace();
+      logger.log(Level.WARNING, "Could not read file " + diagnosticFile, e);
+      setStatus(TaskStatus.ERROR);
+      setErrorMessage(e.toString());
+      return null;
+    }
+
+  }
+
+  /**
+   * Write scan information for detected diagnostic filters.
+   * @param export String array containing scan info
+   */
+  public void writeDiagnostic(List<String> export) {
+    // Write output to csv file - for DFBuilder target chromatogram builder module.
+    try {
+      // Cancel?
+      if (isCanceled()) {
+        return;
+      }
+
+      String namePattern = "{}";
+      File curFile = fileName;
+
+      if (fileName.getPath().contains(namePattern)) {
+
+        String cleanPlName = rawDataFile.getName().replaceAll("[^a-zA-Z0-9.-]", "_");
+        // Substitute
+        String newFilename = fileName.getPath().replaceAll(Pattern.quote(namePattern), cleanPlName);
+        curFile = new File(newFilename);
+      }
+
+      FileWriter writer = new FileWriter(curFile, true);
+
+      String collect = String.join("\n", export);
+
+      writer.write(collect);
+      writer.write("\n");
+      writer.close();
+
+    } catch (IOException e) {
+      System.out.print("Could not output to file");
+      System.out.print(Arrays.toString(e.getStackTrace()));
+
+      setStatus(TaskStatus.FINISHED);
+    }
+  }
+}

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_dfbuilder/DiagnosticInformation.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_dfbuilder/DiagnosticInformation.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2006-2021 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package io.github.mzmine.modules.dataprocessing.featdet_dfbuilder;
+
+public class DiagnosticInformation {
+	
+	private String name;
+	private double[] targetedMZ_List;
+	private double[] targetedNF_List;
+	
+	public DiagnosticInformation(String name, double[] targetedMZ_List, double[] targetedNF_List){
+		this.name = name;
+		this.targetedMZ_List = targetedMZ_List;
+		this.targetedNF_List = targetedNF_List;
+	}
+	
+	public String getName() {
+		return name;
+	}
+	
+	public double[] getMZList(){
+		return targetedMZ_List;
+	}
+	
+	public double[] getNFList(){
+		return targetedNF_List;
+	}
+
+}

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_dfbuilder/ExclusionInformation.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_dfbuilder/ExclusionInformation.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2006-2021 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package io.github.mzmine.modules.dataprocessing.featdet_dfbuilder;
+
+import com.google.common.collect.Range;
+
+public class ExclusionInformation {
+    	
+	private Double mz;
+	private Range<Double> rtRange;
+	
+	public ExclusionInformation(Double mz, Range<Double> rtRange){
+		this.mz = mz;
+		this.rtRange = rtRange;
+	}
+	
+	public Double getMZ() {
+		return mz;
+	}
+	
+	public Range<Double> getRTRange(){
+		return rtRange;
+	}
+}

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_dfbuilder/help/help.html
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_dfbuilder/help/help.html
@@ -1,0 +1,129 @@
+<html>
+<head>
+  <title>Feature detection - MSn - Diagnostic FeatureList Builder (DFBuilder)</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <link rel="stylesheet" type="text/css"
+        href="/net/sf/mzmine/desktop/impl/helpsystem/HelpStyles.css">
+</head>
+
+<body>
+
+<h1>Diagnostic FeatureList Builder (DFBuilder)</h1>
+
+<h2>Description</h2>
+
+<p>
+  The DFBuilder module is feature detection and chromatogram building tool that identifies precursor
+  ions that exhibit diagnostic fragmentation patterns in observed MSn spectra. A feature list for
+  each screened data file is produced containing the precursor ion chromatogram in the specified
+  MZ tolerances and RT ranges for the identified scan.
+</p>
+
+<p>
+  The module utilizes an input CSV file of one or more diagnostic fragmentation patterns and
+  screens the MSn of each data file for the occurrence of these patterns. Fragmentation patterns may
+  include product ions, precursor-product neutral loss transitions, or a combination of both. For
+  precursor ions exhibiting a diagnostic fragmentation pattern, a feature chromatogram is built in
+  the retention time region of interest. To limit false discovery rates, the minimum ion intensity
+  of product ions may be specified to prevent matching to low abundant, noise peaks. A retention
+  time tolerance may be specified to ensure that entirety of the target peak of interest is retained
+  without included neighboring peaks. An optional exclusion list may be specified to exclude
+  previously defined ions from consideration. An optional precursor list export may be obtained that
+  includes the precursor m/z, retention time, and target name matches for each MSn spectra
+  exhibiting a diagnostic loss.
+</p>
+
+<p>
+  The resulting feature list peaks may be further curated using the chromatogram deconvolution tools
+  in the feature list methods to ensure optimal integration bounds are chosen for prospective
+  chromatographic features.
+</p>
+
+<p>
+  For fragment ion filtering and visualization, please use the <b><i>MS/MS Scatter Plot</i></b>
+  visualization tool.
+</p>
+
+<h4>Method parameters</h4>
+
+<dl>
+
+  <dt>Diagnostic feature list file</dt>
+  <dd>Path of the CSV file containing the diagnostic targets to be screened.</dd>
+
+  <dt>Minimum ion intensity (%base peak)</dt>
+  <dd>Minimum product ion intensity to be considered during screening, scaled to base peak.
+  </dd>
+
+  <dt>Retention Time Tolerance</dt>
+  <dd>The retention time tolerance for the chromatogram built for precursor ions exhibiting a
+    diagnostic pattern.
+
+  <dt>Exclusion feature list file</dt>
+  <dd>Optional parameter. Path to the CSV file containing the precursors ions with retention time to
+    be excluded during screening.
+  </dd>
+
+  <dt>Export detected precursor list</dt>
+  <dd>Optional parameter. Export path for CSV file containing all precursor ions exhibiting
+    diagnostic fragment patterns.
+  </dd>
+
+</dl>
+
+<h4>Diagnostic feature list file</h4>
+
+<p>
+  The diagnostic feature list is a CSV file with three columns and no headers. The first column
+  should contain the target name. The second column should contain any diagnostic
+  product ions. The third column should contain any diagnostic precursor-product neutral loss
+  transitions. A valid target may include only product ions, only neutral losses, or
+  a combination of both. Multiple product ions-neutral loss may be simultaneously assessed, use a
+  semi-colon ';' to separate multiple entries. Each diagnostic feature list entry
+  should occur on a new line. An example of a diagnostic feature list is below:
+</p>
+
+<pre>
+"Target A - Product Ion Only", 136.0618,
+"Target B - Neutral Loss Only", ,135.0545
+"Target C - Combined Search", 136.0618, 135.0545
+"Target D - Multiple Targets", 136.0618; 152.0567, 135.0545; 151.0494
+</pre>
+
+<h4>Exclusion feature list file</h4>
+
+<p>
+  The exclusion feature list is an optional CSV files with three columns and no headers. The first
+  column should contain the m/z of the excluded ion. The second column should contain
+  the left retention time (minutes) bound for exclusion. The third column should contain the right
+  retention time (minutes) bound for exclusion. Each exclusion list entry should
+  occur on a new line. An example of an exclusion feature list is below:
+</p>
+
+<pre>
+"252.1091, 0, 55"
+"385.1344, 0, 55"
+"432.1029, 8, 14"
+"516.1813, 30, 33"
+</pre>
+
+<h4>References</h4>
+
+<p>If you use the Diagnostic FeatureList Builder (DFBuilder) module, please cite the the following
+  articles:</p>
+
+<p>[1] Pluskal, T.; Castillo, S.; Villar-Briones, A.; Orešič, M. MZmine 2: Modular Framework for
+  Processing, Visualizing, and Analyzing Mass Spectrometry-Based Molecular
+  Profile Data. BMC Bioinformatics 2010, 11 (1), 395. https://doi.org/10.1186/1471-2105-11-395.</p>
+
+<p>[2] Murray, K. J.; Carlson, E. S.; Stornetta, A.; Balskus, E. P.; Villalta, P. W.; Balbo, S.
+  Extension of Diagnostic Fragmentation Filtering for Automated Discovery in DNA Adductomics.
+  Analytical Chemistry 2021, 93 (14), 5754-5762. https://doi.org/10.1021/acs.analchem.0c04895.</p>
+
+<p>[3] Walsh, J. P.; Renaud, J. B.; Hoogstra, S.; McMullin, D. R.; Ibrahim, A.; Visagie, C. M.;
+  Tanney, J. B.; Yeung, K. K. ‐C.; Sumarah, M. W. Diagnostic Fragmentation
+  Filtering for the Discovery of New Chaetoglobosins and Cytochalasins. Rapid Commun. Mass Spectrom.
+  2019, 33 (1), 133–139. https://doi.org/10.1002/rcm.8306.</p>
+
+</body>
+</html>


### PR DESCRIPTION
New module pull request: Diagnostic FeatureList Builder (DFBuilder).

'Feature Detection' classification, 'MSn' subclassification. 

Module functionality: This module scans MSn scans for diagnostic fragmentation patterns and builds chromatograms for corresponding MS1 precursor masses in surrounding RT region. Diagnostic fragmentation patterns can be neutral losses, product ions, or a combination of both. Multiple patterns may be scanned simultaneously. Restricting the chromatograms only to those precursor of interest improves chromatogram resolving parameter optimization and drastically reduces the time used for chromatogram resolving tools, especially the ADAP resolver. 

Module parameters:
- Raw data files: Mass detection on all MS levels must be performed prior to analysis.
- Scan selection: MS level is set in scan selection field, cannot be 1. If not specified, search all MSn scans. 
- MZtolerance: Tolerance applies to MS1 and all MSn levels. 
- Diagnostic feature list file path: Path to CSV file containing patterns. Three column file with no header containing: name of pattern, product ion m/z, and neutral loss masses. Each entry occupies a new row. At least one product ion or neutral loss mass must be provided for each entry. Multiple dependent product ion or neutral losses may be searched, multiple entries separated with semi-colon. 
- Minimum ion intensity (%base peak): Minimum fragment ion intensity expressed as a percentage of the scan base peak intensity. If left at 0%, parameter not used. 
- Retention time tolerance: RT region (before/after) to build chromatogram around detected precursor. 
- (Optional) Exclusion list file: Path to CSV file containing a list of masses and RT regions to ignore during search. File is 3 column file with no headers, including: ion m/z, start retention time (min), end retention time (min). 
- (Optional) Export detected precursor list: Export scan information of detected diagnostic filtering, including: m/z of MS1 precursor, RT of precursor, detected targets, scan # of hit, raw data file name. 

Intended use: The aim of this module is for discovery metabolomics projects that search for specific compound classes or novel modified compound forms using diagnostic fragmentation patterns. In the original publication, we use the neutral loss of the deoxyribose moiety (116.0474 Da) to detect putative modified DNA species. The module can be extended to a multitude of compound classes or be used to monitor for compound tags observed in MSn scans. 

Novelty: To my knowledge there is no other data processing module that allows you to monitor for fragmentation patterns in MSn scans and restrict the data processing only to those ions. This module was intended to expand the "Visualization" > "MS/MS Scatter plot" > "Diagnostic fragmentation filtering" tool. That visualization tool allows the user to visualize if any precursors that exhibit a diagnostic fragmentation pattern in their associated MS/MS spectra. I am hoping the "Diagnostic FeatureList Builder (DFBuilder)" module will be complimentary to that tool for a complete MZmine3 data processing workflow. 

Publication: This module was published as a forked MZmine2 repo during MZmine3 development. (https://doi.org/10.1021/acs.analchem.0c04895)
