### PR TITLE
Update image builder parameters

### DIFF
--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ModularADAPChromatogramBuilderModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ModularADAPChromatogramBuilderModule.java
@@ -40,18 +40,15 @@ import org.jetbrains.annotations.NotNull;
 public class ModularADAPChromatogramBuilderModule implements MZmineProcessingModule {
 
   private static final String MODULE_NAME = "ADAP Chromatogram Builder";
-  private static final String MODULE_DESCRIPTION =
-      "This module connects data points from mass lists and builds chromatograms.";
+  private static final String MODULE_DESCRIPTION = "This module connects data points from mass lists and builds chromatograms.";
 
   @Override
-  public @NotNull
-  String getName() {
+  public @NotNull String getName() {
     return MODULE_NAME;
   }
 
   @Override
-  public @NotNull
-  String getDescription() {
+  public @NotNull String getDescription() {
     return MODULE_DESCRIPTION;
   }
 
@@ -67,7 +64,8 @@ public class ModularADAPChromatogramBuilderModule implements MZmineProcessingMod
 
     for (int i = 0; i < dataFiles.length; i++) {
       Task newTask = new ModularADAPChromatogramBuilderTask(project, dataFiles[i],
-          parameters.cloneParameterSet(true), storage, moduleCallDate);
+          parameters.cloneParameterSet(true), storage, moduleCallDate,
+          ModularADAPChromatogramBuilderModule.class);
       tasks.add(newTask);
     }
 
@@ -75,14 +73,12 @@ public class ModularADAPChromatogramBuilderModule implements MZmineProcessingMod
   }
 
   @Override
-  public @NotNull
-  MZmineModuleCategory getModuleCategory() {
+  public @NotNull MZmineModuleCategory getModuleCategory() {
     return MZmineModuleCategory.EIC_DETECTION;
   }
 
   @Override
-  public @NotNull
-  Class<? extends ParameterSet> getParameterSetClass() {
+  public @NotNull Class<? extends ParameterSet> getParameterSetClass() {
     return ADAPChromatogramBuilderParameters.class;
   }
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ModularADAPChromatogramBuilderTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_adapchromatogrambuilder/ModularADAPChromatogramBuilderTask.java
@@ -42,6 +42,7 @@ import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
 import io.github.mzmine.datamodel.features.types.FeatureShapeType;
 import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.modules.MZmineModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.parametertypes.selectors.ScanSelection;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
@@ -82,6 +83,7 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
   private final double minGroupIntensity;
   private final double minHighestPoint;
   private final ParameterSet parameters;
+  private final Class<? extends MZmineModule> callingModule;
   private double progress = 0.0;
   private ModularFeatureList newFeatureList;
 
@@ -90,7 +92,7 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
    */
   public ModularADAPChromatogramBuilderTask(MZmineProject project, RawDataFile dataFile,
       ParameterSet parameters, @Nullable MemoryMapStorage storage,
-      @NotNull Instant moduleCallDate) {
+      @NotNull Instant moduleCallDate, Class<? extends MZmineModule> callingModule) {
     super(storage, moduleCallDate);
     this.project = project;
     this.dataFile = dataFile;
@@ -110,6 +112,7 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
     this.minHighestPoint = parameters.getParameter(
         ADAPChromatogramBuilderParameters.minHighestPoint).getValue();
     this.parameters = parameters;
+    this.callingModule = callingModule;
   }
 
   @Override
@@ -314,7 +317,7 @@ public class ModularADAPChromatogramBuilderTask extends AbstractTask {
     dataFile.getAppliedMethods().forEach(m -> newFeatureList.getAppliedMethods().add(m));
     // Add new feature list to the project
     newFeatureList.getAppliedMethods().add(
-        new SimpleFeatureListAppliedMethod(ModularADAPChromatogramBuilderModule.class, parameters,
+        new SimpleFeatureListAppliedMethod(callingModule, parameters,
             getModuleCallDate()));
     project.addFeatureList(newFeatureList);
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_imagebuilder/ImageBuilderModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_imagebuilder/ImageBuilderModule.java
@@ -40,7 +40,6 @@ import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.MemoryMapStorage;
 import java.time.Instant;
 import java.util.Collection;
-import java.util.HashMap;
 import org.jetbrains.annotations.NotNull;
 
 /*
@@ -51,8 +50,7 @@ import org.jetbrains.annotations.NotNull;
 public class ImageBuilderModule implements MZmineProcessingModule {
 
   private static final String MODULE_NAME = "Image builder";
-  private static final String MODULE_DESCRIPTION =
-      "This module connects data points from mass lists and builds images.";
+  private static final String MODULE_DESCRIPTION = "This module connects data points from mass lists and builds images.";
 
   @Override
   public @NotNull String getName() {
@@ -81,7 +79,7 @@ public class ImageBuilderModule implements MZmineProcessingModule {
         continue;
       }
       Task task = new ModularADAPChromatogramBuilderTask(project, file, parametersFromImageBuilder,
-          storage, moduleCallDate);
+          storage, moduleCallDate, ImageBuilderModule.class);
       tasks.add(task);
     }
 
@@ -100,9 +98,8 @@ public class ImageBuilderModule implements MZmineProcessingModule {
     newParameterSet.setParameter(ADAPChromatogramBuilderParameters.suffix,
         parameters.getParameter(ImageBuilderParameters.suffix).getValue());
     newParameterSet.setParameter(ADAPChromatogramBuilderParameters.minGroupIntensity, 0.0);
-    newParameterSet.setParameter(ADAPChromatogramBuilderParameters.minHighestPoint, 0.0);
-    newParameterSet.setParameter(ADAPChromatogramBuilderParameters.allowSingleScans,
-        new HashMap<String, Boolean>());
+    newParameterSet.setParameter(ADAPChromatogramBuilderParameters.minHighestPoint,
+        parameters.getValue(ImageBuilderParameters.minHighest));
     return newParameterSet;
   }
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_imagebuilder/ImageBuilderParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_imagebuilder/ImageBuilderParameters.java
@@ -25,8 +25,10 @@
 
 package io.github.mzmine.modules.dataprocessing.featdet_imagebuilder;
 
+import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
+import io.github.mzmine.parameters.parametertypes.DoubleParameter;
 import io.github.mzmine.parameters.parametertypes.IntegerParameter;
 import io.github.mzmine.parameters.parametertypes.StringParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesParameter;
@@ -34,31 +36,38 @@ import io.github.mzmine.parameters.parametertypes.selectors.ScanSelection;
 import io.github.mzmine.parameters.parametertypes.selectors.ScanSelectionParameter;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZToleranceParameter;
 
-/*
+/**
+ * These parameters must have the same name as the ones in
+ * {@link
+ * io.github.mzmine.modules.dataprocessing.featdet_adapchromatogrambuilder.ADAPChromatogramBuilderParameters}
+ *
  * @author Ansgar Korf (ansgar.korf@uni-muenster.de)
  */
 public class ImageBuilderParameters extends SimpleParameterSet {
 
   public static final RawDataFilesParameter rawDataFiles = new RawDataFilesParameter();
 
-  public static final ScanSelectionParameter scanSelection =
-      new ScanSelectionParameter("Scan " + "selection",
-          "Filter scans based on their properties. Different noise levels ( -> mass "
-              + "lists) are recommended for MS1 and MS/MS scans",
-          new ScanSelection());
+  public static final ScanSelectionParameter scanSelection = new ScanSelectionParameter(
+      new ScanSelection(1));
 
-  public static final MZToleranceParameter mzTolerance = new MZToleranceParameter("m/z tolerance",
-      "m/z tolerance between mobility scans to be assigned to the same mobilogram", 0.005, 5,
-      false);
+  public static final MZToleranceParameter mzTolerance = new MZToleranceParameter(
+      "Scan to scan accuracy (m/z)", "m/z tolerance between scans to be placed in the same image.",
+      0.005, 15, false);
 
   public static final IntegerParameter minTotalSignals = new IntegerParameter(
-      "Minimum total Signals", "Minimum number of signals (data points) to form an image", 200);
+      "Min group size in # of scans",
+      "Minimum number of consecutive signals (data points) to form an image", 50);
+
+  public static final DoubleParameter minHighest = new DoubleParameter("Min highest intensity",
+      "Minimum intensity of an m/z to be considered as an image.",
+      MZmineCore.getConfiguration().getIntensityFormat(), 1E3);
 
 
-  public static final StringParameter suffix =
-      new StringParameter("Suffix", "This string is added to filename as suffix", "images");
+  public static final StringParameter suffix = new StringParameter("Suffix",
+      "This string is added to filename as suffix", "images");
 
   public ImageBuilderParameters() {
-    super(new Parameter[]{rawDataFiles, scanSelection, mzTolerance, minTotalSignals, suffix});
+    super(new Parameter[]{rawDataFiles, scanSelection, mzTolerance, minHighest, minTotalSignals,
+        suffix});
   }
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_diams2/DiaMs2CorrTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_diams2/DiaMs2CorrTask.java
@@ -356,7 +356,7 @@ public class DiaMs2CorrTask extends AbstractTask {
 
   private ModularFeatureList buildChromatograms(MZmineProject dummyProject, RawDataFile file) {
     adapTask = new ModularADAPChromatogramBuilderTask(dummyProject, file, adapParameters,
-        getMemoryMapStorage(), getModuleCallDate());
+        getMemoryMapStorage(), getModuleCallDate(), DiaMs2CorrModule.class);
     adapTask.run();
     adapTask = new FinishedTask(adapTask);
     currentTaksIndex++;


### PR DESCRIPTION
The minimum intensity was missing in the image builder parameters. further, if a batch was created, it was reflected as the adap chromatogram builder instead of the image builder. Also, the description for the min signals in the image builder was wrong.

The names for the image builder parameters and the adap parameters have to match now, for this to work.