### PR TITLE
update MobilityScanMergerTask

### DIFF
--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_mobilityscanmerger/MobilityScanMergerModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_mobilityscanmerger/MobilityScanMergerModule.java
@@ -68,7 +68,7 @@ public class MobilityScanMergerModule implements MZmineProcessingModule {
     for (RawDataFile file : parameters.getParameter(MobilityScanMergerParameters.rawDataFiles)
         .getValue().getMatchingRawDataFiles()) {
       if (file instanceof IMSRawDataFile) {
-        tasks.add(new MoblityScanMergerTask((IMSRawDataFile) file, parameters, moduleCallDate));
+        tasks.add(new MobilityScanMergerTask((IMSRawDataFile) file, parameters, moduleCallDate));
       }
     }
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_mobilityscanmerger/MobilityScanMergerParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_mobilityscanmerger/MobilityScanMergerParameters.java
@@ -43,7 +43,7 @@ public class MobilityScanMergerParameters extends SimpleParameterSet {
 
   public static final RawDataFilesParameter rawDataFiles = new RawDataFilesParameter();
 
-  public static final DoubleParameter noiseLevel = new DoubleParameter("Frane noise level",
+  public static final DoubleParameter noiseLevel = new DoubleParameter("Frame noise level",
       "Noise level for the merged frame. Merged signals below this threshold will be ignored.",
       MZmineCore.getConfiguration().getIntensityFormat(), 1E1, 0d, 1E12);
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_mobilityscanmerger/MobilityScanMergerParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_mobilityscanmerger/MobilityScanMergerParameters.java
@@ -43,12 +43,13 @@ public class MobilityScanMergerParameters extends SimpleParameterSet {
 
   public static final RawDataFilesParameter rawDataFiles = new RawDataFilesParameter();
 
-  public static final DoubleParameter noiseLevel = new DoubleParameter("Noise level",
-      "Data points below this threshold will be ignored.",
+  public static final DoubleParameter noiseLevel = new DoubleParameter("Frane noise level",
+      "Noise level for the merged frame. Merged signals below this threshold will be ignored.",
       MZmineCore.getConfiguration().getIntensityFormat(), 1E1, 0d, 1E12);
 
   public static final ComboParameter<IntensityMergingType> mergingType = new ComboParameter<>(
-      "Merging type", "Spectra merging algorithm", IntensityMergingType.values(), IntensityMergingType.SUMMED);
+      "Merging type", "Spectra merging algorithm", IntensityMergingType.values(),
+      IntensityMergingType.SUMMED);
 
   public static final ComboParameter<Weighting> weightingType = new ComboParameter<>(
       "m/z weighting", "Weights m/z values by their intensities with the given function.",
@@ -57,7 +58,7 @@ public class MobilityScanMergerParameters extends SimpleParameterSet {
   public static final ScanSelectionParameter scanSelection = new ScanSelectionParameter();
 
   public static final MZToleranceParameter mzTolerance = new MZToleranceParameter("m/z tolerance",
-      "", 0.0001, 2, false);
+      "", 0.003, 15, false);
 
   public MobilityScanMergerParameters() {
     super(new Parameter[]{rawDataFiles, noiseLevel, mergingType, weightingType, scanSelection,

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_mobilityscanmerger/MobilityScanMergerTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_mobilityscanmerger/MobilityScanMergerTask.java
@@ -46,9 +46,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 
-public class MoblityScanMergerTask extends AbstractTask {
+public class MobilityScanMergerTask extends AbstractTask {
 
-  private static final Logger logger = Logger.getLogger(MoblityScanMergerTask.class.getName());
+  private static final Logger logger = Logger.getLogger(MobilityScanMergerTask.class.getName());
 
   private final ScanSelection scanSelection;
   private final IMSRawDataFile rawDataFile;
@@ -60,7 +60,7 @@ public class MoblityScanMergerTask extends AbstractTask {
   private int totalFrames;
   private int processedFrames;
 
-  public MoblityScanMergerTask(final IMSRawDataFile file, ParameterSet parameters,
+  public MobilityScanMergerTask(final IMSRawDataFile file, ParameterSet parameters,
       @NotNull Instant moduleCallDate) {
     super(null,
         moduleCallDate); // for now, the merged data points are added to the frame on the raw data
@@ -102,7 +102,7 @@ public class MoblityScanMergerTask extends AbstractTask {
         SimpleFrame frame = (SimpleFrame) f;
         double[][] merged = SpectraMerging.calculatedMergedMzsAndIntensities(
             frame.getMobilityScans().stream().map(MobilityScan::getMassList).toList(), mzTolerance,
-            mergingType, cf, noiseLevel, null, null);
+            mergingType, cf, null, noiseLevel, null);
 
         frame.setDataPoints(merged[0], merged[1]);
         frame.addMassList(new ScanPointerMassList(frame));


### PR DESCRIPTION
The noise level parameter did not clearly state if it is applied to mobiltiy scans or to the frame. It should be applied to the frame (but wasnt in the merger task, probably due to all the refactoring we did to the merge method). applying the noise level to mobscans again would duplicate the mass detector which wouldnt make sense.