### PR TITLE
refactor pasef ms2 merging

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/MergedMassSpectrum.java
+++ b/src/main/java/io/github/mzmine/datamodel/MergedMassSpectrum.java
@@ -34,7 +34,8 @@ public interface MergedMassSpectrum extends Scan {
   MergingType getMergingType();
 
   /**
-   * @return A list of spectra used to create this merged spectrum
+   * @return A list of spectra used to create this merged spectrum. Never a merged spectra, which
+   * are unpacked to their source spectra in case merged spectra are merged.
    */
   List<MassSpectrum> getSourceSpectra();
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_duplicatefilter/DuplicateFilterParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_duplicatefilter/DuplicateFilterParameters.java
@@ -26,6 +26,7 @@
 package io.github.mzmine.modules.dataprocessing.filter_duplicatefilter;
 
 import io.github.mzmine.parameters.Parameter;
+import io.github.mzmine.parameters.impl.IonMobilitySupport;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
 import io.github.mzmine.parameters.parametertypes.BooleanParameter;
 import io.github.mzmine.parameters.parametertypes.ComboParameter;
@@ -37,6 +38,7 @@ import io.github.mzmine.parameters.parametertypes.tolerances.MZToleranceParamete
 import io.github.mzmine.parameters.parametertypes.tolerances.RTToleranceParameter;
 import io.github.mzmine.parameters.parametertypes.tolerances.mobilitytolerance.MobilityTolerance;
 import io.github.mzmine.parameters.parametertypes.tolerances.mobilitytolerance.MobilityToleranceParameter;
+import org.jetbrains.annotations.NotNull;
 
 public class DuplicateFilterParameters extends SimpleParameterSet {
 
@@ -67,6 +69,11 @@ public class DuplicateFilterParameters extends SimpleParameterSet {
         "https://mzmine.github.io/mzmine_documentation/module_docs/filter_duplicate_features/duplicate_feature_filter.html");
   }
 
+  @Override
+  public @NotNull IonMobilitySupport getIonMobilitySupport() {
+    return IonMobilitySupport.SUPPORTED;
+  }
+
   public enum FilterMode {
     OLD_AVERAGE, NEW_AVERAGE, SINGLE_FEATURE;
 
@@ -75,5 +82,4 @@ public class DuplicateFilterParameters extends SimpleParameterSet {
       return super.toString().replaceAll("_", " ");
     }
   }
-
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_groupms2/GroupMS2Parameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_groupms2/GroupMS2Parameters.java
@@ -79,9 +79,10 @@ public class GroupMS2Parameters extends SimpleParameterSet {
       false);
 
   public static final BooleanParameter combineTimsMsMs = new BooleanParameter(
-      "Merge MS/MS spectra (TIMS)",
-      "If checked, all assigned MS/MS spectra with the same collision energy will be merged into a single MS/MS spectrum.",
-      false);
+      "Merge MS/MS spectra (TIMS)", """
+      If checked, all assigned MS/MS spectra with the same collision energy will be merged into a single MS/MS spectrum.
+       These merged spectra will also be merged to a consensus spectrum across all collision energies.
+      """, false);
 
   public static final OptionalParameter<DoubleParameter> outputNoiseLevel = new OptionalParameter<>(
       new DoubleParameter("Minimum signal intensity (absolute, TIMS)",

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_groupms2/GroupMS2Task.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_groupms2/GroupMS2Task.java
@@ -50,6 +50,8 @@ import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.exceptions.MissingMassListException;
+import io.github.mzmine.util.scans.FragmentScanSelection;
+import io.github.mzmine.util.scans.FragmentScanSelection.IncludeInputSpectra;
 import io.github.mzmine.util.scans.FragmentScanSorter;
 import io.github.mzmine.util.scans.SpectraMerging;
 import io.github.mzmine.util.scans.SpectraMerging.IntensityMergingType;
@@ -326,8 +328,10 @@ public class GroupMS2Task extends AbstractTask {
     }
 
     if (!msmsSpectra.isEmpty() && combineTimsMS2) {
-      return SpectraMerging.mergeMsMsSpectra(msmsSpectra, SpectraMerging.pasefMS2MergeTol,
-          IntensityMergingType.SUMMED, ((ModularFeatureList) list).getMemoryMapStorage());
+      final FragmentScanSelection fragmentScanSelection = new FragmentScanSelection(
+          SpectraMerging.pasefMS2MergeTol, combineTimsMS2, IncludeInputSpectra.NONE,
+          IntensityMergingType.SUMMED);
+      return fragmentScanSelection.getAllFragmentSpectra(msmsSpectra);
     }
     return msmsSpectra;
   }

--- a/src/main/java/io/github/mzmine/util/scans/SpectraMerging.java
+++ b/src/main/java/io/github/mzmine/util/scans/SpectraMerging.java
@@ -72,7 +72,6 @@ import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -356,53 +355,6 @@ public class SpectraMerging {
   }
 
   /**
-   * Merges Multiple MS/MS spectra with the same collision energy into a single MS/MS spectrum.
-   *
-   * @param spectra              The source spectra, may be of multiple collision energies.
-   * @param tolerance            The mz tolerance to merch peaks in a spectrum
-   * @param intensityMergingType Specifies the way to treat intensities (sum, avg, max)
-   * @param storage              The storage to use.
-   * @return A list of all merged spectra (Spectra with the same collision energy have been merged).
-   */
-  public static List<Scan> mergeMsMsSpectra(@NotNull final Collection<Scan> spectra,
-      @NotNull final MZTolerance tolerance,
-      @NotNull final SpectraMerging.IntensityMergingType intensityMergingType,
-      @Nullable final MemoryMapStorage storage) {
-
-    final CenterFunction cf = new CenterFunction(CenterMeasure.AVG, Weighting.LINEAR);
-
-    final List<Scan> mergedSpectra = new ArrayList<>();
-    // group spectra with the same CE into the same list
-    final Map<Float, List<Scan>> grouped = spectra.stream()
-        .collect(Collectors.groupingBy(SpectraMerging::getCollisionEnergy));
-
-    for (final Entry<Float, List<Scan>> entry : grouped.entrySet()) {
-      final Scan spectrum = entry.getValue().get(0);
-      final double[][] mzIntensities = calculatedMergedMzsAndIntensities(entry.getValue(),
-          tolerance, intensityMergingType, cf, null, null, null);
-
-      if (mzIntensities[0].length == 0) {
-        continue;
-      }
-
-      final List<MassSpectrum> sourceSpectra = entry.getValue().stream().flatMap(s -> {
-        if (s instanceof MergedMassSpectrum spec) {
-          return spec.getSourceSpectra().stream();
-        } else {
-          return Stream.of(s);
-        }
-      }).collect(Collectors.toList());
-
-      final MergedMsMsSpectrum mergedMsMsSpectrum = new SimpleMergedMsMsSpectrum(storage,
-          mzIntensities[0], mzIntensities[1], spectrum.getMsMsInfo(), spectrum.getMSLevel(),
-          sourceSpectra, intensityMergingType, cf, MergingType.ALL);
-      mergedSpectra.add(mergedMsMsSpectrum);
-    }
-
-    return mergedSpectra;
-  }
-
-  /**
    * Cannot return null as it's used for grouping
    *
    * @return the collision energy or -1 if null
@@ -618,13 +570,13 @@ public class SpectraMerging {
 
     private final String label;
 
+    IntensityMergingType(String label) {
+      this.label = label;
+    }
+
     @Override
     public String toString() {
       return this.label;
-    }
-
-    IntensityMergingType(String label) {
-      this.label = label;
     }
   }
 }


### PR DESCRIPTION
- delete spectramerging.mergemsmsspectra to use the mergespectra method for mergin pasef ms2 scans
- use fragment scan selection