### PR TITLE
dont load preferences from projects

### DIFF
--- a/src/main/java/io/github/mzmine/main/MZmineConfiguration.java
+++ b/src/main/java/io/github/mzmine/main/MZmineConfiguration.java
@@ -103,7 +103,7 @@ public interface MZmineConfiguration {
 
   UnitFormat getUnitFormat();
 
-  void loadConfiguration(File file) throws IOException;
+  void loadConfiguration(File file, boolean loadPreferences) throws IOException;
 
   void saveConfiguration(File file) throws IOException;
 

--- a/src/main/java/io/github/mzmine/main/MZmineCore.java
+++ b/src/main/java/io/github/mzmine/main/MZmineCore.java
@@ -146,7 +146,7 @@ public final class MZmineCore {
       // Load configuration
       if (prefFile.exists() && prefFile.canRead()) {
         try {
-          getInstance().configuration.loadConfiguration(prefFile);
+          getInstance().configuration.loadConfiguration(prefFile, true);
           updateTempDir = true;
         } catch (Exception e) {
           logger.log(Level.WARNING,

--- a/src/main/java/io/github/mzmine/main/impl/MZmineConfigurationImpl.java
+++ b/src/main/java/io/github/mzmine/main/impl/MZmineConfigurationImpl.java
@@ -243,7 +243,7 @@ public class MZmineConfigurationImpl implements MZmineConfiguration {
 
   @SuppressWarnings("unchecked")
   @Override
-  public void loadConfiguration(File file) throws IOException {
+  public void loadConfiguration(File file, boolean loadPreferences) throws IOException {
 
     try {
       DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
@@ -256,27 +256,31 @@ public class MZmineConfigurationImpl implements MZmineConfiguration {
 
       logger.finest("Loading desktop configuration");
 
-      XPathExpression expr = xpath.compile("//configuration/preferences");
-      NodeList nodes = (NodeList) expr.evaluate(configuration, XPathConstants.NODESET);
-      if (nodes.getLength() == 1) {
-        Element preferencesElement = (Element) nodes.item(0);
-        // loading encryption key
-        // this has to be read first because following parameters may
-        // already contain encrypted data
-        // that needs this key for encryption
-        if (file.equals(MZmineConfiguration.CONFIG_FILE)) {
-          new SimpleParameterSet(new Parameter[]{globalEncrypter}).loadValuesFromXML(
-              preferencesElement);
+      XPathExpression expr;
+      NodeList nodes;
+      if (loadPreferences) {
+        expr = xpath.compile("//configuration/preferences");
+        nodes = (NodeList) expr.evaluate(configuration, XPathConstants.NODESET);
+        if (nodes.getLength() == 1) {
+          Element preferencesElement = (Element) nodes.item(0);
+          // loading encryption key
+          // this has to be read first because following parameters may
+          // already contain encrypted data
+          // that needs this key for encryption
+          if (file.equals(MZmineConfiguration.CONFIG_FILE)) {
+            new SimpleParameterSet(new Parameter[]{globalEncrypter}).loadValuesFromXML(
+                preferencesElement);
+          }
+          preferences.loadValuesFromXML(preferencesElement);
         }
-        preferences.loadValuesFromXML(preferencesElement);
-      }
 
-      logger.finest("Loading last projects");
-      expr = xpath.compile("//configuration/lastprojects");
-      nodes = (NodeList) expr.evaluate(configuration, XPathConstants.NODESET);
-      if (nodes.getLength() == 1) {
-        Element lastProjectsElement = (Element) nodes.item(0);
-        lastProjects.loadValueFromXML(lastProjectsElement);
+        logger.finest("Loading last projects");
+        expr = xpath.compile("//configuration/lastprojects");
+        nodes = (NodeList) expr.evaluate(configuration, XPathConstants.NODESET);
+        if (nodes.getLength() == 1) {
+          Element lastProjectsElement = (Element) nodes.item(0);
+          lastProjects.loadValueFromXML(lastProjectsElement);
+        }
       }
 
       logger.finest("Loading modules configuration");

--- a/src/main/java/io/github/mzmine/modules/io/projectload/ProjectOpeningTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/projectload/ProjectOpeningTask.java
@@ -341,7 +341,7 @@ public class ProjectOpeningTask extends AbstractTask {
     fileStream.close();
 
     try {
-      MZmineCore.getConfiguration().loadConfiguration(tempConfigFile);
+      MZmineCore.getConfiguration().loadConfiguration(tempConfigFile, false);
     } catch (Exception e) {
       logger.warning(
           "Could not load configuration from the project: " + ExceptionUtils.exceptionToString(e));


### PR DESCRIPTION
Loading a project always changed the local preferences, too. I find it pretty annoying as you normally configure mzmine the way you like. 

Especially annoying if youre using proxies or so and the settings are lost all the time