### PR TITLE
Compound DB sort by score, batch lib export: best ion for each compound

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/features/compoundannotations/CompoundDBAnnotation.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/compoundannotations/CompoundDBAnnotation.java
@@ -98,7 +98,8 @@ public interface CompoundDBAnnotation extends Cloneable, FeatureAnnotation,
       try {
         annotations.add(neutralAnnotation.ionize(adduct));
       } catch (IllegalStateException e) {
-        logger.log(Level.WARNING, e.getMessage(), e);
+        // do not log the full stack trace as this is expected in many cases
+        logger.log(Level.WARNING, e.getMessage());
       }
     }
 

--- a/src/main/java/io/github/mzmine/datamodel/identities/iontype/IonType.java
+++ b/src/main/java/io/github/mzmine/datamodel/identities/iontype/IonType.java
@@ -422,8 +422,8 @@ public class IonType extends NeutralMolecule implements Comparable<IonType> {
    */
   public boolean isModificationOf(IonType parent) {
     if (!hasMods() || !(parent.getModCount() < getModCount() && mass != parent.mass
-        && adduct.equals(parent.adduct) && molecules == parent.molecules
-        && charge == parent.charge)) {
+                        && adduct.equals(parent.adduct) && molecules == parent.molecules
+                        && charge == parent.charge)) {
       return false;
     } else if (!parent.hasMods()) {
       return true;
@@ -458,12 +458,28 @@ public class IonType extends NeutralMolecule implements Comparable<IonType> {
     return new IonType(1, IonModification.getUndefinedforCharge(this.charge), mod);
   }
 
+
   /**
    * @return count of modification
    */
   public int getModCount() {
     return mod == null ? 0 : mod.getModCount();
   }
+
+  /**
+   * @return count of adducts
+   */
+  public int getAdductCount() {
+    return adduct == null ? 0 : adduct.getModCount();
+  }
+
+  /**
+   * @return sum of modification and adducts, molecules, charge
+   */
+  public int getTotalPartsCount() {
+    return molecules + charge + getModCount() + getAdductCount();
+  }
+
 
   /**
    * ((mz * charge) - deltaMass) / numberOfMolecules

--- a/src/main/java/io/github/mzmine/util/FormulaUtils.java
+++ b/src/main/java/io/github/mzmine/util/FormulaUtils.java
@@ -362,6 +362,9 @@ public class FormulaUtils {
    */
   public static IMolecularFormula replaceAllIsotopesWithoutExactMass(IMolecularFormula f)
       throws IOException {
+    if (f == null) {
+      return null;
+    }
     for (IIsotope iso : f.isotopes()) {
       // find isotope without exact mass
       if (iso.getExactMass() == null || iso.getExactMass() == 0) {
@@ -430,8 +433,13 @@ public class FormulaUtils {
    * @param minMzValue     the minimum mz value to consider
    * @return list of original formula followed by sub formulas, sorted by ascending mz
    */
+  @Nullable
   public static FormulaWithExactMz[] getAllFormulas(IMolecularFormula inputFormula,
       @Nullable Integer resetAbsCharge, double minMzValue) {
+    if (inputFormula == null) {
+      return null;
+    }
+
     if (resetAbsCharge != null) {
       inputFormula = resetAbsCharge(inputFormula, resetAbsCharge);
     }
@@ -702,7 +710,7 @@ public class FormulaUtils {
 
         logger.finest(
             () -> "Compound " + string + " is not neutral as determined by molFormula. charge = "
-                + charge + ". Adjusting protonation.");
+                  + charge + ". Adjusting protonation.");
 
         final boolean adjusted = MolecularFormulaManipulator.adjustProtonation(molecularFormula,
             -charge);
@@ -734,7 +742,7 @@ public class FormulaUtils {
    * Creates the ionized formula combining the adduct from the feature annotation
    */
   public static @Nullable IMolecularFormula getIonizedFormula(final FeatureAnnotation annotation) {
-    if (annotation.getFormula() == null) {
+    if (annotation.getFormula() == null || annotation.getFormula().isBlank()) {
       return null;
     }
 

--- a/src/main/java/io/github/mzmine/util/annotations/CompoundAnnotationUtils.java
+++ b/src/main/java/io/github/mzmine/util/annotations/CompoundAnnotationUtils.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2004-2022 The MZmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.util.annotations;
+
+import io.github.mzmine.datamodel.features.compoundannotations.CompoundDBAnnotation;
+import io.github.mzmine.datamodel.identities.iontype.IonType;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class CompoundAnnotationUtils {
+
+
+  /**
+   * A list of matches where each entry has a different compound name.
+   *
+   * @param matches can contain duplicate compound names - the method will find the best annotation
+   *                for each compound name by sorting by least modified adduct and highest score
+   * @return list of unique compound names
+   */
+  public static List<CompoundDBAnnotation> getBestMatchesPerCompoundName(
+      final List<CompoundDBAnnotation> matches) {
+    Map<String, List<CompoundDBAnnotation>> compoundsMap = new HashMap<>();
+
+    // might have different adducts for the same compound - list them by compound name
+    for (final CompoundDBAnnotation match : matches) {
+      var list = compoundsMap.computeIfAbsent(match.getCompoundName(), s -> new ArrayList<>());
+      list.add(match);
+    }
+    // sort by number of adducts + modifications
+    var oneMatchPerCompound = compoundsMap.values().stream()
+        .map(compound -> compound.stream().min(getSorterLeastModifiedCompoundFirst()).orElse(null))
+        .filter(Objects::nonNull).toList();
+
+    return oneMatchPerCompound;
+  }
+
+  /**
+   * First sort by adduct type: simple IonType first, which means M+H better than 2M+H2+2 and
+   * 2M-H2O+H+.
+   *
+   * @return sorter
+   */
+  public static Comparator<CompoundDBAnnotation> getSorterLeastModifiedCompoundFirst() {
+    return Comparator.comparing(CompoundDBAnnotation::getAdductType,
+            Comparator.nullsLast(Comparator.comparingInt(IonType::getTotalPartsCount)))
+        .thenComparing(getSorterMaxScoreFirst());
+  }
+
+  /**
+   * max score first, score descending
+   *
+   * @return sorter
+   */
+  public static Comparator<CompoundDBAnnotation> getSorterMaxScoreFirst() {
+    return Comparator.comparing(CompoundDBAnnotation::getScore,
+        Comparator.nullsLast(Comparator.reverseOrder()));
+  }
+}

--- a/src/main/java/io/github/mzmine/util/spectraldb/entry/DBEntryField.java
+++ b/src/main/java/io/github/mzmine/util/spectraldb/entry/DBEntryField.java
@@ -83,6 +83,9 @@ public enum DBEntryField {
   QUALITY_CHIMERIC, QUALITY_EXPLAINED_INTENSITY(Float.class), QUALITY_EXPLAINED_SIGNALS(
       Float.class),
 
+  // compound annotation might match to multiple different compounds
+  OTHER_MATCHED_COMPOUNDS_N, OTHER_MATCHED_COMPOUNDS_NAMES,
+
   // number of signals
   NUM_PEAKS(Integer.class), // only used for everything that cannot easily be mapped
   UNSPECIFIED;
@@ -216,7 +219,8 @@ public enum DBEntryField {
           INSTRUMENT_TYPE, POLARITY, ION_SOURCE, PRINCIPAL_INVESTIGATOR, PUBMED, PUBCHEM,  //
           CHEMSPIDER, MONA_ID, GNPS_ID, ENTRY_ID, SYNONYMS, RESOLUTION, FRAGMENTATION_METHOD, //
           QUALITY, QUALITY_CHIMERIC, FILENAME, //
-          SIRIUS_MERGED_SCANS, SIRIUS_MERGED_STATS -> StringType.class;
+          SIRIUS_MERGED_SCANS, SIRIUS_MERGED_STATS, OTHER_MATCHED_COMPOUNDS_N, OTHER_MATCHED_COMPOUNDS_NAMES ->
+          StringType.class;
       case SCAN_NUMBER -> BestScanNumberType.class;
       case MS_LEVEL, NUM_PEAKS, FEATURE_ID -> IntegerType.class;
       case EXACT_MASS, PRECURSOR_MZ, MOLWEIGHT -> MZType.class;
@@ -295,6 +299,8 @@ public enum DBEntryField {
       case QUALITY_CHIMERIC -> "quality_chimeric";
       case QUALITY_EXPLAINED_INTENSITY -> "quality_explained_intensity";
       case QUALITY_EXPLAINED_SIGNALS -> "quality_explained_signals";
+      case OTHER_MATCHED_COMPOUNDS_N -> "other_matched_compounds";
+      case OTHER_MATCHED_COMPOUNDS_NAMES -> "other_matched_compounds_names";
       case FEATURE_ID -> "feature_id";
       case FILENAME -> "raw_file_name";
       case SIRIUS_MERGED_SCANS -> "merged_scans";
@@ -345,6 +351,8 @@ public enum DBEntryField {
       case QUALITY_CHIMERIC -> "quality_chimeric";
       case QUALITY_EXPLAINED_INTENSITY -> "quality_explained_intensity";
       case QUALITY_EXPLAINED_SIGNALS -> "quality_explained_signals";
+      case OTHER_MATCHED_COMPOUNDS_N -> "other_matched_compounds";
+      case OTHER_MATCHED_COMPOUNDS_NAMES -> "other_matched_compounds_names";
       case FEATURE_ID -> "feature_id";
       case FILENAME -> "file_name";
       case SIRIUS_MERGED_SCANS -> "";
@@ -397,6 +405,8 @@ public enum DBEntryField {
       case QUALITY -> "QUALITY";
       case QUALITY_EXPLAINED_INTENSITY -> "QUALITY_EXPLAINED_INTENSITY";
       case QUALITY_EXPLAINED_SIGNALS -> "QUALITY_EXPLAINED_SIGNALS";
+      case OTHER_MATCHED_COMPOUNDS_N -> "OTHER_MATCHED_COMPOUNDS";
+      case OTHER_MATCHED_COMPOUNDS_NAMES -> "OTHER_MATCHED_COMPOUNDS_NAMES";
       case FEATURE_ID -> "FEATURE_ID";
       case FILENAME -> "FILENAME";
       case SIRIUS_MERGED_SCANS -> "MERGED_SCANS";
@@ -440,6 +450,8 @@ public enum DBEntryField {
       case PUBCHEM -> "";
       case CHEMSPIDER -> "";
       case MONA_ID, GNPS_ID -> "";
+      case OTHER_MATCHED_COMPOUNDS_N -> "";
+      case OTHER_MATCHED_COMPOUNDS_NAMES -> "";
       case NUM_PEAKS -> "##NPOINTS";
       case RESOLUTION, SYNONYMS, MOLWEIGHT -> "";
       case CCS -> "";
@@ -492,7 +504,8 @@ public enum DBEntryField {
           ION_TYPE, CHARGE, MERGED_SPEC_TYPE, SIRIUS_MERGED_SCANS, SIRIUS_MERGED_STATS, COLLISION_ENERGY, //
           FRAGMENTATION_METHOD, ISOLATION_WINDOW, ACQUISITION, MSN_COLLISION_ENERGIES, MSN_PRECURSOR_MZS, //
           MSN_FRAGMENTATION_METHODS, MSN_ISOLATION_WINDOWS, INSTRUMENT_TYPE, SOFTWARE, FILENAME, //
-          DATASET_ID, USI, SCAN_NUMBER, SPLASH, QUALITY_CHIMERIC -> value.toString();
+          DATASET_ID, USI, SCAN_NUMBER, SPLASH, QUALITY_CHIMERIC, //
+          OTHER_MATCHED_COMPOUNDS_N, OTHER_MATCHED_COMPOUNDS_NAMES -> value.toString();
       case RT -> switch (value) {
         // float is default for RT but handle Double in case wrong value was present
         case Float f -> "%.2f".formatted(f * 60.f);

--- a/src/main/java/io/github/mzmine/util/spectraldb/parser/mzmine/MZmineJsonLibraryEntry.java
+++ b/src/main/java/io/github/mzmine/util/spectraldb/parser/mzmine/MZmineJsonLibraryEntry.java
@@ -186,6 +186,8 @@ public class MZmineJsonLibraryEntry {
       case CHEMSPIDER -> null;
       case SIRIUS_MERGED_SCANS -> null;
       case SIRIUS_MERGED_STATS -> null;
+      case OTHER_MATCHED_COMPOUNDS_N -> null;
+      case OTHER_MATCHED_COMPOUNDS_NAMES -> null;
       case FEATURE_ID -> null;
       case SCAN_NUMBER -> scanNumber;
       case UNSPECIFIED -> null;

--- a/src/test/java/io/github/mzmine/util/annotations/CompoundAnnotationUtilsTest.java
+++ b/src/test/java/io/github/mzmine/util/annotations/CompoundAnnotationUtilsTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2004-2022 The MZmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.util.annotations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.mzmine.datamodel.features.compoundannotations.CompoundDBAnnotation;
+import io.github.mzmine.datamodel.features.compoundannotations.SimpleCompoundDBAnnotation;
+import io.github.mzmine.datamodel.features.types.annotations.CompoundNameType;
+import io.github.mzmine.datamodel.features.types.annotations.iin.IonTypeType;
+import io.github.mzmine.datamodel.identities.iontype.IonModification;
+import io.github.mzmine.datamodel.identities.iontype.IonType;
+import java.util.List;
+import java.util.Random;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CompoundAnnotationUtilsTest {
+
+  private final Random rand = new Random(42);
+  private List<CompoundDBAnnotation> list;
+
+  @BeforeEach
+  void setUp() {
+    String n1 = "Steffen";
+    String n2 = "Robin";
+    list = List.of(createCompound(n1), createCompound(n1), createCompound(n1), createCompound(n2),
+        createCompound(n2), createCompound(n1), createCompound(n2), createCompound(n1));
+  }
+
+  public SimpleCompoundDBAnnotation createCompound(String name) {
+    var db = new SimpleCompoundDBAnnotation();
+    db.put(CompoundNameType.class, name);
+    db.setScore(rand.nextFloat());
+
+    IonType ion = switch (rand.nextInt(4)) {
+      case 0 -> new IonType(2, IonModification.H);
+      case 1 -> new IonType(1, IonModification.H);
+      case 2 -> new IonType(1, IonModification.H, IonModification.H2O);
+      default -> null;
+    };
+    db.put(IonTypeType.class, ion);
+    return db;
+  }
+
+  @Test
+  void testSorterLeastModifiedCompoundFirst() {
+    var list = this.list.stream()
+        .sorted(CompoundAnnotationUtils.getSorterLeastModifiedCompoundFirst()).toList();
+
+    for (int i = 0; i < list.size() - 1; i++) {
+      var a = list.get(i).getAdductType();
+      var b = list.get(i + 1).getAdductType();
+      if (a == null || b == null) {
+        continue;
+      }
+
+      assertTrue(a.getTotalPartsCount() <= b.getTotalPartsCount(),
+          "Sorting for minimum modified ions is wrong");
+    }
+  }
+
+  @Test
+  void testBestMatchesPerCompoundName() {
+    var matchesPerCompoundName = CompoundAnnotationUtils.getBestMatchesPerCompoundName(list);
+    assertEquals(2, matchesPerCompoundName.size());
+
+    var compoundA = matchesPerCompoundName.get(0);
+    var compoundB = matchesPerCompoundName.get(1);
+
+    assertTrue(compoundB.getScore() <= compoundA.getScore(),
+        "Score sorting descending did not work");
+  }
+}


### PR DESCRIPTION
Added two functions to sort and select CompoundDBAnnotations

### sort by the simplicity of the adducts and then by score
![image](https://user-images.githubusercontent.com/10366914/224493248-487baf1e-2d66-4316-bc88-8b9e984a8c3c.png)

### select the top compounds per compound name
![image](https://user-images.githubusercontent.com/10366914/224493365-96ddde19-df38-4174-a7e7-ed63dffe9db4.png)

Simple adduct + best score. 

## Changes to batch spectral lib export
- use method to get best adduct+score for each compound name and export all
- flag rows (spectral entries) that had multiple compounds matched, e.g., when there ere many compounds in the same sample with overlapping mz/ions
**json looks like this for a row that had an overlap with another compound named SN 2:** "other_matched_compounds":1, "other_matched_compounds_names":"SN 2: [M+H]+: 0.929"