### PR TITLE
fix slow file type detection in all data import

### DIFF
--- a/src/main/java/io/github/mzmine/modules/io/import_rawdata_all/AllSpectralDataImportModule.java
+++ b/src/main/java/io/github/mzmine/modules/io/import_rawdata_all/AllSpectralDataImportModule.java
@@ -298,13 +298,15 @@ public class AllSpectralDataImportModule implements MZmineProcessingModule {
    * @return the task or null if the data format is not supported for direct mass detection
    */
   private AbstractTask createAdvancedTask(RawDataFileType fileType, MZmineProject project,
-      File file, RawDataFile newMZmineFile, @NotNull AdvancedSpectraImportParameters advancedParam,
-      Class<? extends MZmineModule> module, ParameterSet parameters,
-      @NotNull Instant moduleCallDate, @Nullable final MemoryMapStorage storage) {
+      File file, @Nullable RawDataFile newMZmineFile,
+      @NotNull AdvancedSpectraImportParameters advancedParam, Class<? extends MZmineModule> module,
+      ParameterSet parameters, @NotNull Instant moduleCallDate,
+      @Nullable final MemoryMapStorage storage) {
     return switch (fileType) {
       // MS
-      case MZML -> new MSDKmzMLImportTask(project, file, null, advancedParam, module, parameters,
-          moduleCallDate, storage);
+      case MZML, MZML_IMS ->
+          new MSDKmzMLImportTask(project, file, null, advancedParam, module, parameters,
+              moduleCallDate, storage);
       case MZXML ->
           new MzXMLImportTask(project, file, newMZmineFile, advancedParam, module, parameters,
               moduleCallDate);
@@ -314,7 +316,7 @@ public class AllSpectralDataImportModule implements MZmineProcessingModule {
       case AIRD ->
           new AirdImportTask(project, file, newMZmineFile, module, parameters, moduleCallDate);
       // all unsupported tasks are wrapped to apply import and mass detection separately
-      case MZDATA, THERMO_RAW, WATERS_RAW, NETCDF, MZML_ZIP, MZML_GZIP, ICPMSMS_CSV, IMZML, MZML_IMS ->
+      case MZDATA, THERMO_RAW, WATERS_RAW, NETCDF, MZML_ZIP, MZML_GZIP, ICPMSMS_CSV, IMZML ->
           createWrappedAdvancedTask(fileType, project, file, newMZmineFile, advancedParam, module,
               parameters, moduleCallDate, storage);
       default -> throw new IllegalStateException("Unexpected data type: " + fileType);
@@ -334,6 +336,7 @@ public class AllSpectralDataImportModule implements MZmineProcessingModule {
             storage), advancedParam, moduleCallDate);
   }
 
+  @Nullable
   private RawDataFile createDataFile(RawDataFileType fileType, String absPath, String newName,
       MemoryMapStorage storage) throws IOException {
     return switch (fileType) {

--- a/src/main/java/io/github/mzmine/util/RawDataFileTypeDetector.java
+++ b/src/main/java/io/github/mzmine/util/RawDataFileTypeDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ * Copyright 2006-2022 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -32,44 +32,39 @@ import org.jetbrains.annotations.NotNull;
  */
 public class RawDataFileTypeDetector {
 
-  private static Logger logger = Logger.getLogger(RawDataFileTypeDetector.class.getName());
-
   /*
    * See "https://unidata.ucar.edu/software/netcdf/docs/netcdf_introduction.html#netcdf_format"
    */
   private static final String CDF_HEADER = "CDF";
   private static final String HDF_HEADER = "HDF";
-
   /*
    * mzML files with index start with <indexedmzML><mzML>tags, but files with no index contain only
    * the <mzML> tag. See
    * "http://psidev.cvs.sourceforge.net/viewvc/psidev/psi/psi-ms/mzML/schema/mzML1.1.0.xsd"
    */
   private static final String MZML_HEADER = "<mzML";
-
   /*
    * mzXML files with index start with <mzXML><msRun> tags, but files with no index contain only the
    * <msRun> tag. See "http://sashimi.sourceforge.net/schema_revision/mzXML_3.2/mzXML_3.2.xsd"
    */
   private static final String MZXML_HEADER = "<msRun";
-
   // See "http://www.psidev.info/sites/default/files/mzdata.xsd.txt"
   private static final String MZDATA_HEADER = "<mzData";
-
   // See "https://code.google.com/p/unfinnigan/wiki/FileHeader"
   private static final String THERMO_HEADER = String.valueOf(
       new char[]{0x01, 0xA1, 'F', 0, 'i', 0, 'n', 0, 'n', 0, 'i', 0, 'g', 0, 'a', 0, 'n', 0});
-
   private static final String GZIP_HEADER = String.valueOf(new char[]{0x1f, 0x8b});
-
   private static final String ZIP_HEADER = String.valueOf(new char[]{'P', 'K', 0x03, 0x04});
-
   private static final String TDF_SUFFIX = ".tdf";
   private static final String TDF_BIN_SUFFIX = ".tdf_bin";
   private static final String TSF_BIN_SUFFIX = ".tsf_bin";
   private static final String TSF_SUFFIX = ".tsf_bin";
   private static final String BRUKER_FOLDER_SUFFIX = ".d";
   private static final String AIRD_SUFFIX = ".aird";
+  private static final String MZML_SUFFIX = ".mzml";
+  private static final String IMZML_SUFFIX = ".imzml";
+
+  private static final Logger logger = Logger.getLogger(RawDataFileTypeDetector.class.getName());
 
   /**
    * @return Detected file type or null if the file is not of any supported type
@@ -99,31 +94,38 @@ public class RawDataFileTypeDetector {
       return null;
     }
 
-    if (fileName.isFile()) {
-      //the suffix is json and have a .aird file with same name
-      if (fileName.getName().toLowerCase().endsWith(AIRD_SUFFIX)) {
-        String airdIndexFilePath = AirdScanUtil.getIndexPathByAirdPath(fileName.getPath());
-        if (airdIndexFilePath != null) {
-          File airdIndexFile = new File(airdIndexFilePath);
-          if (airdIndexFile.exists()) {
-            return RawDataFileType.AIRD;
-          }
+    try {
+      if (fileName.isFile()) {
+        if (fileName.getName().toLowerCase().endsWith(MZML_SUFFIX)) {
+          return RawDataFileType.MZML;
         }
-        logger.info("It's not an aird format file or the aird index file not exist");
-      }
-      if (fileName.getName().contains(TDF_SUFFIX) || fileName.getName().contains(TDF_BIN_SUFFIX)) {
-        return RawDataFileType.BRUKER_TDF;
-      }
-      if (fileName.getName().contains(TDF_SUFFIX) || fileName.getName().contains(TDF_BIN_SUFFIX)) {
-        return RawDataFileType.BRUKER_TSF;
-      }
-
-      try {
+        if (fileName.getName().toLowerCase().endsWith(IMZML_SUFFIX)) {
+          return RawDataFileType.IMZML;
+        }
+        //the suffix is json and have a .aird file with same name
+        if (fileName.getName().toLowerCase().endsWith(AIRD_SUFFIX)) {
+          String airdIndexFilePath = AirdScanUtil.getIndexPathByAirdPath(fileName.getPath());
+          if (airdIndexFilePath != null) {
+            File airdIndexFile = new File(airdIndexFilePath);
+            if (airdIndexFile.exists()) {
+              return RawDataFileType.AIRD;
+            }
+          }
+          logger.info("It's not an aird format file or the aird index file not exist");
+        }
+        if (fileName.getName().contains(TDF_SUFFIX) || fileName.getName()
+            .contains(TDF_BIN_SUFFIX)) {
+          return RawDataFileType.BRUKER_TDF;
+        }
+        if (fileName.getName().contains(TDF_SUFFIX) || fileName.getName()
+            .contains(TDF_BIN_SUFFIX)) {
+          return RawDataFileType.BRUKER_TSF;
+        }
 
         // Read the first 1kB of the file into a String
         InputStreamReader reader = new InputStreamReader(new FileInputStream(fileName),
             StandardCharsets.ISO_8859_1);
-        char buffer[] = new char[1024];
+        char[] buffer = new char[1024];
         reader.read(buffer);
         reader.close();
         String fileHeader = new String(buffer);
@@ -160,7 +162,7 @@ public class RawDataFileTypeDetector {
         }
 
         if (fileHeader.contains(MZML_HEADER)) {
-          return getMzmlType(fileName);
+          return RawDataFileType.MZML;
         }
 
         if (fileHeader.contains(MZDATA_HEADER)) {
@@ -171,15 +173,22 @@ public class RawDataFileTypeDetector {
           return RawDataFileType.MZXML;
         }
 
-      } catch (Exception e) {
-        e.printStackTrace();
       }
+    } catch (Exception e) {
+      e.printStackTrace();
     }
 
     return null;
 
   }
 
+  /**
+   * Currently not used because the import task takes care of everything. Only here as reference
+   *
+   * @param fileName
+   * @return
+   * @throws IOException
+   */
   @NotNull
   public static RawDataFileType getMzmlType(File fileName) throws IOException {
     if (fileName.getName().toLowerCase().endsWith("imzml")) {
@@ -187,10 +196,10 @@ public class RawDataFileTypeDetector {
     } else {
       InputStreamReader reader2 = new InputStreamReader(new FileInputStream(fileName),
           StandardCharsets.ISO_8859_1);
-      char buffer2[] = new char[4096 * 3];
+      char[] buffer2 = new char[4096 * 3];
       String content = new String(buffer2);
       boolean containsScan = false, containsAccession = false;
-      while (containsScan == false && containsAccession == false) {
+      while (!containsScan && !containsAccession) {
         reader2.read(buffer2);
         content = new String(buffer2);
         content.replaceAll("[^\\x00-\\x7F]", "");

--- a/src/main/java/io/github/mzmine/util/RawDataFileTypeDetector.java
+++ b/src/main/java/io/github/mzmine/util/RawDataFileTypeDetector.java
@@ -117,8 +117,8 @@ public class RawDataFileTypeDetector {
             .contains(TDF_BIN_SUFFIX)) {
           return RawDataFileType.BRUKER_TDF;
         }
-        if (fileName.getName().contains(TDF_SUFFIX) || fileName.getName()
-            .contains(TDF_BIN_SUFFIX)) {
+        if (fileName.getName().contains(TSF_SUFFIX) || fileName.getName()
+            .contains(TSF_BIN_SUFFIX)) {
           return RawDataFileType.BRUKER_TSF;
         }
 

--- a/src/main/java/io/github/mzmine/util/RawDataFileUtils.java
+++ b/src/main/java/io/github/mzmine/util/RawDataFileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ * Copyright 2006-2022 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -82,56 +82,60 @@ public class RawDataFileUtils {
       Task newTask = null;
       switch (fileType) {
         case ICPMSMS_CSV:
-          newMZmineFile = MZmineCore
-              .createNewFile(fileName.getName(), fileName.getAbsolutePath(), storage);
-          newTask = new IcpMsCVSImportTask(project, fileName, newMZmineFile, module, parameters, moduleCallDate);
+          newMZmineFile = MZmineCore.createNewFile(fileName.getName(), fileName.getAbsolutePath(),
+              storage);
+          newTask = new IcpMsCVSImportTask(project, fileName, newMZmineFile, module, parameters,
+              moduleCallDate);
           break;
         case MZDATA:
-          newMZmineFile = MZmineCore
-              .createNewFile(fileName.getName(), fileName.getAbsolutePath(), storage);
-          newTask = new MzDataImportTask(project, fileName, newMZmineFile, module, parameters, moduleCallDate);
+          newMZmineFile = MZmineCore.createNewFile(fileName.getName(), fileName.getAbsolutePath(),
+              storage);
+          newTask = new MzDataImportTask(project, fileName, newMZmineFile, module, parameters,
+              moduleCallDate);
           break;
-        case MZML:
-          newTask = new MSDKmzMLImportTask(project, fileName, module, parameters,moduleCallDate, storage);
+        case MZML, MZML_IMS:
+          newTask = new MSDKmzMLImportTask(project, fileName, module, parameters, moduleCallDate,
+              storage);
           break;
         case IMZML:
-          newMZmineFile = MZmineCore
-              .createNewImagingFile(fileName.getName(), fileName.getAbsolutePath(), storage);
+          newMZmineFile = MZmineCore.createNewImagingFile(fileName.getName(),
+              fileName.getAbsolutePath(), storage);
           newTask = new ImzMLImportTask(project, fileName, (ImagingRawDataFile) newMZmineFile,
               module, parameters, moduleCallDate);
           break;
         case MZXML:
-          newMZmineFile = MZmineCore
-              .createNewFile(fileName.getName(), fileName.getAbsolutePath(), storage);
-          newTask = new MzXMLImportTask(project, fileName, newMZmineFile, module, parameters, moduleCallDate);
+          newMZmineFile = MZmineCore.createNewFile(fileName.getName(), fileName.getAbsolutePath(),
+              storage);
+          newTask = new MzXMLImportTask(project, fileName, newMZmineFile, module, parameters,
+              moduleCallDate);
           break;
         case NETCDF:
-          newMZmineFile = MZmineCore
-              .createNewFile(fileName.getName(), fileName.getAbsolutePath(), storage);
-          newTask = new NetCDFImportTask(project, fileName, newMZmineFile, module, parameters, moduleCallDate);
+          newMZmineFile = MZmineCore.createNewFile(fileName.getName(), fileName.getAbsolutePath(),
+              storage);
+          newTask = new NetCDFImportTask(project, fileName, newMZmineFile, module, parameters,
+              moduleCallDate);
           break;
         case THERMO_RAW:
-          newMZmineFile = MZmineCore
-              .createNewFile(fileName.getName(), fileName.getAbsolutePath(), storage);
-          newTask = new ThermoRawImportTask(project, fileName, newMZmineFile, module, parameters, moduleCallDate);
+          newMZmineFile = MZmineCore.createNewFile(fileName.getName(), fileName.getAbsolutePath(),
+              storage);
+          newTask = new ThermoRawImportTask(project, fileName, newMZmineFile, module, parameters,
+              moduleCallDate);
         case WATERS_RAW:
-          newMZmineFile = MZmineCore
-              .createNewFile(fileName.getName(), fileName.getAbsolutePath(), storage);
-          newTask = new WatersRawImportTask(project, fileName, newMZmineFile, module, parameters, moduleCallDate);
+          newMZmineFile = MZmineCore.createNewFile(fileName.getName(), fileName.getAbsolutePath(),
+              storage);
+          newTask = new WatersRawImportTask(project, fileName, newMZmineFile, module, parameters,
+              moduleCallDate);
           break;
         case MZML_ZIP:
         case MZML_GZIP:
-          newTask = new ZipImportTask(project, fileName, module, parameters, moduleCallDate, storage);
+          newTask = new ZipImportTask(project, fileName, module, parameters, moduleCallDate,
+              storage);
           break;
         case BRUKER_TDF:
-          newMZmineFile = MZmineCore
-              .createNewIMSFile(fileName.getName(), fileName.getAbsolutePath(),
-                  MemoryMapStorage.forRawDataFile());
+          newMZmineFile = MZmineCore.createNewIMSFile(fileName.getName(),
+              fileName.getAbsolutePath(), MemoryMapStorage.forRawDataFile());
           newTask = new TDFImportTask(project, fileName, (IMSRawDataFile) newMZmineFile, module,
               parameters, moduleCallDate);
-          break;
-        case MZML_IMS:
-          newTask = new MSDKmzMLImportTask(project, fileName, module, parameters, moduleCallDate, storage);
           break;
         default:
           break;
@@ -151,9 +155,9 @@ public class RawDataFileUtils {
    * <p>
    * Assumes that fileNames doesn't contain null entries.
    */
-  public static @Nullable String askToRemoveCommonPrefix(@NotNull File fileNames[]) {
+  public static @Nullable String askToRemoveCommonPrefix(@NotNull File[] fileNames) {
 
-    if(true) {
+    if (true) {
       // currently this will break project load/save, because the files are renamed before they
       // exist. So let's just deactivate it for now.
       return null;
@@ -226,7 +230,7 @@ public class RawDataFileUtils {
     return null;
   }
 
-  public static @NotNull Range<Float> findTotalRTRange(RawDataFile dataFiles[], int msLevel) {
+  public static @NotNull Range<Float> findTotalRTRange(RawDataFile[] dataFiles, int msLevel) {
     Range<Float> rtRange = null;
     for (RawDataFile file : dataFiles) {
       Range<Float> dfRange = file.getDataRTRange(msLevel);
@@ -245,7 +249,7 @@ public class RawDataFileUtils {
     return rtRange;
   }
 
-  public static @NotNull Range<Double> findTotalMZRange(RawDataFile dataFiles[], int msLevel) {
+  public static @NotNull Range<Double> findTotalMZRange(RawDataFile[] dataFiles, int msLevel) {
     Range<Double> mzRange = null;
     for (RawDataFile file : dataFiles) {
       Range<Double> dfRange = file.getDataMZRange(msLevel);


### PR DESCRIPTION
By default we were using in input stream two times to determine the correct mzML import: IMS or no IMS
Now we are handling IMS and mzML files the same way with the advanced MSDK import.

This actually took a long time sometimes for ~500 files.

Also, I am checking if the file name ends with .mzml case insensitive.

