### PR TITLE
check for the presence of the substitute-pattern {} in CSVExporModule

### DIFF
--- a/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularParameters.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularParameters.java
@@ -76,7 +76,7 @@ public class CSVExportModularParameters extends SimpleParameterSet {
     String plNamePattern = "{}";
     boolean substitute = filename.getValue().getPath().contains(plNamePattern);
 
-    if (!substitute && featureLists.getValue().getSpecificFeatureLists().length > 1) {
+    if (!substitute && this.getValue(featureLists).getMatchingFeatureLists().length > 1) {
       errorMessages.add("""
           Cannot export multiple feature lists to the same CSV file. Please use "{}" pattern in filename. \
           This will be replaced with the feature list name to generate one file per feature list.

--- a/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularParameters.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularParameters.java
@@ -74,7 +74,7 @@ public class CSVExportModularParameters extends SimpleParameterSet {
 
     // Check if substitute pattern is present in filename if several feature lists are selected by the user
     String plNamePattern = "{}";
-    boolean substitute = filename.getValue().getPath().contains(plNamePattern);
+    boolean substitute = this.getValue(filename).getPath().contains(plNamePattern);
 
     if (!substitute && this.getValue(featureLists).getMatchingFeatureLists().length > 1) {
       errorMessages.add("""

--- a/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularParameters.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularParameters.java
@@ -34,6 +34,8 @@ import io.github.mzmine.parameters.parametertypes.StringParameter;
 import io.github.mzmine.parameters.parametertypes.filenames.FileNameParameter;
 import io.github.mzmine.parameters.parametertypes.filenames.FileSelectionType;
 import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
+import io.github.mzmine.taskcontrol.TaskStatus;
+import java.util.Collection;
 import java.util.List;
 import javafx.stage.FileChooser.ExtensionFilter;
 
@@ -66,4 +68,21 @@ public class CSVExportModularParameters extends SimpleParameterSet {
         filter});
   }
 
+  @Override
+  public boolean checkParameterValues(Collection<String> errorMessages) {
+    final boolean superCheck = super.checkParameterValues(errorMessages);
+
+    // Check if substitute pattern is present in filename if several feature lists are selected by the user
+    String plNamePattern = "{}";
+    boolean substitute = filename.getValue().getPath().contains(plNamePattern);
+
+    if (!substitute && featureLists.getValue().getSpecificFeatureLists().length > 1) {
+      errorMessages.add("""
+          Cannot export multiple feature lists to the same CSV file. Please use "{}" pattern in filename. \
+          This will be replaced with the feature list name to generate one file per feature list.
+          """);
+    }
+
+    return superCheck && errorMessages.isEmpty();
+  }
 }

--- a/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularTask.java
@@ -141,6 +141,15 @@ public class CSVExportModularTask extends AbstractTask implements ProcessedItems
     String plNamePattern = "{}";
     boolean substitute = fileName.getPath().contains(plNamePattern);
 
+    if (!substitute && featureLists.length > 1) {
+      setErrorMessage("""
+          Cannot export multiple feature lists to the same CSV file. Please use "{}" pattern in filename.\
+          This will be replaced with the feature list name to generate one file per feature list.
+          """);
+      setStatus(TaskStatus.ERROR);
+      return;
+    }
+
     // Total number of rows
     for (ModularFeatureList featureList : featureLists) {
       totalTypes += featureList.getNumberOfRows();

--- a/src/main/java/io/github/mzmine/modules/io/export_features_featureML/FeatureMLExportModularParameters.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_featureML/FeatureMLExportModularParameters.java
@@ -67,7 +67,7 @@ public class FeatureMLExportModularParameters extends SimpleParameterSet {
     String plNamePattern = "{}";
     boolean substitute = filename.getValue().getPath().contains(plNamePattern);
 
-    if (!substitute && featureLists.getValue().getSpecificFeatureLists().length > 1) {
+    if (!substitute && this.getValue(featureLists).getMatchingFeatureLists().length > 1) {
       errorMessages.add("""
           Cannot export multiple feature lists to the same featureML file. Please use "{}" pattern in filename. \
           This will be replaced with the feature list name to generate one file per feature list.

--- a/src/main/java/io/github/mzmine/modules/io/export_features_featureML/FeatureMLExportModularParameters.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_featureML/FeatureMLExportModularParameters.java
@@ -65,7 +65,7 @@ public class FeatureMLExportModularParameters extends SimpleParameterSet {
 
     // Check if substitute pattern is present in filename if several feature lists are selected by the user
     String plNamePattern = "{}";
-    boolean substitute = filename.getValue().getPath().contains(plNamePattern);
+    boolean substitute = this.getValue(filename).getPath().contains(plNamePattern);
 
     if (!substitute && this.getValue(featureLists).getMatchingFeatureLists().length > 1) {
       errorMessages.add("""

--- a/src/main/java/io/github/mzmine/modules/io/export_features_featureML/FeatureMLExportModularParameters.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_featureML/FeatureMLExportModularParameters.java
@@ -33,6 +33,7 @@ import io.github.mzmine.parameters.parametertypes.filenames.FileNameParameter;
 import io.github.mzmine.parameters.parametertypes.filenames.FileSelectionType;
 import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
 
+import java.util.Collection;
 import java.util.List;
 
 import javafx.stage.FileChooser.ExtensionFilter;
@@ -57,4 +58,22 @@ public class FeatureMLExportModularParameters extends SimpleParameterSet {
     super(new Parameter[]{featureLists, filename, filter});
   }
 
+
+  @Override
+  public boolean checkParameterValues(Collection<String> errorMessages) {
+    final boolean superCheck = super.checkParameterValues(errorMessages);
+
+    // Check if substitute pattern is present in filename if several feature lists are selected by the user
+    String plNamePattern = "{}";
+    boolean substitute = filename.getValue().getPath().contains(plNamePattern);
+
+    if (!substitute && featureLists.getValue().getSpecificFeatureLists().length > 1) {
+      errorMessages.add("""
+          Cannot export multiple feature lists to the same featureML file. Please use "{}" pattern in filename. \
+          This will be replaced with the feature list name to generate one file per feature list.
+          """);
+    }
+
+    return superCheck && errorMessages.isEmpty();
+  }
 }


### PR DESCRIPTION
added check for the presence of the substitute-pattern {} in CSVExportModule when multiple features lists are selected 
(based on the code suggestion of robinschmid from PR#1100, commit ed5aa04e138c9c9f57632f0f1ffa1ba7bd8b40e2)
// Code formatted and tested