### PR TITLE
Patch out of bound in IsotopeFinder

### DIFF
--- a/src/main/java/io/github/mzmine/util/IsotopesUtils.java
+++ b/src/main/java/io/github/mzmine/util/IsotopesUtils.java
@@ -419,6 +419,10 @@ public class IsotopesUtils {
 
   public static List<DataPoint> findIsotopesInScan(List<Double> isoMzDiffs, double maxIsoMzDiff,
       MZTolerance isoMzTolerance, MassSpectrum spectrum, DataPoint target) {
+    if (spectrum.getNumberOfDataPoints() <= 0) {
+      return List.of();
+    }
+
     int dp = spectrum.getNumberOfDataPoints() - 1;
 
     List<DataPoint> candidates = new ArrayList<>();


### PR DESCRIPTION
Empty mobility scans were throwing out of bounds exceptions