### PR TITLE
MassDetector that uses the lowest intensity * user factor as noise level

### DIFF
--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_join/RowVsRowScore.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_join/RowVsRowScore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ * Copyright 2006-2022 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -26,7 +26,8 @@ import io.github.mzmine.datamodel.features.FeatureListRow;
 public class RowVsRowScore implements Comparable<RowVsRowScore> {
 
   double score;
-  private FeatureListRow peakListRow, alignedRow;
+  private final FeatureListRow peakListRow;
+  private final FeatureListRow alignedRow;
 
   public RowVsRowScore(FeatureListRow peakListRow, FeatureListRow alignedRow, double mzMaxDiff,
       double mzWeight, double rtMaxDiff, double rtWeight) {
@@ -88,18 +89,10 @@ public class RowVsRowScore implements Comparable<RowVsRowScore> {
   }
 
   /**
-   * @see Comparable#compareTo(Object)
+   * Sorts in descending order
    */
   public int compareTo(RowVsRowScore object) {
-
-    // We must never return 0, because the TreeSet in JoinAlignerTask would
-    // treat such elements as equal
-    if (score < object.getScore()) {
-      return 1;
-    } else {
-      return -1;
-    }
-
+    return Double.compare(object.getScore(), score);
   }
 
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_massdetection/MassDetectionParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_massdetection/MassDetectionParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ * Copyright 2006-2022 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -26,6 +26,7 @@ import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.dataprocessing.featdet_massdetection.auto.AutoMassDetector;
 import io.github.mzmine.modules.dataprocessing.featdet_massdetection.centroid.CentroidMassDetector;
 import io.github.mzmine.modules.dataprocessing.featdet_massdetection.exactmass.ExactMassDetector;
+import io.github.mzmine.modules.dataprocessing.featdet_massdetection.factor_of_lowest.FactorOfLowestMassDetector;
 import io.github.mzmine.modules.dataprocessing.featdet_massdetection.localmaxima.LocalMaxMassDetector;
 import io.github.mzmine.modules.dataprocessing.featdet_massdetection.recursive.RecursiveMassDetector;
 import io.github.mzmine.modules.dataprocessing.featdet_massdetection.wavelet.WaveletMassDetector;
@@ -50,6 +51,8 @@ import org.jetbrains.annotations.NotNull;
 
 public class MassDetectionParameters extends SimpleParameterSet {
 
+  public static final FactorOfLowestMassDetector factorOfLowest = MZmineCore.getModuleInstance(
+      FactorOfLowestMassDetector.class);
   public static final CentroidMassDetector centroid = MZmineCore.getModuleInstance(
       CentroidMassDetector.class);
   public static final ExactMassDetector exact = MZmineCore.getModuleInstance(
@@ -62,8 +65,8 @@ public class MassDetectionParameters extends SimpleParameterSet {
       WaveletMassDetector.class);
   public static final AutoMassDetector auto = MZmineCore.getModuleInstance(AutoMassDetector.class);
 
-  public static final MassDetector[] massDetectors = {centroid, exact, localmax, recursive, wavelet,
-      auto};
+  public static final MassDetector[] massDetectors = {factorOfLowest, centroid, exact, localmax,
+      recursive, wavelet, auto};
 
   public static final ModuleComboParameter<MassDetector> massDetector = new ModuleComboParameter<MassDetector>(
       "Mass detector", "Algorithm to use for mass detection and its parameters.", massDetectors,
@@ -107,7 +110,7 @@ public class MassDetectionParameters extends SimpleParameterSet {
   public boolean checkParameterValues(Collection<String> errorMessages) {
     final boolean superCheck = super.checkParameterValues(errorMessages);
 
-    RawDataFile selectedFiles[] = getParameter(dataFiles).getValue().getMatchingRawDataFiles();
+    RawDataFile[] selectedFiles = getParameter(dataFiles).getValue().getMatchingRawDataFiles();
     getParameter(dataFiles).getValue().resetSelection(); // reset selection after evaluation.
 
     // If no file selected (e.g. in batch mode setup), just return
@@ -121,7 +124,7 @@ public class MassDetectionParameters extends SimpleParameterSet {
     ScanSelection scanSel = getParameter(scanSelection).getValue();
 
     for (RawDataFile file : selectedFiles) {
-      Scan scans[] = scanSel.getMatchingScans(file);
+      Scan[] scans = scanSel.getMatchingScans(file);
       for (Scan s : scans) {
         if (s.getSpectrumType() == MassSpectrumType.CENTROIDED) {
           numCentroided++;
@@ -144,10 +147,11 @@ public class MassDetectionParameters extends SimpleParameterSet {
     // Check the selected mass detector
     String massDetectorName = getParameter(massDetector).getValue().toString();
     if (!massDetectorName.contains("Auto")) {
-      if (mostlyCentroided && (!massDetectorName.startsWith("Centroid"))) {
+      if (mostlyCentroided && !(massDetectorName.startsWith("Centroid")
+          || massDetectorName.startsWith("Factor"))) {
         String msg =
             "MZmine thinks you are running the profile mode mass detector on (mostly) centroided scans.\n"
-                + "This will likely produce wrong results. Try the Centroid mass detector instead.\n"
+                + "This will likely produce wrong results. Try the Centroid mass detector or Factor of lowest signal mass detector instead.\n"
                 + "Continue anyway?";
         if (MZmineCore.getDesktop().displayConfirmation(msg, ButtonType.YES, ButtonType.NO)
             == ButtonType.NO) {
@@ -155,9 +159,10 @@ public class MassDetectionParameters extends SimpleParameterSet {
         }
       }
 
-      if ((!mostlyCentroided) && (massDetectorName.startsWith("Centroid"))) {
+      if ((!mostlyCentroided) && (massDetectorName.startsWith("Centroid")
+          || massDetectorName.startsWith("Factor"))) {
         String msg =
-            "MZmine thinks you are running the centroid mass detector on (mostly) profile scans.\n"
+            "MZmine thinks you are running the centroid or factor mass detector on (mostly) profile scans.\n"
                 + "This will likely produce wrong results.\nContinue anyway?";
         if (MZmineCore.getDesktop().displayConfirmation(msg, ButtonType.YES, ButtonType.NO)
             == ButtonType.NO) {
@@ -173,7 +178,7 @@ public class MassDetectionParameters extends SimpleParameterSet {
           "The scan types selection is set to \"" + types
               + "\" but there are non IMS files selected."
               + "This will not add a mass list to the files " + Arrays.stream(selectedFiles)
-              .map(RawDataFile::getName).toList().toString() + ".\nDo you want to continue anyway?",
+              .map(RawDataFile::getName).toList() + ".\nDo you want to continue anyway?",
           ButtonType.YES, ButtonType.NO);
       if (buttonType == ButtonType.NO) {
         return false;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_massdetection/factor_of_lowest/FactorOfLowestMassDetector.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_massdetection/factor_of_lowest/FactorOfLowestMassDetector.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2006-2022 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+package io.github.mzmine.modules.dataprocessing.featdet_massdetection.factor_of_lowest;
+
+import gnu.trove.list.array.TDoubleArrayList;
+import io.github.mzmine.datamodel.MassSpectrum;
+import io.github.mzmine.modules.dataprocessing.featdet_massdetection.MassDetector;
+import io.github.mzmine.parameters.ParameterSet;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Remove peaks below the minimum intensity x a user defined factor
+ */
+public class FactorOfLowestMassDetector implements MassDetector {
+
+  @Override
+  public double[][] getMassValues(MassSpectrum spectrum, ParameterSet parameters) {
+    // most likely working on {@link ScanDataAccess}
+
+    final double noiseFactor = parameters.getValue(
+        FactorOfLowestMassDetectorParameters.noiseFactor);
+
+    // get the minimum intensity and base noise on this
+    double noiseLevel = minIntensity(spectrum) * noiseFactor;
+
+    // use number of centroid signals as base array list capacity
+    final int points = spectrum.getNumberOfDataPoints();
+
+    // lists of primitive doubles
+    TDoubleArrayList mzs = new TDoubleArrayList(points);
+    TDoubleArrayList intensities = new TDoubleArrayList(points);
+    // Find possible mzPeaks
+    for (int i = 0; i < points; i++) {
+      // Is intensity above the noise level?
+      double intensity = spectrum.getIntensityValue(i);
+      if (intensity >= noiseLevel) {
+        // add data point
+        mzs.add(spectrum.getMzValue(i));
+        intensities.add(intensity);
+      }
+    }
+    return new double[][]{mzs.toArray(), intensities.toArray()};
+  }
+
+  @Override
+  public double[][] getMassValues(double[] mzs, double[] intensities, ParameterSet parameters) {
+    assert mzs.length == intensities.length;
+
+    final double noiseFactor = parameters.getValue(
+        FactorOfLowestMassDetectorParameters.noiseFactor);
+    return getMassValues(mzs, intensities, noiseFactor);
+  }
+
+  public double[][] getMassValues(double[] mzs, double[] intensities, double noiseFactor) {
+    assert mzs.length == intensities.length;
+
+    // get the minimum intensity and base noise on this
+    double noiseLevel = minIntensity(intensities) * noiseFactor;
+
+    // use number of centroid signals as base array list capacity
+    final int points = mzs.length;
+    // lists of primitive doubles
+    TDoubleArrayList pickedMZs = new TDoubleArrayList(points);
+    TDoubleArrayList pickedIntensities = new TDoubleArrayList(points);
+
+    // Find possible mzPeaks
+    for (int i = 0; i < points; i++) {
+      // Is intensity above the noise level?
+      if (intensities[i] >= noiseLevel) {
+        // Yes, then mark this index as mzPeak
+        pickedMZs.add(mzs[i]);
+        pickedIntensities.add(intensities[i]);
+      }
+    }
+    return new double[][]{pickedMZs.toArray(), pickedIntensities.toArray()};
+  }
+
+  private double minIntensity(double[] rawIntensities) {
+    double minIntensity = Double.MAX_VALUE;
+    for (double v : rawIntensities) {
+      if (v < minIntensity) {
+        minIntensity = v;
+      }
+    }
+    if (Double.compare(minIntensity, Double.MAX_VALUE) == 0) {
+      minIntensity = 0;
+    }
+    return minIntensity;
+  }
+
+  private double minIntensity(MassSpectrum spec) {
+    double minIntensity = Double.MAX_VALUE;
+    for (int i = 0; i < spec.getNumberOfDataPoints(); i++) {
+      if (spec.getIntensityValue(i) < minIntensity) {
+        minIntensity = spec.getIntensityValue(i);
+      }
+    }
+    if (Double.compare(minIntensity, Double.MAX_VALUE) == 0) {
+      minIntensity = 0;
+    }
+    return minIntensity;
+  }
+
+  @Override
+  public @NotNull String getName() {
+    return "Factor of lowest signal";
+  }
+
+  @Override
+  public @NotNull Class<? extends ParameterSet> getParameterSetClass() {
+    return FactorOfLowestMassDetectorParameters.class;
+  }
+
+}

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_massdetection/factor_of_lowest/FactorOfLowestMassDetectorParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_massdetection/factor_of_lowest/FactorOfLowestMassDetectorParameters.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2006-2022 The MZmine Development Team
+ *
+ * This file is part of MZmine.
+ *
+ * MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MZmine; if not,
+ * write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+package io.github.mzmine.modules.dataprocessing.featdet_massdetection.factor_of_lowest;
+
+import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.modules.dataprocessing.featdet_massdetection.MassDetectorSetupDialog;
+import io.github.mzmine.parameters.UserParameter;
+import io.github.mzmine.parameters.impl.SimpleParameterSet;
+import io.github.mzmine.parameters.parametertypes.DoubleParameter;
+import io.github.mzmine.util.ExitCode;
+
+public class FactorOfLowestMassDetectorParameters extends SimpleParameterSet {
+
+  public static final DoubleParameter noiseFactor = new DoubleParameter("Noise factor",
+      "Signals less than lowest intensity x noiseFactor are removed",
+      MZmineCore.getConfiguration().getScoreFormat(), 2.5);
+
+  public FactorOfLowestMassDetectorParameters() {
+    super(new UserParameter[]{noiseFactor});
+  }
+
+  @Override
+  public ExitCode showSetupDialog(boolean valueCheckRequired) {
+    MassDetectorSetupDialog dialog = new MassDetectorSetupDialog(valueCheckRequired,
+        FactorOfLowestMassDetector.class, this);
+    dialog.showAndWait();
+    return dialog.getExitCode();
+  }
+
+}

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_massdetection/factor_of_lowest/help/help.html
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_massdetection/factor_of_lowest/help/help.html
@@ -1,0 +1,43 @@
+<!--
+  ~ Copyright 2006-2022 The MZmine Development Team
+  ~
+  ~ This file is part of MZmine.
+  ~
+  ~ MZmine is free software; you can redistribute it and/or modify it under the terms of the GNU
+  ~ General Public License as published by the Free Software Foundation; either version 2 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ MZmine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+  ~ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with MZmine; if not,
+  ~ write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+  ~
+  -->
+
+<html>
+	<head>
+		<title>Peak detection - Mass detection - Centroid mass detector</title>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+		<link rel="stylesheet" type="text/css" href="/net/sf/mzmine/desktop/impl/helpsystem/HelpStyles.css">
+    </head>
+
+<body>
+
+<h1>Factor of lowest signal mass detector</h1>
+
+<h2>Description</h2>
+
+<p>
+This mass detector is suitable for already centroided data. It removes all data points below a spectrums lowest intensity multiplied by a factor.
+</p>
+
+<h4>Method parameters</h4>
+<dl>
+<dt>Noise factor</dt>
+<dd>The noise factor is multiplied with each spectrum's lowest intensity to calculate a noise level.</dd>
+</dl>
+
+</body>
+</html>


### PR DESCRIPTION
Each individual scan will have a noise level defined by the lowest intensity and a user factor. Only works with centroid data for now.