### PR TITLE
Options to hide shapes columns in large datasets in FeatureTableFX

### DIFF
--- a/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFX.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFX.java
@@ -38,6 +38,7 @@ import io.github.mzmine.datamodel.features.types.AreaShareType;
 import io.github.mzmine.datamodel.features.types.DataType;
 import io.github.mzmine.datamodel.features.types.DataTypes;
 import io.github.mzmine.datamodel.features.types.FeatureShapeIonMobilityRetentionTimeHeatMapType;
+import io.github.mzmine.datamodel.features.types.FeatureShapeMobilogramType;
 import io.github.mzmine.datamodel.features.types.FeatureShapeType;
 import io.github.mzmine.datamodel.features.types.FeaturesType;
 import io.github.mzmine.datamodel.features.types.ImageType;
@@ -168,8 +169,7 @@ public class FeatureTableFX extends TreeTableView<ModularFeatureListRow> impleme
     // create custom button context menu to select columns
     FeatureTableColumnMenuHelper contextMenuHelper = new FeatureTableColumnMenuHelper(this);
     // Adding additional menu options
-    addContextMenuItem(contextMenuHelper, "Compact LC/GC-MS",
-        e -> showCompactChromatographyColumns());
+    addContextMenuItem(contextMenuHelper, "Compact table", e -> showCompactChromatographyColumns());
     addContextMenuItem(contextMenuHelper, "Toggle Ion Identities", e -> toggleIonIdentities());
     addContextMenuItem(contextMenuHelper, "Toggle Library Matches", e -> toggleLibraryMatches());
 
