### PR TITLE
Speedup advanced mzML import 6 times 

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/impl/MsdkScanWrapper.java
+++ b/src/main/java/io/github/mzmine/datamodel/impl/MsdkScanWrapper.java
@@ -47,9 +47,16 @@ public class MsdkScanWrapper implements Scan {
   // wrap this scan
   private final MsScan scan;
   private final MsMsInfo msMsInfo;
+  private final double[] mzs;
+  private final float[] intensities;
 
   public MsdkScanWrapper(MsScan scan) {
     this.scan = scan;
+
+    // preload as getMzValue(i) is inefficient in MSDK scans
+    mzs = scan.getMzValues();
+    intensities = scan.getIntensityValues();
+
     scan.getIsolations();
     if (!scan.getIsolations().isEmpty()) {
       IsolationInfo isolationInfo = scan.getIsolations().get(0);
@@ -69,7 +76,7 @@ public class MsdkScanWrapper implements Scan {
 
   @Override
   public int getNumberOfDataPoints() {
-    return scan.getNumberOfDataPoints();
+    return mzs.length;
   }
 
   @Override
@@ -79,7 +86,8 @@ public class MsdkScanWrapper implements Scan {
 
   @Override
   public double[] getMzValues(@NotNull double[] dst) {
-    return scan.getMzValues(dst);
+    throw new UnsupportedOperationException(
+        "Unsupported operation. MSDK scan uses float array and the conversion in this method is not efficient.");
   }
 
   @Override
@@ -90,12 +98,12 @@ public class MsdkScanWrapper implements Scan {
 
   @Override
   public double getMzValue(int index) {
-    return scan.getMzValues()[index];
+    return mzs[index];
   }
 
   @Override
   public double getIntensityValue(int index) {
-    return scan.getIntensityValues()[index];
+    return intensities[index];
   }
 
   @Nullable

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_massdetection/centroid/CentroidMassDetector.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_massdetection/centroid/CentroidMassDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ * Copyright 2006-2022 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -19,13 +19,13 @@
 package io.github.mzmine.modules.dataprocessing.featdet_massdetection.centroid;
 
 import com.google.common.primitives.Doubles;
-import gnu.trove.list.array.TDoubleArrayList;
 import io.github.mzmine.datamodel.MassSpectrum;
 import io.github.mzmine.modules.dataprocessing.featdet_massdetection.DetectIsotopesParameter;
 import io.github.mzmine.modules.dataprocessing.featdet_massdetection.MassDetector;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.util.IsotopesUtils;
+import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -48,22 +48,27 @@ public class CentroidMassDetector implements MassDetector {
   @Override
   public double[][] getMassValues(MassSpectrum spectrum, ParameterSet parameters) {
 
-    final double noiseLevel =
-        parameters.getParameter(CentroidMassDetectorParameters.noiseLevel).getValue();
+    final double noiseLevel = parameters.getParameter(CentroidMassDetectorParameters.noiseLevel)
+        .getValue();
 
-    boolean detectIsotopes = parameters.getParameter(CentroidMassDetectorParameters.detectIsotopes).getValue();
+    boolean detectIsotopes = parameters.getParameter(CentroidMassDetectorParameters.detectIsotopes)
+        .getValue();
 
     // If isotopes are going to be detected get all the required parameters
     MZTolerance isotopesMzTolerance = null;
     if (detectIsotopes) {
-      ParameterSet isotopesParameters = parameters.getParameter(CentroidMassDetectorParameters.detectIsotopes).getEmbeddedParameters();
-      List<Element> isotopeElements = isotopesParameters.getParameter(DetectIsotopesParameter.elements).getValue();
-      int isotopeMaxCharge = isotopesParameters.getParameter(DetectIsotopesParameter.maxCharge).getValue();
-      isotopesMzTolerance = isotopesParameters.getParameter(DetectIsotopesParameter.isotopeMzTolerance).getValue();
+      ParameterSet isotopesParameters = parameters.getParameter(
+          CentroidMassDetectorParameters.detectIsotopes).getEmbeddedParameters();
+      List<Element> isotopeElements = isotopesParameters.getParameter(
+          DetectIsotopesParameter.elements).getValue();
+      int isotopeMaxCharge = isotopesParameters.getParameter(DetectIsotopesParameter.maxCharge)
+          .getValue();
+      isotopesMzTolerance = isotopesParameters.getParameter(
+          DetectIsotopesParameter.isotopeMzTolerance).getValue();
 
       // Update isotopesMzDiffs only if isotopeElements and isotopeMaxCharge differ from the last call
-      if (!Objects.equals(this.isotopeElements, isotopeElements)
-          || !Objects.equals(this.isotopeMaxCharge, isotopeMaxCharge)) {
+      if (!Objects.equals(this.isotopeElements, isotopeElements) || !Objects.equals(
+          this.isotopeMaxCharge, isotopeMaxCharge)) {
 
         // Update isotopesMzDiffs
         this.isotopesMzDiffs = IsotopesUtils.getIsotopesMzDiffs(isotopeElements, isotopeMaxCharge);
@@ -77,33 +82,34 @@ public class CentroidMassDetector implements MassDetector {
     // use number of centroid signals as base array list capacity
     final int points = spectrum.getNumberOfDataPoints();
     // lists of primitive doubles
-    TDoubleArrayList mzs = new TDoubleArrayList(points);
-    TDoubleArrayList intensities = new TDoubleArrayList(points);
+    DoubleArrayList mzs = new DoubleArrayList(points);
+    DoubleArrayList intensities = new DoubleArrayList(points);
 
     // Find possible mzPeaks
     for (int i = 0; i < points; i++) {
       // Is intensity above the noise level or m/z value corresponds to isotope mass?
       double intensity = spectrum.getIntensityValue(i);
-      if (intensity >= noiseLevel
-          || (detectIsotopes
-            // If the difference between current m/z and last detected m/z is greater than maximum
-            // possible isotope m/z difference do not call isPossibleIsotopeMz
-            && (mzs.isEmpty() || Doubles.compare(spectrum.getMzValue(i) - mzs.get(mzs.size() - 1), maxIsotopeMzDiff) <= 0)
-            && IsotopesUtils.isPossibleIsotopeMz(spectrum.getMzValue(i), mzs, isotopesMzDiffs, isotopesMzTolerance))) {
+      double mz = spectrum.getMzValue(i);
+      if (intensity >= noiseLevel || (detectIsotopes
+          // If the difference between current m/z and last detected m/z is greater than maximum
+          // possible isotope m/z difference do not call isPossibleIsotopeMz
+          && (mzs.isEmpty()
+          || Doubles.compare(mz - mzs.getDouble(mzs.size() - 1), maxIsotopeMzDiff) <= 0)
+          && IsotopesUtils.isPossibleIsotopeMz(mz, mzs, isotopesMzDiffs, isotopesMzTolerance))) {
         // Yes, then mark this index as mzPeak
-        mzs.add(spectrum.getMzValue(i));
+        mzs.add(mz);
         intensities.add(intensity);
       }
     }
-    return new double[][]{mzs.toArray(), intensities.toArray()};
+    return new double[][]{mzs.toDoubleArray(), intensities.toDoubleArray()};
   }
 
   @Override
   public double[][] getMassValues(double[] mzs, double[] intensities, ParameterSet parameters) {
     assert mzs.length == intensities.length;
 
-    final double noiseLevel =
-        parameters.getParameter(CentroidMassDetectorParameters.noiseLevel).getValue();
+    final double noiseLevel = parameters.getParameter(CentroidMassDetectorParameters.noiseLevel)
+        .getValue();
     return getMassValues(mzs, intensities, noiseLevel);
   }
 
@@ -113,8 +119,8 @@ public class CentroidMassDetector implements MassDetector {
     // use number of centroid signals as base array list capacity
     final int points = mzs.length;
     // lists of primitive doubles
-    TDoubleArrayList pickedMZs = new TDoubleArrayList(points);
-    TDoubleArrayList pickedIntensities = new TDoubleArrayList(points);
+    DoubleArrayList pickedMZs = new DoubleArrayList(points);
+    DoubleArrayList pickedIntensities = new DoubleArrayList(points);
 
     // Find possible mzPeaks
     for (int i = 0; i < points; i++) {
@@ -125,7 +131,7 @@ public class CentroidMassDetector implements MassDetector {
         pickedIntensities.add(intensities[i]);
       }
     }
-    return new double[][]{pickedMZs.toArray(), pickedIntensities.toArray()};
+    return new double[][]{pickedMZs.toDoubleArray(), pickedIntensities.toDoubleArray()};
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_massdetection/exactmass/ExactMassDetector.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_massdetection/exactmass/ExactMassDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ * Copyright 2006-2022 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -19,13 +19,13 @@
 package io.github.mzmine.modules.dataprocessing.featdet_massdetection.exactmass;
 
 import com.google.common.primitives.Doubles;
-import gnu.trove.list.array.TDoubleArrayList;
 import io.github.mzmine.datamodel.MassSpectrum;
 import io.github.mzmine.modules.dataprocessing.featdet_massdetection.DetectIsotopesParameter;
 import io.github.mzmine.modules.dataprocessing.featdet_massdetection.MassDetector;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.util.IsotopesUtils;
+import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -53,8 +53,8 @@ public class ExactMassDetector implements MassDetector {
       boolean detectIsotopes, MZTolerance isotopesMzTolerance, List<Double> isotopesMzDiffs,
       double maxIsotopeMzDiff) {
     // lists of primitive doubles
-    TDoubleArrayList mzs = new TDoubleArrayList(100);
-    TDoubleArrayList intensities = new TDoubleArrayList(100);
+    DoubleArrayList mzs = new DoubleArrayList(128);
+    DoubleArrayList intensities = new DoubleArrayList(128);
 
     // First get all candidate peaks (local maximum)
     int localMaximumIndex = 0;
@@ -95,11 +95,11 @@ public class ExactMassDetector implements MassDetector {
         // Add the m/z peak if it is above the noise level or m/z value corresponds to isotope mass
         if (spectrum.getIntensityValue(localMaximumIndex) > noiseLevel || //
             (detectIsotopes
-             // If the difference between current m/z and last detected m/z is greater than maximum
-             // possible isotope m/z difference do not call isPossibleIsotopeMz
-             && (mzs.isEmpty()
-                 || Doubles.compare(exactMz - mzs.get(mzs.size() - 1), maxIsotopeMzDiff) <= 0)
-             && IsotopesUtils.isPossibleIsotopeMz(exactMz, mzs, isotopesMzDiffs,
+                // If the difference between current m/z and last detected m/z is greater than maximum
+                // possible isotope m/z difference do not call isPossibleIsotopeMz
+                && (mzs.isEmpty()
+                || Doubles.compare(exactMz - mzs.getDouble(mzs.size() - 1), maxIsotopeMzDiff) <= 0)
+                && IsotopesUtils.isPossibleIsotopeMz(exactMz, mzs, isotopesMzDiffs,
                 isotopesMzTolerance))) {
 
           // Add data point to lists
@@ -114,7 +114,7 @@ public class ExactMassDetector implements MassDetector {
     }
 
     // Return an array of detected MzPeaks sorted by MZ
-    return new double[][]{mzs.toArray(), intensities.toArray()};
+    return new double[][]{mzs.toDoubleArray(), intensities.toDoubleArray()};
   }
 
   /**
@@ -146,7 +146,7 @@ public class ExactMassDetector implements MassDetector {
       // Left side of the curve
       if ((spectrum.getIntensityValue(rangeDataPoints.get(i)) <= halfIntensity) && (
           spectrum.getMzValue(rangeDataPoints.get(i)) < spectrum.getMzValue(topIndex)) && (
-              spectrum.getIntensityValue(rangeDataPoints.get(i + 1)) >= halfIntensity)) {
+          spectrum.getIntensityValue(rangeDataPoints.get(i + 1)) >= halfIntensity)) {
 
         // First point with intensity just less than half of total
         // intensity
@@ -178,7 +178,7 @@ public class ExactMassDetector implements MassDetector {
       // Right side of the curve
       if ((spectrum.getIntensityValue(rangeDataPoints.get(i)) >= halfIntensity) && (
           spectrum.getMzValue(rangeDataPoints.get(i)) > spectrum.getMzValue(topIndex)) && (
-              spectrum.getIntensityValue(rangeDataPoints.get(i + 1)) <= halfIntensity)) {
+          spectrum.getIntensityValue(rangeDataPoints.get(i + 1)) <= halfIntensity)) {
 
         // First point with intensity just bigger than half of total
         // intensity

--- a/src/main/java/io/github/mzmine/util/IsotopesUtils.java
+++ b/src/main/java/io/github/mzmine/util/IsotopesUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2021 The MZmine Development Team
+ * Copyright 2006-2022 The MZmine Development Team
  *
  * This file is part of MZmine.
  *
@@ -20,7 +20,6 @@ package io.github.mzmine.util;
 
 import com.google.common.collect.Range;
 import com.google.common.primitives.Doubles;
-import gnu.trove.list.array.TDoubleArrayList;
 import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.MassSpectrum;
 import io.github.mzmine.datamodel.impl.SimpleDataPoint;
@@ -40,7 +39,7 @@ import org.openscience.cdk.interfaces.IIsotope;
 
 public class IsotopesUtils {
 
-  private static DataPointSorter mzSorter = new DataPointSorter(SortingProperty.MZ,
+  private static final DataPointSorter mzSorter = new DataPointSorter(SortingProperty.MZ,
       SortingDirection.Ascending);
   private static Isotopes isotopes;
 
@@ -289,7 +288,7 @@ public class IsotopesUtils {
    *                        value equal
    * @return True if new m/z corresponds to an isotope of known m/z's, false otherwise.
    */
-  public static boolean isPossibleIsotopeMz(double newMz, @NotNull TDoubleArrayList knownMzs,
+  public static boolean isPossibleIsotopeMz(double newMz, @NotNull DoubleArrayList knownMzs,
       @NotNull List<Double> isotopesMzDiffs, @NotNull MZTolerance mzTolerance) {
 
     // Iterate over possible isotope m/z differences
@@ -309,7 +308,7 @@ public class IsotopesUtils {
       for (int mzIndex = knownMzs.size() - 1; mzIndex >= 0; mzIndex--) {
 
         // Get real m/z from knownMzs that is going to be compared with the theoretical one
-        double realMz = knownMzs.get(mzIndex);
+        double realMz = knownMzs.getDouble(mzIndex);
 
         // Do not go left further if the theoretical m/z is higher than real
         if (Doubles.compare(theoreticalMzTolRange.lowerEndpoint(), realMz) > 0) {
@@ -367,7 +366,7 @@ public class IsotopesUtils {
   }
 
   /**
-   * Used in loops form high to lower m/z to add preceeding isotopes first
+   * Used in loops form high to lower m/z to add preceding isotopes first
    */
   public static boolean isPossibleIsotopeMzNegativeDirection(double newMz,
       @NotNull List<DataPoint> knownMzs, @NotNull List<Double> isotopesMzDiffs,
@@ -423,7 +422,7 @@ public class IsotopesUtils {
     int dp = spectrum.getNumberOfDataPoints() - 1;
 
     List<DataPoint> candidates = new ArrayList<>();
-    // add the actual data point in the scan so we don't end up with duplicates.
+    // add the actual data point in the scan, so we don't end up with duplicates.
     final int targetIndex = spectrum.binarySearch(target.getMZ(), true);
     candidates.add(new SimpleDataPoint(spectrum.getMzValue(targetIndex),
         spectrum.getIntensityValue(targetIndex)));
@@ -431,8 +430,8 @@ public class IsotopesUtils {
     double mz = spectrum.getMzValue(targetIndex);
     double lastMZ = mz;
 
-    // first try to find preceeding isotope signals
-    // e.g. if the monoisotopic m/z (smalles mz) is not the most abundant, which is common for
+    // first try to find preceding isotope signals
+    // e.g. if the mono isotopic m/z (smallest mz) is not the most abundant, which is common for
     // compounds with many 13C or Br/Cl or compounds with metals (e.g., Gd)
     for (; dp >= 0 && mz >= lastMZ - maxIsoMzDiff; dp--) {
       mz = spectrum.getMzValue(dp);


### PR DESCRIPTION
Data access on MzMLScan and the MSDKScanWrapper was very inefficient as used in the advanced import where mass detection is applied directly, to safe memory and need for memory mapping.

for 250 mzML files it went down from 12 min --> 2 min