### PR TITLE
Discussion: Best Approach to Get Most Intense MSn Scan of FeatureList Row

### DIFF
--- a/src/main/java/io/github/mzmine/util/scans/ScanUtils.java
+++ b/src/main/java/io/github/mzmine/util/scans/ScanUtils.java
@@ -1635,10 +1635,9 @@ public class ScanUtils {
 
     Scan ms2Scan = feature.getMostIntenseFragmentScan();
     List<PrecursorIonTree> tree = getMSnFragmentTrees(ms2Scan.getDataFile());
-    List<Scan> scanRange = feature.getScanNumbers();
+    Range<Float> rtRange = feature.getRawDataPointsRTRange();
 
-
-    return getMostIntenseMSnScan(ms2Scan, msLevel, tree, scanRange);
+    return getMostIntenseMSnScan(ms2Scan, msLevel, tree, rtRange);
 
   }
 
@@ -1656,9 +1655,9 @@ public class ScanUtils {
 
     Scan ms2Scan = row.getMostIntenseFragmentScan();
     List<PrecursorIonTree> tree = getMSnFragmentTrees(ms2Scan.getDataFile());
-    List<Scan> scanRange = row.getFeature(ms2Scan.getDataFile()).getScanNumbers();
+    Range<Float> rtRange = row.getFeature(ms2Scan.getDataFile()).getRawDataPointsRTRange();
 
-    return getMostIntenseMSnScan(ms2Scan, msLevel, tree, scanRange);
+    return getMostIntenseMSnScan(ms2Scan, msLevel, tree, rtRange);
   }
 
   /**
@@ -1667,14 +1666,12 @@ public class ScanUtils {
    * @param ms2Scan MS2 scan of feature
    * @param msLevel MSn scan level
    * @param msNFragmentTrees PrecursorIonTree for raw data file of most intense fragment scan.
-   * @param scanRange Scan range of feature associated with MS2 scan - TODO: Switch to RT
+   * @param rtRange RT range of feature associated with MS2 scan.
    * @return
    */
   public static Scan getMostIntenseMSnScan(Scan ms2Scan, int msLevel,
-      List<PrecursorIonTree> msNFragmentTrees, List<Scan> scanRange) {
-
-    int firstScanNum = scanRange.get(0).getScanNumber();
-    int lastScanNum = scanRange.get(scanRange.size() - 1).getScanNumber();
+      List<PrecursorIonTree> msNFragmentTrees,
+      Range<Float> rtRange) {
 
     // Loop through each tree
     for (PrecursorIonTree tree : msNFragmentTrees) {
@@ -1696,10 +1693,8 @@ public class ScanUtils {
 
             Double value = msn.getTIC();
 
-            // Get most intense MSn scan in feature scan range
-            if(msn.getScanNumber() > firstScanNum &&
-                msn.getScanNumber() < lastScanNum &&
-                value > intensity){
+            // Get most intense MSn scan in feature rt range
+            if(rtRange.contains(msn.getRetentionTime()) &&  value > intensity){
               msnScan = msn;
               intensity = value;
             }

--- a/src/main/java/io/github/mzmine/util/scans/ScanUtils.java
+++ b/src/main/java/io/github/mzmine/util/scans/ScanUtils.java
@@ -715,6 +715,29 @@ public class ScanUtils {
   }
 
   /**
+   * Checks if MSn scan full scan precursor mz and rt is in ranges.
+   *
+   * @param s tested scan
+   * @param rtRange
+   * @param mzRange
+   * @return true if ms2fragmentscan precursor mz and scan rt in range.
+   */
+  public static boolean matchesMSnScan(Scan s, Range<Float> rtRange, Range<Double> mzRange){
+
+    if(rtRange != null && !rtRange.contains(s.getRetentionTime())) {
+      return false;
+    }
+
+    Double precursorMz = null;
+    if (s.getMSLevel() == 2) {
+      precursorMz = s.getPrecursorMz();
+    } else if (s.getMsMsInfo() instanceof MSnInfoImpl msn) {
+      precursorMz = msn.getMS2PrecursorMz();
+    }
+    return precursorMz != null && mzRange.contains(precursorMz);
+  }
+
+  /**
    * @param msLevel 0 for all scans
    */
   public static Stream<Scan> streamScans(RawDataFile dataFile, int msLevel) {
@@ -1654,7 +1677,10 @@ public class ScanUtils {
   public static Scan getMostIntenseMSnScan(FeatureListRow row, int msLevel){
 
     Scan ms2Scan = row.getMostIntenseFragmentScan();
+    RawDataFile dataFile = ms2Scan.getDataFile();
+
     List<PrecursorIonTree> tree = getMSnFragmentTrees(ms2Scan.getDataFile());
+
     Range<Float> rtRange = row.getFeature(ms2Scan.getDataFile()).getRawDataPointsRTRange();
 
     return getMostIntenseMSnScan(ms2Scan, msLevel, tree, rtRange);

--- a/src/main/java/io/github/mzmine/util/scans/ScanUtils.java
+++ b/src/main/java/io/github/mzmine/util/scans/ScanUtils.java
@@ -702,7 +702,7 @@ public class ScanUtils {
    * @param mzRange
    * @return stream sorted by default sorting (highest TIC)
    */
-  public static Stream<Scan> streamAllMsnFragmentScans(@NotNull RawDataFile dataFile,
+  public static Stream<Scan> streamAllMSnFragmentScans(@NotNull RawDataFile dataFile,
       @Nullable Range<Float> rtRange, @NotNull Range<Double> mzRange){
     return streamAllMSnFragmentScans(dataFile, rtRange, mzRange, FragmentScanSorter.DEFAULT_TIC);
   }

--- a/src/main/java/io/github/mzmine/util/scans/ScanUtils.java
+++ b/src/main/java/io/github/mzmine/util/scans/ScanUtils.java
@@ -692,6 +692,41 @@ public class ScanUtils {
   }
 
   /**
+   * Finds all MSn scans (n>=2) within given retention time range and with MS2 precursor m/z within given
+   * m/z range.
+   *
+   * TODO - evaluate if TIC sorting is appropriate for implementation.
+   *
+   * @param dataFile
+   * @param rtRange
+   * @param mzRange
+   * @return stream sorted by default sorting (highest TIC)
+   */
+  public static Stream<Scan> streamAllMsnFragmentScans(@NotNull RawDataFile dataFile,
+      @Nullable Range<Float> rtRange, @NotNull Range<Double> mzRange){
+    return streamAllMSnFragmentScans(dataFile, rtRange, mzRange, FragmentScanSorter.DEFAULT_TIC);
+  }
+
+  /**
+   * Finds all MSn scans (n>=2) within given retention time range and with MS2 precursor m/z within given
+   * m/z range. Applies sorting if sorter is not null.
+   *
+   * @param dataFile
+   * @param rtRange
+   * @param mzRange
+   * @param sorter sorted stream see {@link FragmentScanSorter}. Unsorted if null
+   * @return sorted stream
+   */
+  public static Stream<Scan> streamAllMSnFragmentScans(@NotNull RawDataFile dataFile,
+      @Nullable Range<Float> rtRange, @NotNull Range<Double> mzRange,
+      @Nullable Comparator<Scan> sorter) {
+
+    final Stream<Scan> stream = dataFile.getScanNumbers(0).stream()
+        .filter(s -> matchesMSnScan(s, rtRange, mzRange));
+    return sorter == null ? stream : stream.sorted(sorter);
+  }
+
+  /**
    * Finds all MS/MS scans on MS2 level within given retention time range and with precursor m/z
    * within given m/z range
    */

--- a/src/main/java/io/github/mzmine/util/scans/ScanUtils.java
+++ b/src/main/java/io/github/mzmine/util/scans/ScanUtils.java
@@ -1631,6 +1631,17 @@ public class ScanUtils {
     }
   }
 
+  public static Scan getMostIntenseMSnScan(Feature feature, int msLevel){
+
+    Scan ms2Scan = feature.getMostIntenseFragmentScan();
+    List<PrecursorIonTree> tree = getMSnFragmentTrees(ms2Scan.getDataFile());
+    List<Scan> scanRange = feature.getScanNumbers();
+
+
+    return getMostIntenseMSnScan(ms2Scan, msLevel, tree, scanRange);
+
+  }
+
 
   /**
    * Return the closest MSn scan to the most intense MS2 fragment scan.
@@ -1645,24 +1656,23 @@ public class ScanUtils {
 
     Scan ms2Scan = row.getMostIntenseFragmentScan();
     List<PrecursorIonTree> tree = getMSnFragmentTrees(ms2Scan.getDataFile());
+    List<Scan> scanRange = row.getFeature(ms2Scan.getDataFile()).getScanNumbers();
 
-    return getMostIntenseMSnScan(row, msLevel, tree);
+    return getMostIntenseMSnScan(ms2Scan, msLevel, tree, scanRange);
   }
 
   /**
    * Get most intense MSn scan for feature list row
    *
-   * @param row Feature List row
+   * @param ms2Scan MS2 scan of feature
    * @param msLevel MSn scan level
    * @param msNFragmentTrees PrecursorIonTree for raw data file of most intense fragment scan.
+   * @param scanRange Scan range of feature associated with MS2 scan - TODO: Switch to RT
    * @return
    */
-  public static Scan getMostIntenseMSnScan(FeatureListRow row, int msLevel,
-      List<PrecursorIonTree> msNFragmentTrees) {
+  public static Scan getMostIntenseMSnScan(Scan ms2Scan, int msLevel,
+      List<PrecursorIonTree> msNFragmentTrees, List<Scan> scanRange) {
 
-    Scan ms2Scan = row.getMostIntenseFragmentScan();
-
-    List<Scan> scanRange = row.getFeature(ms2Scan.getDataFile()).getScanNumbers();
     int firstScanNum = scanRange.get(0).getScanNumber();
     int lastScanNum = scanRange.get(scanRange.size() - 1).getScanNumber();
 

--- a/src/main/java/io/github/mzmine/util/scans/ScanUtils.java
+++ b/src/main/java/io/github/mzmine/util/scans/ScanUtils.java
@@ -1687,7 +1687,7 @@ public class ScanUtils {
         // Get scans associated with MS Level
         List<Scan> fragmentScans = root.getFragmentScans(msLevel - 2);
 
-        if (fragmentScans != null) {
+        if (fragmentScans.size() != 0) {
 
           Scan msnScan = null;
           double intensity = 0;


### PR DESCRIPTION
I would like to discuss what other developers think is the best way to get the most intense MSn scan associated with a feature list row entry. I am not necessarily aiming to have this code merged unless we decide its an appropriate approach. 

### Background
Our lab utilizes a constant neutral loss MS3 approach in our research (LC-MS/MS-CNL-MS3). In short, if the acquisition software observes a diagnostic neutral loss in the MS2 it triggers a singular MS3 on the associated fragment ion. We would like to use these spectra with various annotative tools, such as, spectral library searching, formula assignment, etc. My aim was to create a function that would return the "most intense" MSn scan associated with feature list row for data generated in a singular DDA-MSn fashion, ie. assuming only one data dependent MSn scan per precursor. I don't think this function would be particularly useful for a fragmentation tree acquisition design. 

### Approach
The Util functions return the "most intense" MSn scan of a feature list row object. MSn scans are found through searching the PrecursorIonTree of the raw data file associated with the most intense fragment scan of the row. If the precursor mass is found in the tree and the node possess an appropriate max MS depth, the most intense MSn scan (determined by TIC) in the feature scan region is returned. Currently the search region is limited by the scan number range of the row feature but this could be easily changed to retention time. For iterative use, if you create a HashMap object to store the PrecursorIonTrees for each raw datafile of an aligned feature list, it saves quite a bit of processing time. 

This approach works with my test data. I've tried this with data generated on the Thermo Fusion and Lumos with MS3, MS4, MS5, and MS6 data. I have not tested this with other vendor data types. Additionally, this approach does not have any ion mobility components yet (I only have FAIMS ion mobility data to test). 

### Discussion
I'm curious other developers thoughts are on this approach? I feel like its a bit clunky and inefficient but there are not many other ways to link MSn scans with feature list rows currently implemented. 