@@ -767,13 +767,19 @@ public class FeatureTableFX extends TreeTableView<ModularFeatureListRow> impleme
   }
 
   private void showCompactChromatographyColumns() {
+    var flist = getFeatureList();
+    if (flist == null) {
+      return;
+    }
+
     // disable all feature types but height
     featureTypesParameter.setAll(false);
     setVisible(ColumnType.FEATURE_TYPE, HeightType.class, true);
 
     // keep states of all row types but check graphical columns
-    setVisible(ColumnType.ROW_TYPE, FeatureShapeType.class,
-        getFeatureList().getNumberOfRawDataFiles() <= 10);
+    boolean smallDataset = flist.getNumberOfRawDataFiles() <= 10;
+    setVisible(ColumnType.ROW_TYPE, FeatureShapeType.class, smallDataset);
+    setVisible(ColumnType.ROW_TYPE, FeatureShapeMobilogramType.class, smallDataset);
     setVisible(ColumnType.ROW_TYPE, FeaturesType.class, true);
 
     applyVisibilityParametersToAllColumns();
@@ -786,7 +792,7 @@ public class FeatureTableFX extends TreeTableView<ModularFeatureListRow> impleme
   private void setVisible(ColumnType columnType, String parentHeader, Class clazz,
       boolean visible) {
     final DataType type = DataTypes.get(clazz);
-    String key = (parentHeader != null && parentHeader.isBlank() ? parentHeader + ":" : "")
+    String key = (parentHeader == null || parentHeader.isBlank() ? "" : parentHeader + ":")
         + type.getHeaderString();
     if (columnType == ColumnType.ROW_TYPE) {
       rowTypesParameter.setDataTypeVisible(key, visible);

--- a/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFX.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFX.java
@@ -194,18 +194,37 @@ public class FeatureTableFX extends TreeTableView<ModularFeatureListRow> impleme
     };
   }
 
+  /**
+   * Applies when a new FeatureTableFX is created
+   *
+   * @return default visibility of shapes
+   */
+  public boolean getDefaultVisibilityOfShapes() {
+    return parameters.getValue(FeatureTableFXParameters.defaultVisibilityOfShapes);
+  }
+
+  /**
+   * @return the maximum samples before deactivating the shapes columns
+   */
+  public int getMaximumSamplesForVisibleShapes() {
+    return parameters.getValue(FeatureTableFXParameters.deactivateShapesGreaterNSamples);
+  }
+
+  private void setShapeColumnsVisible(boolean state) {
+    setVisible(ColumnType.ROW_TYPE, FeatureShapeType.class, state);
+    setVisible(ColumnType.ROW_TYPE, FeatureShapeMobilogramType.class, state);
+    applyVisibilityParametersToAllColumns();
+  }
+
   private void toggleShapeColumns() {
     final var columnEntry = getColumnEntry(FeatureShapeType.class);
     if (columnEntry == null) {
       return;
     }
 
-    final ColumnID mainColumn = columnEntry.getValue();
-    final boolean toggledState = !rowTypesParameter.isDataTypeVisible(mainColumn);
+    final boolean toggledState = !rowTypesParameter.isDataTypeVisible(columnEntry.getValue());
     // set visibility of all types to the same
-    rowTypesParameter.setDataTypeVisible(mainColumn, toggledState);
-    setVisible(ColumnType.ROW_TYPE, FeatureShapeMobilogramType.class, toggledState);
-    applyVisibilityParametersToAllColumns();
+    setShapeColumnsVisible(toggledState);
   }
 
   private void toggleIonIdentities() {
@@ -773,7 +792,8 @@ public class FeatureTableFX extends TreeTableView<ModularFeatureListRow> impleme
         }
         addColumns(newValue);
         // first check if feature list is too large
-        if (newValue.getNumberOfRawDataFiles() > 10) {
+        setShapeColumnsVisible(getDefaultVisibilityOfShapes());
+        if (newValue.getNumberOfRawDataFiles() > getMaximumSamplesForVisibleShapes()) {
           showCompactChromatographyColumns();
         }
 
@@ -803,7 +823,7 @@ public class FeatureTableFX extends TreeTableView<ModularFeatureListRow> impleme
     setVisible(ColumnType.FEATURE_TYPE, getDefaultAbundanceMeasureType(), true);
 
     // keep states of all row types but check graphical columns
-    boolean smallDataset = flist.getNumberOfRawDataFiles() <= 10;
+    boolean smallDataset = flist.getNumberOfRawDataFiles() <= getMaximumSamplesForVisibleShapes();
     setVisible(ColumnType.ROW_TYPE, FeatureShapeType.class, smallDataset);
     setVisible(ColumnType.ROW_TYPE, FeatureShapeMobilogramType.class, smallDataset);
     setVisible(ColumnType.ROW_TYPE, FeaturesType.class, true);

--- a/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFXParameters.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFXParameters.java
@@ -30,6 +30,7 @@ import io.github.mzmine.datamodel.features.types.modifiers.GraphicalColumType;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
 import io.github.mzmine.parameters.parametertypes.BooleanParameter;
 import io.github.mzmine.parameters.parametertypes.ComboParameter;
+import io.github.mzmine.parameters.parametertypes.IntegerParameter;
 import io.github.mzmine.parameters.parametertypes.datatype.DataTypeCheckListParameter;
 
 public class FeatureTableFXParameters extends SimpleParameterSet {
@@ -46,6 +47,14 @@ public class FeatureTableFXParameters extends SimpleParameterSet {
       "Default feature intensity", "Used in the compact table", AbundanceMeasure.values(),
       AbundanceMeasure.Height);
 
+  public static final BooleanParameter defaultVisibilityOfShapes = new BooleanParameter(
+      "Default visibility of shapes", "This parameter is applied when opening a new feature table",
+      true);
+
+  public static final IntegerParameter deactivateShapesGreaterNSamples = new IntegerParameter(
+      "Deactivate shapes >N samples", "Deactivate shapes for better performance above N samples.",
+      12);
+
   public static final BooleanParameter lockImagesToAspectRatio = new BooleanParameter(
       "Lock images to aspect ratio",
       "If enabled, the width of the column will be determined by the lateral width of "
@@ -57,7 +66,8 @@ public class FeatureTableFXParameters extends SimpleParameterSet {
 
   public FeatureTableFXParameters() {
     super(showRowTypeColumns, showFeatureTypeColumns, defaultAbundanceMeasure,
-        lockImagesToAspectRatio, hideImageAxes);
+        defaultVisibilityOfShapes, deactivateShapesGreaterNSamples, lockImagesToAspectRatio,
+        hideImageAxes);
   }
 
 }

--- a/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFXParameters.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFXParameters.java
@@ -47,8 +47,18 @@ public class FeatureTableFXParameters extends SimpleParameterSet {
       "Default feature intensity", "Used in the compact table", AbundanceMeasure.values(),
       AbundanceMeasure.Height);
 
+  public static final BooleanParameter defaultVisibilityOfImsFeature = new BooleanParameter(
+      "Default visibility (IMS feature charts)",
+      "This parameter is applied when opening a new feature table. Only used for single sample feature lists.",
+      true);
+
+  public static final BooleanParameter defaultVisibilityOfImages = new BooleanParameter(
+      "Default visibility (images)",
+      "This parameter is applied when opening a new feature table.  Only used for single sample feature lists.",
+      true);
+
   public static final BooleanParameter defaultVisibilityOfShapes = new BooleanParameter(
-      "Default visibility of shapes", "This parameter is applied when opening a new feature table",
+      "Default visibility (shapes)", "This parameter is applied when opening a new feature table",
       true);
 
   public static final IntegerParameter deactivateShapesGreaterNSamples = new IntegerParameter(
@@ -66,8 +76,8 @@ public class FeatureTableFXParameters extends SimpleParameterSet {
 
   public FeatureTableFXParameters() {
     super(showRowTypeColumns, showFeatureTypeColumns, defaultAbundanceMeasure,
-        defaultVisibilityOfShapes, deactivateShapesGreaterNSamples, lockImagesToAspectRatio,
-        hideImageAxes);
+        defaultVisibilityOfImsFeature, defaultVisibilityOfImages, defaultVisibilityOfShapes,
+        deactivateShapesGreaterNSamples, lockImagesToAspectRatio, hideImageAxes);
   }
 
 }

--- a/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFXParameters.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFXParameters.java
@@ -25,10 +25,11 @@
 
 package io.github.mzmine.modules.visualization.featurelisttable_modular;
 
+import io.github.mzmine.datamodel.AbundanceMeasure;
 import io.github.mzmine.datamodel.features.types.modifiers.GraphicalColumType;
-import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
 import io.github.mzmine.parameters.parametertypes.BooleanParameter;
+import io.github.mzmine.parameters.parametertypes.ComboParameter;
 import io.github.mzmine.parameters.parametertypes.datatype.DataTypeCheckListParameter;
 
 public class FeatureTableFXParameters extends SimpleParameterSet {
@@ -41,6 +42,10 @@ public class FeatureTableFXParameters extends SimpleParameterSet {
       "Feature type columns",
       "Specify which data type columns shall be displayed in the feature list table");
 
+  public static final ComboParameter<AbundanceMeasure> defaultAbundanceMeasure = new ComboParameter<>(
+      "Default feature intensity", "Used in the compact table", AbundanceMeasure.values(),
+      AbundanceMeasure.Height);
+
   public static final BooleanParameter lockImagesToAspectRatio = new BooleanParameter(
       "Lock images to aspect ratio",
       "If enabled, the width of the column will be determined by the lateral width of "
@@ -51,8 +56,8 @@ public class FeatureTableFXParameters extends SimpleParameterSet {
       "If ticked, the axes of image plots will be hidden.", false);
 
   public FeatureTableFXParameters() {
-    super(new Parameter[]{showRowTypeColumns, showFeatureTypeColumns, lockImagesToAspectRatio,
-        hideImageAxes});
+    super(showRowTypeColumns, showFeatureTypeColumns, defaultAbundanceMeasure,
+        lockImagesToAspectRatio, hideImageAxes);
   }
 
 }


### PR DESCRIPTION
Automatically applies when a new feautre list is loaded.
![image](https://user-images.githubusercontent.com/10366914/220083284-50c79f54-1ad4-4f88-b3c5-261455534fcd.png)
