### PR TITLE
Add GC-MS menu

### DIFF
--- a/src/main/java/io/github/mzmine/gui/mainwindow/MainMenu.fxml
+++ b/src/main/java/io/github/mzmine/gui/mainwindow/MainMenu.fxml
@@ -208,14 +208,17 @@
 
   <Menu text="Feature detection">
     <Menu text="LC-MS">
-      <MenuItem onAction="#runModule"
-        text="ADAP chromatogram builder"
+      <MenuItem onAction="#runModule" text="ADAP chromatogram builder"
         userData="io.github.mzmine.modules.dataprocessing.featdet_adapchromatogrambuilder.ModularADAPChromatogramBuilderModule"/>
       <MenuItem text="GridMass" onAction="#runModule"
         userData="io.github.mzmine.modules.dataprocessing.featdet_gridmass.GridMassModule"/>
       <MenuItem onAction="#runModule"
         text="Targeted feature detection"
         userData="io.github.mzmine.modules.dataprocessing.featdet_targeted.TargetedFeatureDetectionModule"/>
+    </Menu>
+    <Menu text="GC-MS">
+          <MenuItem onAction="#runModule" text="ADAP chromatogram builder"
+            userData="io.github.mzmine.modules.dataprocessing.featdet_adapchromatogrambuilder.ModularADAPChromatogramBuilderModule"/>
     </Menu>
     <Menu text="LC-IMS-MS">
       <MenuItem onAction="#runModule"


### PR DESCRIPTION
Only use ADAP chrom builder 
targeted does not work in GC-MS because of the missing other peaks that are usually later clustered.