### PR TITLE
FeatureFilterTask, fix keep ms2 only

### DIFF
--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_featurefilter/FeatureFilterParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_featurefilter/FeatureFilterParameters.java
@@ -85,14 +85,14 @@ public class FeatureFilterParameters extends SimpleParameterSet {
       "Remove source feature list after filtering",
       "If checked, the original feature list will be removed leaving only the filtered version");
 
-  public static final BooleanParameter MS2_Filter =
+  public static final BooleanParameter KEEP_MS2_ONLY =
       new BooleanParameter("Keep only features with MS/MS scan",
           "If checked, the feature that don't contain MS2 scan will be removed.");
 
   public FeatureFilterParameters() {
     super(
         new Parameter[] {PEAK_LISTS, SUFFIX, PEAK_DURATION, PEAK_AREA, PEAK_HEIGHT, PEAK_DATAPOINTS,
-            PEAK_FWHM, PEAK_TAILINGFACTOR, PEAK_ASYMMETRYFACTOR, MS2_Filter, AUTO_REMOVE},
+            PEAK_FWHM, PEAK_TAILINGFACTOR, PEAK_ASYMMETRYFACTOR, KEEP_MS2_ONLY, AUTO_REMOVE},
         "https://mzmine.github.io/mzmine_documentation/module_docs/feature_filter/feature_filter.html");
   }
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_featurefilter/FeatureFilterTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_featurefilter/FeatureFilterTask.java
@@ -160,8 +160,8 @@ public class FeatureFilterTask extends AbstractTask {
         parameters.getParameter(FeatureFilterParameters.PEAK_TAILINGFACTOR).getValue();
     final boolean filterByAsymmetryFactor =
         parameters.getParameter(FeatureFilterParameters.PEAK_ASYMMETRYFACTOR).getValue();
-    final boolean filterByMS2 =
-        parameters.getParameter(FeatureFilterParameters.MS2_Filter).getValue();
+    final boolean keepMs2Only =
+        parameters.getParameter(FeatureFilterParameters.KEEP_MS2_ONLY).getValue();
 
     final Range<Double> durationRange =
         parameters.getParameter(FeatureFilterParameters.PEAK_DURATION).getEmbeddedParameter()
@@ -210,7 +210,7 @@ public class FeatureFilterTask extends AbstractTask {
         final double peakArea = peak.getArea();
         final double peakHeight = peak.getHeight();
         final int peakDatapoints = peak.getScanNumbers().size();
-        final Scan msmsScanNumber = peak.getMostIntenseFragmentScan();
+        final Scan bestMsMs = peak.getMostIntenseFragmentScan();
 
         Float peakFWHM = peak.getFWHM();
         Float peakTailingFactor = peak.getTailingFactor();
@@ -239,7 +239,7 @@ public class FeatureFilterTask extends AbstractTask {
             (filterByFWHM && !fwhmRange.contains(peakFWHM)) ||
             (filterByTailingFactor && !tailingRange.contains(peakTailingFactor)) ||
             (filterByAsymmetryFactor && !asymmetryRange.contains(peakAsymmetryFactor)) ||
-            (filterByMS2 && msmsScanNumber != null)) {
+            (keepMs2Only && bestMsMs == null)) {
           // Mark peak to be removed
           keepPeak[i] = false;
         }


### PR DESCRIPTION
fixes issue in #1089 

The feature filter condition for the ms2s removed all features with ms2s instead of keeping them