### PR TITLE
Module refine MS2 groupings by minimum relative feature height

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/features/Feature.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/Feature.java
@@ -113,8 +113,8 @@ public interface Feature {
   }
 
   /**
-   * Used to loop over retention time, scans, and data points in combination with ({@link
-   * #getDataPointAtIndex(int)}
+   * Used to loop over retention time, scans, and data points in combination with
+   * ({@link #getDataPointAtIndex(int)}
    *
    * @param i index
    * @return
@@ -187,8 +187,7 @@ public interface Feature {
    * Sorted list of all fragmentation scans of this feature. First is the representative ("best")
    * fragmentation spectrum.
    */
-  @NotNull
-  List<Scan> getAllMS2FragmentScans();
+  @NotNull List<Scan> getAllMS2FragmentScans();
 
   /**
    * Set all fragmentation scans. First element is "best" representative scan. No sorting is
@@ -204,18 +203,22 @@ public interface Feature {
    * Set all fragmentation scans. First element is "best" representative scan. Option to apply the
    * default sorting.
    *
-   * @param allMS2FragmentScanNumbers usually sorted by most intense scans first (represantative
-   *                                  scan as first element)
-   * @param applyDefaultSorting       applies the default sorting to the list (in place)
+   * @param allFragmentScans    usually sorted by most intense scans first (represantative scan as
+   *                            first element)
+   * @param applyDefaultSorting applies the default sorting to the list (in place)
    */
