### PR TITLE
update default ms2 grouping selection (true = default)

### DIFF
--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/GeneralResolverParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/GeneralResolverParameters.java
@@ -44,7 +44,8 @@ public abstract class GeneralResolverParameters extends SimpleParameterSet {
       new OriginalFeatureListHandlingParameter(true);
 
   public static final OptionalModuleParameter<GroupMS2SubParameters> groupMS2Parameters = new OptionalModuleParameter<>(
-      "MS/MS scan pairing", "Set MS/MS scan pairing parameters.", new GroupMS2SubParameters());
+      "MS/MS scan pairing", "Set MS/MS scan pairing parameters.", new GroupMS2SubParameters(),
+      true);
 
   public static final ComboParameter<ResolvingDimension> dimension = new ComboParameter<>(
       "Dimension", "Select the dimension to be resolved.",

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_groupms2/GroupMS2Parameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_groupms2/GroupMS2Parameters.java
@@ -47,7 +47,7 @@ public class GroupMS2Parameters extends SimpleParameterSet {
       new RTTolerance(0.2f, Unit.MINUTES));
 
   public static final BooleanParameter limitRTByFeature = new BooleanParameter("Limit by RT edges",
-      "Use the feature's edges (retention time) as a filter.", false);
+      "Use the feature's edges (retention time) as a filter.", true);
 
   public static final BooleanParameter combineTimsMsMs = new BooleanParameter(
       "Combine MS/MS spectra (TIMS)",

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_groupms2/GroupMS2SubParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_groupms2/GroupMS2SubParameters.java
@@ -44,7 +44,7 @@ public class GroupMS2SubParameters extends SimpleParameterSet {
       new RTTolerance(0.2f, Unit.MINUTES));
 
   public static final BooleanParameter limitRTByFeature = new BooleanParameter("Limit by RT edges",
-      "Use the feature's edges (retention time) as a filter.", false);
+      "Use the feature's edges (retention time) as a filter.", true);
 
   public static final BooleanParameter combineTimsMsMs = new BooleanParameter(
       "Combine MS/MS spectra (TIMS)",


### PR DESCRIPTION
Change the selection of the group ms2 parameter in the resolver to true, so MS2s are grouped by default.
Also select the limit by rt edges by default.