-  default void setAllMS2FragmentScans(List<Scan> allMS2FragmentScanNumbers,
-      boolean applyDefaultSorting) {
-    if (applyDefaultSorting && allMS2FragmentScanNumbers != null) {
-      // in case list is immutable
-      allMS2FragmentScanNumbers = new ArrayList<>(allMS2FragmentScanNumbers);
-      allMS2FragmentScanNumbers.sort(FragmentScanSorter.DEFAULT_TIC);
+  default void setAllMS2FragmentScans(List<Scan> allFragmentScans, boolean applyDefaultSorting) {
+    if (allFragmentScans == null || allFragmentScans.isEmpty()) {
+      setAllMS2FragmentScans(allFragmentScans);
+      return;
     }
-    setAllMS2FragmentScans(allMS2FragmentScanNumbers);
+
+    if (applyDefaultSorting) {
+      // in case list is immutable
+      allFragmentScans = new ArrayList<>(allFragmentScans);
+      allFragmentScans.sort(FragmentScanSorter.DEFAULT_TIC);
+    }
+    setAllMS2FragmentScans(allFragmentScans);
   }
 
   /**
@@ -226,8 +229,8 @@ public interface Feature {
   @Nullable Float getMobility();
 
   /**
-   * Sets the mobility of this feature. Note that mobility has a unit, which should be set by {@link
-   * Feature#setMobilityUnit(MobilityType)}.
+   * Sets the mobility of this feature. Note that mobility has a unit, which should be set by
+   * {@link Feature#setMobilityUnit(MobilityType)}.
    *
    * @param mobility The mobility.
    */

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeature.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeature.java
@@ -129,8 +129,10 @@ public class ModularFeature implements Feature, ModularDataModel {
   }
 
   @Deprecated
-  public ModularFeature(ModularFeatureList flist, RawDataFile dataFile, double mz, float rt, float height, float area, List<Scan> scans, double[] mzs, double[] intensities,
-      FeatureStatus featureStatus, Scan representativeScan, List<Scan> allMS2FragmentScanNumbers, @NotNull Range<Float> rtRange, @NotNull Range<Double> mzRange,
+  public ModularFeature(ModularFeatureList flist, RawDataFile dataFile, double mz, float rt,
+      float height, float area, List<Scan> scans, double[] mzs, double[] intensities,
+      FeatureStatus featureStatus, Scan representativeScan, List<Scan> allMS2FragmentScanNumbers,
+      @NotNull Range<Float> rtRange, @NotNull Range<Double> mzRange,
       @NotNull Range<Float> intensityRange) {
     this(flist);
 
@@ -192,7 +194,8 @@ public class ModularFeature implements Feature, ModularDataModel {
   }
 
   /**
-   * Creates a new feature. The properties are determined via {@link FeatureDataUtils#recalculateIonSeriesDependingTypes(ModularFeature)}.
+   * Creates a new feature. The properties are determined via
+   * {@link FeatureDataUtils#recalculateIonSeriesDependingTypes(ModularFeature)}.
    *
    * @param flist         The feature list.
    * @param dataFile      The raw data file of this feature.
@@ -288,7 +291,8 @@ public class ModularFeature implements Feature, ModularDataModel {
         DataType newType = tclass.getConstructor().newInstance();
         ModularFeatureList flist = (ModularFeatureList) getFeatureList();
         flist.addFeatureType(newType);
-      } catch (NullPointerException | InstantiationException | NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+      } catch (NullPointerException | InstantiationException | NoSuchMethodException |
+               InvocationTargetException | IllegalAccessException e) {
         e.printStackTrace();
         return false;
       }
@@ -317,7 +321,9 @@ public class ModularFeature implements Feature, ModularDataModel {
   }
 
   /**
-   * Use {@link ModularFeature#getFeatureData()} and {@link io.github.mzmine.datamodel.featuredata.IonSpectrumSeries#getIntensityForSpectrum(MassSpectrum)}
+   * Use {@link ModularFeature#getFeatureData()} and
+   * {@link
+   * io.github.mzmine.datamodel.featuredata.IonSpectrumSeries#getIntensityForSpectrum(MassSpectrum)}
    * or {@link io.github.mzmine.datamodel.featuredata.IonSpectrumSeries#getIntensity} instead.
    *
    * @param scan
@@ -375,9 +381,9 @@ public class ModularFeature implements Feature, ModularDataModel {
   }
 
   @Override
-  public void setAllMS2FragmentScans(List<Scan> allMS2FragmentScanNumbers) {
-    //    logger.finest("SET MS2 to feature");
-    set(FragmentScanNumbersType.class, allMS2FragmentScanNumbers);
+  public void setAllMS2FragmentScans(List<Scan> allFragmentScans) {
+    boolean empty = allFragmentScans == null || allFragmentScans.isEmpty();
+    set(FragmentScanNumbersType.class, empty ? null : allFragmentScans);
   }
 
   @Nullable

--- a/src/main/java/io/github/mzmine/gui/mainwindow/MainMenu.fxml
+++ b/src/main/java/io/github/mzmine/gui/mainwindow/MainMenu.fxml
@@ -328,6 +328,8 @@
         userData="io.github.mzmine.modules.dataprocessing.filter_groupms2.GroupMS2Module"/>
       <MenuItem onAction="#runModule" text="Assign DIA pseudo spectra to features (experimental)"
         userData="io.github.mzmine.modules.dataprocessing.filter_diams2.DiaMs2CorrModule"/>
+      <MenuItem onAction="#runModule" text="Refine fragmentation scans of features"
+        userData="io.github.mzmine.modules.dataprocessing.filter_groupms2_refine.GroupedMs2RefinementModule"/>
       <MenuItem onAction="#runModule"
         text="Internal reference CCS calibration"
         userData="io.github.mzmine.modules.dataprocessing.id_ccscalibration.reference.ReferenceCCSCalibrationModule"/>

--- a/src/main/java/io/github/mzmine/modules/batchmode/BatchModeModulesList.java
+++ b/src/main/java/io/github/mzmine/modules/batchmode/BatchModeModulesList.java
@@ -65,6 +65,7 @@ import io.github.mzmine.modules.dataprocessing.filter_duplicatefilter.DuplicateF
 import io.github.mzmine.modules.dataprocessing.filter_extractscans.ExtractScansModule;
 import io.github.mzmine.modules.dataprocessing.filter_featurefilter.FeatureFilterModule;
 import io.github.mzmine.modules.dataprocessing.filter_groupms2.GroupMS2Module;
+import io.github.mzmine.modules.dataprocessing.filter_groupms2_refine.GroupedMs2RefinementModule;
 import io.github.mzmine.modules.dataprocessing.filter_interestingfeaturefinder.AnnotateIsomersModule;
 import io.github.mzmine.modules.dataprocessing.filter_isotopefinder.IsotopeFinderModule;
 import io.github.mzmine.modules.dataprocessing.filter_isotopegrouper.IsotopeGrouperModule;
@@ -109,8 +110,8 @@ import io.github.mzmine.modules.dataprocessing.norm_rtcalibration.RTCalibrationM
 import io.github.mzmine.modules.dataprocessing.norm_standardcompound.StandardCompoundNormalizerModule;
 import io.github.mzmine.modules.io.deprecated_jmzml.MzMLImportModule;
 import io.github.mzmine.modules.io.export_features_csv.CSVExportModularModule;
-import io.github.mzmine.modules.io.export_features_featureML.FeatureMLExportModularModule;
 import io.github.mzmine.modules.io.export_features_csv_legacy.LegacyCSVExportModule;
+import io.github.mzmine.modules.io.export_features_featureML.FeatureMLExportModularModule;
 import io.github.mzmine.modules.io.export_features_gnps.fbmn.GnpsFbmnExportAndSubmitModule;
 import io.github.mzmine.modules.io.export_features_gnps.gc.GnpsGcExportAndSubmitModule;
 import io.github.mzmine.modules.io.export_features_metaboanalyst.MetaboAnalystExportModule;
@@ -305,6 +306,7 @@ public class BatchModeModulesList {
       ReferenceCCSCalibrationModule.class, //
       CliqueMSModule.class, //
       GroupMS2Module.class, //
+      GroupedMs2RefinementModule.class, //
       DiaMs2CorrModule.class, //
       FormulaPredictionFeatureListModule.class, //
       IsotopePeakScannerModule.class, //

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_groupms2/GroupMS2Module.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_groupms2/GroupMS2Module.java
@@ -42,7 +42,7 @@ import org.jetbrains.annotations.NotNull;
 public class GroupMS2Module implements MZmineProcessingModule {
 
   private static final String MODULE_NAME = "Group MS2 scans with features";
-  private static final String MODULE_DESCRIPTION = "This method assings all MS2 scans within range to all features in this feature list";
+  private static final String MODULE_DESCRIPTION = "This method assigns all MS2 scans within range to all features in this feature list";
 
   @Override
   public @NotNull String getName() {

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_groupms2_refine/GroupedMs2RefinementModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_groupms2_refine/GroupedMs2RefinementModule.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2004-2022 The MZmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.dataprocessing.filter_groupms2_refine;
+
+import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.features.FeatureList;
+import io.github.mzmine.modules.MZmineModuleCategory;
+import io.github.mzmine.modules.MZmineProcessingModule;
+import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.taskcontrol.Task;
+import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * After grouping of fragmentation scans with features, only keep those that have at least X % of
+ * the highest grouped feature
+ */
+public class GroupedMs2RefinementModule implements MZmineProcessingModule {
+
+  private static final String MODULE_NAME = "Refine fragmentation scans of features";
+  private static final String MODULE_DESCRIPTION = "After grouping of fragmentation scans with features, only keep those that have at least X % of the highest grouped feature";
+
+  @Override
+  public @NotNull String getName() {
+    return MODULE_NAME;
+  }
+
+  @Override
+  public @NotNull String getDescription() {
+    return MODULE_DESCRIPTION;
+  }
+
+  @Override
+  @NotNull
+  public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
+      @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
+
+    final FeatureList[] featureLists = parameters.getParameter(
+        GroupedMs2RefinementParameters.featureLists).getValue().getMatchingFeatureLists();
+
+    for (FeatureList featureList : featureLists) {
+      Task newTask = new GroupedMs2RefinementTask(featureList, parameters, moduleCallDate);
+      tasks.add(newTask);
+    }
+    return ExitCode.OK;
+  }
+
+  @Override
+  public @NotNull MZmineModuleCategory getModuleCategory() {
+    return MZmineModuleCategory.FEATURELISTFILTERING;
+  }
+
+  @Override
+  public @NotNull Class<? extends ParameterSet> getParameterSetClass() {
+    return GroupedMs2RefinementParameters.class;
+  }
+}

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_groupms2_refine/GroupedMs2RefinementParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_groupms2_refine/GroupedMs2RefinementParameters.java
@@ -41,7 +41,7 @@ public class GroupedMs2RefinementParameters extends SimpleParameterSet {
   public static final PercentParameter minimumRelativeFeatureHeight = new PercentParameter(
       "Minimum relative feature height",
       "If an MS2 was assigned to multiple features, only keep the feature assignments where feature height is at least X% of the highest feature.",
-      0.20, 0d, 1d);
+      0.25, 0d, 1d);
 
   public static final DoubleParameter minimumAbsoluteFeatureHeight = new DoubleParameter(
       "Minimum absolute feature height",

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_groupms2_refine/GroupedMs2RefinementParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_groupms2_refine/GroupedMs2RefinementParameters.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2004-2022 The MZmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.dataprocessing.filter_groupms2_refine;
+
+import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.parameters.Parameter;
+import io.github.mzmine.parameters.impl.IonMobilitySupport;
+import io.github.mzmine.parameters.impl.SimpleParameterSet;
+import io.github.mzmine.parameters.parametertypes.DoubleParameter;
+import io.github.mzmine.parameters.parametertypes.PercentParameter;
+import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
+import org.jetbrains.annotations.NotNull;
+
+public class GroupedMs2RefinementParameters extends SimpleParameterSet {
+
+  public static final FeatureListsParameter featureLists = new FeatureListsParameter();
+
+  public static final PercentParameter minimumRelativeFeatureHeight = new PercentParameter(
+      "Minimum relative feature height",
+      "If an MS2 was assigned to multiple features, only keep the feature assignments where feature height is at least X% of the highest feature.",
+      0.20, 0d, 1d);
+
+  public static final DoubleParameter minimumAbsoluteFeatureHeight = new DoubleParameter(
+      "Minimum absolute feature height",
+      "Only keep MS2-feature assignments if the feature height is at least this value. (comparable to the trigger intensity)",
+      MZmineCore.getConfiguration().getIntensityFormat(), 0d);
+
+
+  public GroupedMs2RefinementParameters() {
+    super(new Parameter[]{featureLists, minimumRelativeFeatureHeight, minimumAbsoluteFeatureHeight},
+        "https://mzmine.github.io/mzmine_documentation/module_docs/featdet_ms2_scan_pairing/ms2_scan_pairing.html");
+  }
+
+  @Override
+  public @NotNull IonMobilitySupport getIonMobilitySupport() {
+    return IonMobilitySupport.SUPPORTED;
+  }
+
+}

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_groupms2_refine/GroupedMs2RefinementTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_groupms2_refine/GroupedMs2RefinementTask.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2004-2022 The MZmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.dataprocessing.filter_groupms2_refine;
+
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.datamodel.features.FeatureList;
+import io.github.mzmine.datamodel.features.ModularFeature;
+import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
+import io.github.mzmine.main.MZmineConfiguration;
+import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.taskcontrol.AbstractTask;
+import io.github.mzmine.taskcontrol.TaskStatus;
+import io.github.mzmine.util.FeatureSorter;
+import io.github.mzmine.util.SortingDirection;
+import io.github.mzmine.util.SortingProperty;
+import it.unimi.dsi.fastutil.objects.Object2FloatOpenHashMap;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Filters out feature list rows.
+ */
+public class GroupedMs2RefinementTask extends AbstractTask {
+
+  private static final Logger logger = Logger.getLogger(GroupedMs2RefinementTask.class.getName());
+
+  private final FeatureList featureList;
+  private final ParameterSet parameters;
+  private final String description;
+  private final Double minAbsFeatureHeight;
+  private final Double minRelFeatureHeight;
+  private final AtomicLong totalFeatures = new AtomicLong(0);
+  private final AtomicLong processedFeatures = new AtomicLong(0);
+  private final AtomicLong removedScans = new AtomicLong(0);
+  private final AtomicLong totalScans = new AtomicLong(0);
+  private final AtomicLong totalUniqueScans = new AtomicLong(0);
+
+  /**
+   * @param featureList  feature list to process.
+   * @param parameterSet task parameters.
+   */
+  public GroupedMs2RefinementTask(final FeatureList featureList, final ParameterSet parameterSet,
+      @NotNull Instant moduleCallDate) {
+    super(null, moduleCallDate); // no new data stored -> null
+    this.featureList = featureList;
+    description = "Refine grouped fragmentation spectra for feature in %s".formatted(
+        featureList.getName());
+
+    parameters = parameterSet;
+    // RT has two options / tolerance is only provided for second option
+    minAbsFeatureHeight = parameters.getValue(
+        GroupedMs2RefinementParameters.minimumAbsoluteFeatureHeight);
+    minRelFeatureHeight = parameters.getValue(
+        GroupedMs2RefinementParameters.minimumRelativeFeatureHeight);
+  }
+
+  @Override
+  public void run() {
+    try {
+      setStatus(TaskStatus.PROCESSING);
+
+      processFeatureList();
+
+      featureList.getAppliedMethods().add(
+          new SimpleFeatureListAppliedMethod(GroupedMs2RefinementModule.class, parameters,
+              getModuleCallDate()));
+      setStatus(TaskStatus.FINISHED);
+      logger.info("Finished refining fragment scans for features in " + featureList.getName());
+
+    } catch (Exception t) {
+      setErrorMessage(t.getMessage());
+      setStatus(TaskStatus.ERROR);
+      logger.log(Level.SEVERE,
+          "Error while refining fragment scans for features in " + featureList.getName(), t);
+    }
+  }
+
+  /**
+   * Refine fragmentation scans of the selected feature list of this object. This is done for all
+   * {@link RawDataFile}.
+   */
+  public void processFeatureList() {
+    if (featureList.getRawDataFiles().size() == 1) {
+      processDataFile(featureList.getRawDataFiles().get(0));
+    } else {
+      featureList.getRawDataFiles().parallelStream().forEach(this::processDataFile);
+    }
+
+    // log statistics
+    MZmineConfiguration config = MZmineCore.getConfiguration();
+    logger.info("""
+        Refinement of fragmentation scan-feature assignment (total=%s; unique scans=%s) has removed %d scans (%s) from lower abundant feature with a relative intensity threshold of %s.
+        The absolute minimum intensity threshold of %s does not count to this value.""".formatted(
+        totalScans.get(), totalUniqueScans.get(), removedScans.get(),
+        config.getPercentFormat().format(removedScans.get() / (double) totalScans.get()),
+        config.getPercentFormat().format(minRelFeatureHeight),
+        config.getIntensityFormat().format(minAbsFeatureHeight)));
+  }
+
+  private void processDataFile(final RawDataFile raw) {
+    // create map
+    List<ModularFeature> features = featureList.getFeatures(raw);
+    totalFeatures.addAndGet(features.size());
+    features.sort(new FeatureSorter(SortingProperty.Height, SortingDirection.Descending));
+
+    // map scan to the highest feature height
+    Object2FloatOpenHashMap<Scan> scanToHeightMap = new Object2FloatOpenHashMap<>();
+
+    for (final ModularFeature feature : features) {
+      if (isCanceled()) {
+        return;
+      }
+      final float height = feature.getHeight();
+      if (height < minAbsFeatureHeight) {
+        // remove all scans
+        feature.setAllMS2FragmentScans(null);
+      } else {
+        // filter by relative height to max highest feature
+        var filteredScans = feature.getAllMS2FragmentScans().stream().filter(ms2 -> {
+          float maxHeight = scanToHeightMap.computeIfAbsent(ms2, key -> height);
+
+          boolean keep = height / maxHeight >= minRelFeatureHeight;
+          if (!keep) {
+            removedScans.incrementAndGet();
+          }
+          totalScans.incrementAndGet();
+          return keep;
+        }).toList();
+
+        feature.setAllMS2FragmentScans(filteredScans);
+      }
+      processedFeatures.incrementAndGet();
+    }
+    totalUniqueScans.addAndGet(scanToHeightMap.size());
+  }
+
+  @Override
+  public double getFinishedPercentage() {
+    return totalFeatures.get() == 0 ? 0.0 : processedFeatures.get() / (double) totalFeatures.get();
+  }
+
+  @Override
+  public String getTaskDescription() {
+    return description;
+  }
+}


### PR DESCRIPTION
This is the output that I get for some DOM data with mz 0.2 isolation width.
Total is the number of MS2 grouped with feature
Unique is only the unique ones.
and removed is the number of MS2 that were removed from a feature because said feature had <25% of the highest feature
```
INFO: Refinement of fragmentation scan-feature assignment (total=26847; unique scans=21616) has removed 2047 scans (7.6 %) from lower abundant feature with a relative intensity threshold of 25.0 %.
The absolute minimum intensity threshold of 0.0E0 does not count to this value. 
```