### PR TITLE
Improve ion parsing from String

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/identities/iontype/CombinedIonModification.java
+++ b/src/main/java/io/github/mzmine/datamodel/identities/iontype/CombinedIonModification.java
@@ -208,4 +208,9 @@ public class CombinedIonModification extends IonModification {
         streamModifications().map(IonModification::getMolFormula).collect(Collectors.joining(";")));
     return map;
   }
+
+  @Override
+  public IonModification withCharge(final int newCharge) {
+    return new CombinedIonModification(mods, type, mass, newCharge);
+  }
 }

--- a/src/main/java/io/github/mzmine/datamodel/identities/iontype/IonModification.java
+++ b/src/main/java/io/github/mzmine/datamodel/identities/iontype/IonModification.java
@@ -25,9 +25,13 @@
 
 package io.github.mzmine.datamodel.identities.iontype;
 
+import static java.util.Objects.requireNonNullElse;
+
+import io.github.mzmine.datamodel.PolarityType;
 import io.github.mzmine.datamodel.identities.NeutralMolecule;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.io.projectload.version_3_0.CONST;
+import io.github.mzmine.util.FormulaUtils;
 import io.github.mzmine.util.StringMapParser;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -47,112 +51,100 @@ public class IonModification extends NeutralMolecule implements Comparable<IonMo
     StringMapParser<IonModification> {
 
   // use combinations of X adducts (2H++; -H+Na2+) and modifications
-  public static final IonModification M_MINUS =
-      new IonModification(IonModificationType.ADDUCT, "e", +0.00054858, -1);
+  public static final IonModification M_MINUS = new IonModification(IonModificationType.ADDUCT, "e",
+      +0.00054858, -1);
   // NR4+ is already charged, mass might also be charged already
-  public static final IonModification M_MINUS_ALREADY_CHARGED =
-      new IonModification(IonModificationType.ADDUCT, "e", 0, -1);
-  public static final IonModification H_NEG =
-      new IonModification(IonModificationType.ADDUCT, "H", "H", -1.007276, -1);
-  public static final IonModification M_PLUS =
-      new IonModification(IonModificationType.ADDUCT, "e", -0.00054858, 1);
+  public static final IonModification M_MINUS_ALREADY_CHARGED = new IonModification(
+      IonModificationType.ADDUCT, "e", 0, -1);
+  public static final IonModification H_NEG = new IonModification(IonModificationType.ADDUCT, "H",
+      "H", -1.007276, -1);
+  public static final IonModification M_PLUS = new IonModification(IonModificationType.ADDUCT, "e",
+      -0.00054858, 1);
   // NR4+ is already charged, mass might also be charged already
-  public static final IonModification M_PLUS_ALREADY_CHARGED =
-      new IonModification(IonModificationType.ADDUCT, "e", 0, 1);
-  public static final IonModification H =
-      new IonModification(IonModificationType.ADDUCT, "H", "H", 1.007276, 1);
+  public static final IonModification M_PLUS_ALREADY_CHARGED = new IonModification(
+      IonModificationType.ADDUCT, "e", 0, 1);
+  public static final IonModification H = new IonModification(IonModificationType.ADDUCT, "H", "H",
+      1.007276, 1);
   //
-  public static final IonModification NA =
-      new IonModification(IonModificationType.ADDUCT, "Na", "Na", 22.989218, 1);
-  public static final IonModification NH4 =
-      new IonModification(IonModificationType.ADDUCT, "NH4", "NH4", 18.033823, 1);
-  public static final IonModification K =
-      new IonModification(IonModificationType.ADDUCT, "K", "K", 38.963158, 1);
-  public static final IonModification FE =
-      new IonModification(IonModificationType.ADDUCT, "Fe", "Fe", 55.933840, 2);
-  public static final IonModification CA =
-      new IonModification(IonModificationType.ADDUCT, "Ca", "Ca", 39.961493820, 2);
-  public static final IonModification MG =
-      new IonModification(IonModificationType.ADDUCT, "Mg", "Mg", 47.96953482, 2);
+  public static final IonModification NA = new IonModification(IonModificationType.ADDUCT, "Na",
+      "Na", 22.989218, 1);
+  public static final IonModification NH4 = new IonModification(IonModificationType.ADDUCT, "NH4",
+      "NH4", 18.033823, 1);
+  public static final IonModification K = new IonModification(IonModificationType.ADDUCT, "K", "K",
+      38.963158, 1);
+  public static final IonModification FE = new IonModification(IonModificationType.ADDUCT, "Fe",
+      "Fe", 55.933840, 2);
+  public static final IonModification CA = new IonModification(IonModificationType.ADDUCT, "Ca",
+      "Ca", 39.961493820, 2);
+  public static final IonModification MG = new IonModification(IonModificationType.ADDUCT, "Mg",
+      "Mg", 47.96953482, 2);
   // combined
-  public static final IonModification H2plus =
-      CombinedIonModification.create(H, H);
-  public static final IonModification M2plus =
-      CombinedIonModification.create(M_PLUS, M_PLUS);
-  public static final IonModification NA_H =
-      CombinedIonModification.create(NA, H);
-  public static final IonModification K_H =
-      CombinedIonModification.create(K, H);
-  public static final IonModification NH4_H =
-      CombinedIonModification.create(NH4, H);
-  public static final IonModification Hneg_NA2 =
-      CombinedIonModification.create(NA, NA, H_NEG);
-  public static final IonModification Hneg_CA =
-      CombinedIonModification.create(CA, H_NEG);
-  public static final IonModification Hneg_FE =
-      CombinedIonModification.create(FE, H_NEG);
-  public static final IonModification Hneg_MG =
-      CombinedIonModification.create(MG, H_NEG);
+  public static final IonModification H2plus = CombinedIonModification.create(H, H);
+  public static final IonModification M2plus = CombinedIonModification.create(M_PLUS, M_PLUS);
+  public static final IonModification NA_H = CombinedIonModification.create(NA, H);
+  public static final IonModification K_H = CombinedIonModification.create(K, H);
+  public static final IonModification NH4_H = CombinedIonModification.create(NH4, H);
+  public static final IonModification Hneg_NA2 = CombinedIonModification.create(NA, NA, H_NEG);
+  public static final IonModification Hneg_CA = CombinedIonModification.create(CA, H_NEG);
+  public static final IonModification Hneg_FE = CombinedIonModification.create(FE, H_NEG);
+  public static final IonModification Hneg_MG = CombinedIonModification.create(MG, H_NEG);
 
   // NEGATIVE
-  public static final IonModification CL =
-      new IonModification(IonModificationType.ADDUCT, "Cl", "Cl", 34.969401, -1);
-  public static final IonModification BR =
-      new IonModification(IonModificationType.ADDUCT, "Br", "Br", 78.918886, -1);
-  public static final IonModification FA =
-      new IonModification(IonModificationType.ADDUCT, "FA", "HCO2", 44.99820285, -1);
+  public static final IonModification CL = new IonModification(IonModificationType.ADDUCT, "Cl",
+      "Cl", 34.969401, -1);
+  public static final IonModification BR = new IonModification(IonModificationType.ADDUCT, "Br",
+      "Br", 78.918886, -1);
+  public static final IonModification FA = new IonModification(IonModificationType.ADDUCT, "FA",
+      "HCO2", 44.99820285, -1);
   // combined
   // +Na -2H+]-
-  public static final IonModification NA_2H =
-      CombinedIonModification.create(NA, H_NEG, H_NEG);
+  public static final IonModification NA_2H = CombinedIonModification.create(NA, H_NEG, H_NEG);
 
   // modifications
-  public static final IonModification H2 =
-      new IonModification(IonModificationType.NEUTRAL_LOSS, "H2", "H2", -2.015650, 0);
-  public static final IonModification C2H4 =
-      new IonModification(IonModificationType.NEUTRAL_LOSS, "C2H4", "C2H4", -28.031301, 0);
-  public static final IonModification H2O =
-      new IonModification(IonModificationType.NEUTRAL_LOSS, "H2O", "H2O", -18.010565, 0);
-  public static final IonModification H2O_2 =
-      CombinedIonModification.create(H2O, H2O);
-  public static final IonModification H2O_3 =
-      CombinedIonModification.create(H2O, H2O, H2O);
-  public static final IonModification H2O_4 =
-      CombinedIonModification.create(H2O, H2O, H2O, H2O);
-  public static final IonModification H2O_5 =
-      CombinedIonModification.create(H2O, H2O, H2O, H2O, H2O);
+  public static final IonModification H2 = new IonModification(IonModificationType.NEUTRAL_LOSS,
+      "H2", "H2", -2.015650, 0);
+  public static final IonModification C2H4 = new IonModification(IonModificationType.NEUTRAL_LOSS,
+      "C2H4", "C2H4", -28.031301, 0);
+  public static final IonModification H2O = new IonModification(IonModificationType.NEUTRAL_LOSS,
+      "H2O", "H2O", -18.010565, 0);
+  public static final IonModification H2O_2 = CombinedIonModification.create(H2O, H2O);
+  public static final IonModification H2O_3 = CombinedIonModification.create(H2O, H2O, H2O);
+  public static final IonModification H2O_4 = CombinedIonModification.create(H2O, H2O, H2O, H2O);
+  public static final IonModification H2O_5 = CombinedIonModification.create(H2O, H2O, H2O, H2O,
+      H2O);
 
-  public static final IonModification NH3 =
-      new IonModification(IonModificationType.NEUTRAL_LOSS, "NH3", "NH3", -17.026549, 0);
-  public static final IonModification CO =
-      new IonModification(IonModificationType.NEUTRAL_LOSS, "CO", "CO", -27.994915, 0);
-  public static final IonModification CO2 =
-      new IonModification(IonModificationType.NEUTRAL_LOSS, "CO2", "CO2", -43.989829, 0);
+  public static final IonModification NH3 = new IonModification(IonModificationType.NEUTRAL_LOSS,
+      "NH3", "NH3", -17.026549, 0);
+  public static final IonModification CO = new IonModification(IonModificationType.NEUTRAL_LOSS,
+      "CO", "CO", -27.994915, 0);
+  public static final IonModification CO2 = new IonModification(IonModificationType.NEUTRAL_LOSS,
+      "CO2", "CO2", -43.989829, 0);
   // cluster
-  public static final IonModification MEOH =
-      new IonModification(IonModificationType.CLUSTER, "MeOH", "CH3OH", 32.026215, 0);
-  public static final IonModification HFA =
-      new IonModification(IonModificationType.CLUSTER, "HFA", "CHOOH", 46.005479, 0);
-  public static final IonModification HAc =
-      new IonModification(IonModificationType.CLUSTER, "HAc", "CH3COOH", 60.021129, 0);
-  public static final IonModification ACN =
-      new IonModification(IonModificationType.CLUSTER, "ACN", "CH3CN", 41.026549, 0);
-  public static final IonModification O =
-      new IonModification(IonModificationType.CLUSTER, "O", "O", 15.99491462, 0);
-  public static final IonModification ISOPROP =
-      new IonModification(IonModificationType.CLUSTER, "IsoProp", "C3H8O", 60.058064, 0);
+  public static final IonModification MEOH = new IonModification(IonModificationType.CLUSTER,
+      "MeOH", "CH3OH", 32.026215, 0);
+  public static final IonModification HFA = new IonModification(IonModificationType.CLUSTER, "HFA",
+      "CHOOH", 46.005479, 0);
+  public static final IonModification HAc = new IonModification(IonModificationType.CLUSTER, "HAc",
+      "CH3COOH", 60.021129, 0);
+  public static final IonModification ACN = new IonModification(IonModificationType.CLUSTER, "ACN",
+      "CH3CN", 41.026549, 0);
+  public static final IonModification O = new IonModification(IonModificationType.CLUSTER, "O", "O",
+      15.99491462, 0);
+  public static final IonModification ISOPROP = new IonModification(IonModificationType.CLUSTER,
+      "IsoProp", "C3H8O", 60.058064, 0);
   // isotopes
-  public static final IonModification C13 =
-      new IonModification(IonModificationType.ISOTOPE, "(13C)", 1.003354838, 0);
+  public static final IonModification C13 = new IonModification(IonModificationType.ISOTOPE,
+      "(13C)", 1.003354838, 0);
 
   // default values
   public static final IonModification[] DEFAULT_VALUES_POSITIVE = {H_NEG, M_PLUS, H, NA, K, NH4,
-      M2plus, H2plus, CA, FE, MG, NA_H, NH4_H, K_H, Hneg_NA2, Hneg_CA, Hneg_FE, M_PLUS_ALREADY_CHARGED, Hneg_MG};
-  public static final IonModification[] DEFAULT_VALUES_NEGATIVE =
-      {M_MINUS, H_NEG, NA_2H, NA, CL, BR, FA, M_MINUS_ALREADY_CHARGED};
+      M2plus, H2plus, CA, FE, MG, NA_H, NH4_H, K_H, Hneg_NA2, Hneg_CA, Hneg_FE,
+      M_PLUS_ALREADY_CHARGED, Hneg_MG};
+  public static final IonModification[] DEFAULT_VALUES_NEGATIVE = {M_MINUS, H_NEG, NA_2H, NA, CL,
+      BR, FA, M_MINUS_ALREADY_CHARGED};
   // default modifications
-  public static final IonModification[] DEFAULT_VALUES_MODIFICATIONS =
-      {H2O, H2O_2, H2O_3, H2O_4, H2O_5, NH3, O, CO, CO2, C2H4, HFA, HAc, MEOH, ACN, ISOPROP};
+  public static final IonModification[] DEFAULT_VALUES_MODIFICATIONS = {H2O, H2O_2, H2O_3, H2O_4,
+      H2O_5, NH3, O, CO, CO2, C2H4, HFA, HAc, MEOH, ACN, ISOPROP};
   // isotopes
   public static final IonModification[] DEFAULT_VALUES_ISOTOPES = {C13};
   public static final String XML_ELEMENT = "ionmodification";
@@ -188,6 +180,19 @@ public class IonModification extends NeutralMolecule implements Comparable<IonMo
     parsedName = parseName();
   }
 
+  /**
+   * Only for super classes that need to parse their own name (see {@link CombinedIonModification})
+   *
+   * @param type
+   * @param massDifference
+   * @param charge
+   */
+  protected IonModification(IonModificationType type, double massDifference, int charge) {
+    super("", null, massDifference);
+    this.charge = charge;
+    this.type = type;
+  }
+
   public void saveToXML(@NotNull final XMLStreamWriter writer) throws XMLStreamException {
     writer.writeStartElement(XML_ELEMENT);
     writer.writeAttribute("name", name);
@@ -199,7 +204,7 @@ public class IonModification extends NeutralMolecule implements Comparable<IonMo
   }
 
   public static IonModification loadFromXML(@NotNull final XMLStreamReader reader) {
-    if(!(reader.isStartElement() && reader.getLocalName().equals(XML_ELEMENT))) {
+    if (!(reader.isStartElement() && reader.getLocalName().equals(XML_ELEMENT))) {
       throw new IllegalStateException("Current element is not an ion modification element.");
     }
 
@@ -213,18 +218,6 @@ public class IonModification extends NeutralMolecule implements Comparable<IonMo
         Double.parseDouble(massDiff), Integer.parseInt(charge));
   }
 
-  /**
-   * Only for super classes that need to parse their own name (see {@link CombinedIonModification})
-   *
-   * @param type
-   * @param massDifference
-   * @param charge
-   */
-  protected IonModification(IonModificationType type, double massDifference, int charge) {
-    super("", null, massDifference);
-    this.charge = charge;
-    this.type = type;
-  }
 
   /**
    * Get the default adducts.
@@ -251,7 +244,7 @@ public class IonModification extends NeutralMolecule implements Comparable<IonMo
    * Undefined adduct for charge
    *
    * @param charge
-   * @return
+   * @return [M+?]+-charge
    */
   public static IonModification getUndefinedforCharge(int charge) {
     double mass = IonModification.M_PLUS.getMass() * charge;
@@ -260,7 +253,7 @@ public class IonModification extends NeutralMolecule implements Comparable<IonMo
 
   @Override
   public String parseName() {
-    if("e".equals(name)){
+    if ("e".equals(name)) {
       return "";
     }
     String sign = this.getMass() < 0 ? "-" : "+";
@@ -296,12 +289,67 @@ public class IonModification extends NeutralMolecule implements Comparable<IonMo
   /**
    * checks all sub/raw ESIAdductTypes
    *
-   * @param a
-   * @return
+   * @param a other
+   * @return true if parsedName equals
    */
   public boolean nameEquals(IonModification a) {
     return parsedName.equals(a.parsedName);
   }
+
+
+  /**
+   * @param part formula or predefined single part (modification or adduct)
+   * @return modification or null
+   */
+  public static @NotNull IonModification parseFromString(String part) {
+    return Stream.of(DEFAULT_VALUES_POSITIVE, DEFAULT_VALUES_NEGATIVE, DEFAULT_VALUES_MODIFICATIONS)
+        .flatMap(Arrays::stream).filter(m -> {
+          String sign = m.getSign();
+          return part.equals(sign + m.getName()) || part.equals(sign + m.getMolFormula()) ||
+                 // positive part can also be without sign
+                 (sign.equals("+") && (part.equals(m.getName()) || part.equals(m.getMolFormula())));
+        }).findFirst().orElseGet(() -> {
+          // if formula fails - cannot know the charge and massDiff - so just default to zero
+          // parser will add charges later
+          return requireNonNullElse(fromFormula(part),
+              new IonModification(IonModificationType.UNKNOWN, part, 0, 0));
+        });
+  }
+
+  @NotNull
+  public String getSign() {
+    return switch (charge) {
+      case -1 -> "-";
+      case 1 -> "+";
+      default -> "";
+    };
+  }
+
+  /**
+   * @param part formula with sign or without -Na is negative while +Na or Na are positive
+   * @return null if formula cannot be parsed
+   */
+  @Nullable
+  public static IonModification fromFormula(String part) {
+    if (part == null || part.isBlank()) {
+      return null;
+    }
+    char first = part.charAt(0);
+    int multiplier = 1;
+    if (first == '+' || first == '-') {
+      part = part.substring(1);
+      if (first == '-') {
+        multiplier = -1;
+      }
+    }
+    var formula = FormulaUtils.createMajorIsotopeMolFormula(part);
+    if (formula == null) {
+      return null;
+    }
+    return new IonModification(IonModificationType.UNKNOWN, part, part,
+        multiplier * FormulaUtils.getMonoisotopicMass(formula), 0);
+  }
+
 
   @Override
   public String toString() {
@@ -357,8 +405,8 @@ public class IonModification extends NeutralMolecule implements Comparable<IonMo
   }
 
   /**
-   * @return array of modifications ({@link IonModification} has one; {@link
-   * CombinedIonModification} has n)
+   * @return array of modifications ({@link IonModification} has one;
+   * {@link CombinedIonModification} has n)
    */
   @NotNull
   public IonModification[] getModifications() {
@@ -502,8 +550,8 @@ public class IonModification extends NeutralMolecule implements Comparable<IonMo
   }
 
   /**
-   * Removes all sub types of parameter from this type. See also {@link
-   * CombinedIonModification#remove(IonModification)}
+   * Removes all sub types of parameter from this type. See also
+   * {@link CombinedIonModification#remove(IonModification)}
    *
    * @param type
    * @return
@@ -587,5 +635,22 @@ public class IonModification extends NeutralMolecule implements Comparable<IonMo
         return null;
       }
     }
+  }
+
+  /**
+   * @return checks for charge smaller / greater than 0
+   */
+  public PolarityType getPolarity() {
+    return PolarityType.fromInt(charge);
+  }
+
+  /**
+   * Create new modification with changed charge
+   *
+   * @param newCharge new charge overrides only the old charge. nothing else
+   * @return copy of this ion modification with other charge
+   */
+  public IonModification withCharge(final int newCharge) {
+    return new IonModification(type, name, molFormula, mass, newCharge);
   }
 }

--- a/src/main/java/io/github/mzmine/datamodel/identities/iontype/IonType.java
+++ b/src/main/java/io/github/mzmine/datamodel/identities/iontype/IonType.java
@@ -37,8 +37,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
@@ -148,69 +146,6 @@ public class IonType extends NeutralMolecule implements Comparable<IonType> {
    */
   public IonType(int molecules, IonType ion) {
     this(molecules, ion.adduct, ion.mod);
-  }
-
-  public static IonType parseFromString(String str) {
-    if (str == null) {
-      return null;
-    }
-
-    // [ 2 M + NH4+H ] 2 +
-    // groups:
-    // 1: [ (opt)
-    // 2: 2 (opt)
-    // 3: M (mandatory)
-    // 4: + (+ or - mandatory)
-    // 5: NH4+H (mandatory)
-    // 6: ] (opt)
-    // 7: 2 (opt)
-    // 8: + (+ or - opt)
-
-    final Pattern pattern = Pattern.compile(
-        "(\\[)?(\\d*)(M)([\\+\\-])([a-zA-Z_0-9\\\\+\\\\-]+)([\\]])?([\\d])?([\\+\\-])?");
-    final Matcher matcher = pattern.matcher(str);
-    if (!matcher.matches()) {
-      return null;
-    }
-
-    StringBuilder b = new StringBuilder();
-    for (int i = 0; i < matcher.groupCount(); i++) {
-      b.append("group ").append(i).append(" ").append(matcher.group(i));
-    }
-
-    final int numMolecules = matcher.group(2) == null || matcher.group(2).isBlank() ? 1
-        : Integer.parseInt(matcher.group(2));
-    final int absCharge = matcher.group(7) == null || matcher.group(7).isBlank() ? 1
-        : Integer.parseInt(matcher.group(7));
-
-    final String modification = matcher.group(5);
-    if (modification == null || modification.isBlank()) {
-      return null;
-    }
-
-    final PolarityType pol =
-        matcher.group(8) == null || matcher.group(8).isBlank() ? PolarityType.POSITIVE
-            : PolarityType.fromSingleChar(matcher.group(8));
-
-    IonModification mod = switch (pol) {
-      case POSITIVE -> Arrays.stream(IonModification.DEFAULT_VALUES_POSITIVE)
-          .filter(m -> m.getName().equals(modification) || modification.equals(m.getMolFormula()))
-          .findFirst().orElse(null);
-      case NEGATIVE -> Arrays.stream(IonModification.DEFAULT_VALUES_NEGATIVE)
-          .filter(m -> m.getName().equals(modification) || modification.equals(m.getMolFormula()))
-          .findFirst().orElse(null);
-      default -> null;
-    };
-    if (mod == null) {
-      return null;
-    }
-
-    final IonType ionType = new IonType(numMolecules, mod);
-    if (ionType.getAbsCharge() != absCharge) {
-      return null;
-    }
-
-    return ionType;
   }
 
   /**
@@ -336,8 +271,10 @@ public class IonType extends NeutralMolecule implements Comparable<IonType> {
 
   public String toString(boolean showMass) {
     int absCharge = Math.abs(charge);
-    String z = absCharge > 1 ? absCharge + "" : "";
-    z += (charge < 0 ? "-" : "+");
+    String z = charge < 0 ? "-" : "+";
+    if (absCharge > 1) {
+      z += absCharge;
+    }
     if (charge == 0) {
       z = "";
     }
@@ -598,7 +535,8 @@ public class IonType extends NeutralMolecule implements Comparable<IonType> {
     return result;
   }
 
-  @Override
+
+    @Override
   public boolean equals(final Object obj) {
     if (obj == null || !obj.getClass().equals(this.getClass())
         || !(obj instanceof final IonType a)) {

--- a/src/main/java/io/github/mzmine/datamodel/identities/iontype/IonTypeParser.java
+++ b/src/main/java/io/github/mzmine/datamodel/identities/iontype/IonTypeParser.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2004-2022 The MZmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.datamodel.identities.iontype;
+
+import io.github.mzmine.util.StringUtils;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Parses strings to {@link IonType}
+ */
+public class IonTypeParser {
+
+  private static final Logger logger = Logger.getLogger(IonTypeParser.class.getName());
+
+  /**
+   * Pattern that groups +3H2O to  +  3  H2O
+   */
+  private static final Pattern PART_PATTERN = Pattern.compile("([+-])(\\d*)(\\w+)");
+
+  @Nullable
+  public static IonType parse(final @Nullable String str) {
+    if (str == null || str.isBlank()) {
+      return null;
+    }
+    // clean up but keep [] for now
+    String clean = str.replaceAll("[^a-zA-Z0-9+-\\[\\]]", "");
+    String[] splitCharge = clean.split("]");
+    // default charge is 1 - because we are usually looking at charged ions
+    int charge = 1;
+    if (splitCharge.length > 1) {
+      // [M+H]+ to [M+H and +
+      charge = StringUtils.parseSignAndIntegerOrElse(splitCharge[1], true, 1);
+      clean = splitCharge[0];
+    } else {
+      // read charge that was not separated by ']' so maybe from M+H or M+H+
+      int lastPlusMinusSignIndex = StringUtils.findLastPlusMinusSignIndex(clean, true);
+      if (lastPlusMinusSignIndex > -1) {
+        charge = StringUtils.parseSignAndIntegerOrElse(clean.substring(lastPlusMinusSignIndex-1),
+            true, 1);
+        clean = clean.substring(0, lastPlusMinusSignIndex);
+      }
+    }
+
+    // remove all other characters (already cleaned before)
+    clean = clean.replaceAll("[\\[\\]]", "");
+    int starti = 0;
+
+    int molMultiplier = 1;
+    boolean molFound = false;
+    List<IonModification> mods = new ArrayList<>();
+
+    for (int i = 0; i < clean.length(); i++) {
+      char c = clean.charAt(i);
+      if (c == '+') {
+        String mod = clean.substring(starti, i);
+        if (!molFound) {
+          // remove the M from the end of 2M or M
+          molMultiplier = getMolMultiplier(mod, 1);
+          molFound = true;
+        } else {
+          parseAndAddIonModifications(mods, mod);
+        }
+        starti = i;
+      }
+      if (c == '-') {
+        String mod = clean.substring(starti, i);
+        if (!molFound) {
+          // remove the M from the end of 2M or M
+          molMultiplier = getMolMultiplier(mod, 1);
+          molFound = true;
+        } else {
+          parseAndAddIonModifications(mods, mod);
+        }
+        starti = i;
+      }
+    }
+//
+
+    // charge was already removed - remainder is the last modification part
+    String remainder = clean.substring(starti);
+    if (!molFound) {
+      // remove the M from the end of 2M or M
+      molMultiplier = getMolMultiplier(remainder, 1);
+      molFound = true;
+    } else {
+      parseAndAddIonModifications(mods, remainder);
+    }
+
+    IonType ion = createIon(molMultiplier, mods);
+    int chargeDiff = charge - ion.getCharge();
+    if (chargeDiff != 0) {
+      var electron = chargeDiff>0? IonModification.M_PLUS : IonModification.M_MINUS;
+      for(int c=0; c<Math.abs(chargeDiff); c++){
+        mods.add(electron);
+      }
+      return createIon(molMultiplier, mods);
+    } else {
+      return ion;
+    }
+  }
+
+  @NotNull
+  private static IonType createIon(final int molMultiplier, final List<IonModification> mods) {
+    var adducts = mods.stream().filter(Objects::nonNull).filter(m -> m.getAbsCharge() > 0)
+        .toArray(IonModification[]::new);
+    var modifications = mods.stream().filter(Objects::nonNull).filter(m -> m.getAbsCharge() == 0)
+        .toArray(IonModification[]::new);
+
+    return new IonType(molMultiplier, CombinedIonModification.create(adducts),
+        CombinedIonModification.create(modifications));
+  }
+
+  private static void parseAndAddIonModifications(final List<IonModification> mods, String mod) {
+    // mod is +Na or -H so with sign
+    // handle +2H by removing the number
+    var matcher = PART_PATTERN.matcher(mod);
+    if (!matcher.find()) {
+      return;
+    }
+
+    // keep parsing prefix number like this
+    int adductMultiplier = StringUtils.parseIntegerPrefixOrElse(mod, 1);
+
+    // need +H or -H2O to get the correct part
+    String sign = StringUtils.orDefault(matcher.group(1), "+");
+    String part = sign + StringUtils.orDefault(matcher.group(3), "");
+
+    var ionPart = IonModification.parseFromString(part);
+
+    for (int j = 0; j < Math.abs(adductMultiplier); j++) {
+      mods.add(ionPart);
+    }
+  }
+
+  private static int getMolMultiplier(String mod, int defaultValue) {
+    mod = mod.substring(0, mod.length() - 1);
+    if (!mod.isBlank()) {
+      try {
+        return Integer.parseInt(mod);
+      } catch (Exception ex) {
+        logger.finest("Cannot parse prefix of M in ion notation");
+      }
+    }
+    return defaultValue;
+  }
+
+
+}

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_localcsvsearch/LocalCSVDatabaseSearchTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_localcsvsearch/LocalCSVDatabaseSearchTask.java
@@ -49,7 +49,7 @@ import io.github.mzmine.datamodel.features.types.numbers.MobilityType;
 import io.github.mzmine.datamodel.features.types.numbers.NeutralMassType;
 import io.github.mzmine.datamodel.features.types.numbers.PrecursorMZType;
 import io.github.mzmine.datamodel.features.types.numbers.RTType;
-import io.github.mzmine.datamodel.identities.iontype.IonType;
+import io.github.mzmine.datamodel.identities.iontype.IonTypeParser;
 import io.github.mzmine.modules.dataprocessing.id_ion_identity_networking.ionidnetworking.IonNetworkLibrary;
 import io.github.mzmine.modules.dataprocessing.id_onlinecompounddb.OnlineDatabases;
 import io.github.mzmine.parameters.ParameterSet;
@@ -446,8 +446,7 @@ public class LocalCSVDatabaseSearchTask extends AbstractTask {
     doIfNotNull(inchiKey, () -> a.put(inchiKeyType, inchiKey));
     doIfNotNull(lineMZ, () -> a.put(precursorMz, lineMZ));
     doIfNotNull(neutralMass, () -> a.put(neutralMassType, neutralMass));
-    doIfNotNull(IonType.parseFromString(lineAdduct),
-        () -> a.put(ionTypeType, IonType.parseFromString(lineAdduct)));
+    a.putIfNotNull(ionTypeType, IonTypeParser.parse(lineAdduct));
     doIfNotNull(pubchemId, () -> a.put(new DatabaseMatchInfoType(),
         new DatabaseMatchInfo(OnlineDatabases.PubChem, pubchemId)));
     return a;

--- a/src/main/java/io/github/mzmine/util/CSVParsingUtils.java
+++ b/src/main/java/io/github/mzmine/util/CSVParsingUtils.java
@@ -36,6 +36,7 @@ import io.github.mzmine.datamodel.features.types.numbers.abstr.DoubleType;
 import io.github.mzmine.datamodel.features.types.numbers.abstr.FloatType;
 import io.github.mzmine.datamodel.features.types.numbers.abstr.IntegerType;
 import io.github.mzmine.datamodel.identities.iontype.IonType;
+import io.github.mzmine.datamodel.identities.iontype.IonTypeParser;
 import io.github.mzmine.modules.dataprocessing.id_ion_identity_networking.ionidnetworking.IonNetworkLibrary;
 import io.github.mzmine.parameters.parametertypes.ImportType;
 import io.github.mzmine.taskcontrol.TaskStatus;
@@ -122,8 +123,8 @@ public class CSVParsingUtils {
           case IntegerType it -> annotation.put(it, Integer.parseInt(line[columnIndex]));
           case DoubleType dt -> annotation.put(dt, Double.parseDouble(line[columnIndex]));
           case IonAdductType ignored -> {
-            final IonType ionType = IonType.parseFromString(line[columnIndex]);
-            annotation.put(IonTypeType.class, ionType);
+            final IonType ionType = IonTypeParser.parse(line[columnIndex]);
+            annotation.putIfNotNull(IonTypeType.class, ionType);
           }
           case StringType st -> annotation.put(st, line[columnIndex]);
           default -> throw new RuntimeException(

--- a/src/main/java/io/github/mzmine/util/FormulaUtils.java
+++ b/src/main/java/io/github/mzmine/util/FormulaUtils.java
@@ -325,11 +325,21 @@ public class FormulaUtils {
   }
 
   /**
+   * @param formula formula maybe with defined isotopes
+   * @return mono isotopic mass
+   */
+  public static double getMonoisotopicMass(IMolecularFormula formula) {
+    return formula == null ? 0d
+        : MolecularFormulaManipulator.getMass(formula, MolecularFormulaManipulator.MonoIsotopic);
+  }
+
+  /**
    * Creates a formula with the major isotopes (important to use this method for exact mass
    * calculation over the CDK version, which generates formulas without an exact mass)
    *
    * @return the formula or null
    */
+  @Nullable
   public static IMolecularFormula createMajorIsotopeMolFormula(String formula) {
     try {
       // new formula consists of isotopes without exact mass

--- a/src/main/java/io/github/mzmine/util/StringUtils.java
+++ b/src/main/java/io/github/mzmine/util/StringUtils.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2004-2022 The MZmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.util;
+
+import org.jetbrains.annotations.NotNull;
+
+public class StringUtils {
+
+  /**
+   * @param str           input
+   * @param onlyUseDigits use only digits contained in string - otherwise try on the whole string
+   * @param defaultValue  default to return
+   * @return parsed integer or the default value on exception
+   */
+  public static int parseIntegerOrElse(String str, boolean onlyUseDigits, int defaultValue) {
+    try {
+      return Integer.parseInt(onlyUseDigits ? getDigits(str) : str);
+    } catch (Exception ex) {
+      // silent
+      return defaultValue;
+    }
+  }
+
+  /**
+   * Tries to find a number prefix like -2H will be -2
+   *
+   * @param str          input
+   * @param defaultValue default to return
+   * @return parsed integer or the default value on exception
+   */
+  public static int parseIntegerPrefixOrElse(String str, int defaultValue) {
+    try {
+      int i = 0;
+      for (; i < str.length(); i++) {
+        var c = str.charAt(i);
+        if (!(Character.isDigit(c) || c == '+' || c == '-')) {
+          break;
+        }
+      }
+
+      return Integer.parseInt(str.substring(0, i));
+    } catch (Exception ex) {
+      // silent
+      return defaultValue;
+    }
+  }
+
+  /**
+   * Tries to remove a number prefix like -2H will be H
+   *
+   * @param str input
+   * @return str with removed integer prefix
+   */
+  public static String removeIntegerPrefix(String str) {
+    try {
+      int i = 0;
+      for (; i < str.length(); i++) {
+        var c = str.charAt(i);
+        if (!(Character.isDigit(c) || c == '+' || c == '-')) {
+          break;
+        }
+      }
+
+      var sub = str.substring(0, i);
+      int prefix = Integer.parseInt(sub);
+      return sub;
+    } catch (Exception ex) {
+      // silent
+      return str;
+    }
+  }
+
+  /**
+   * Will search for a sign + or - that precedes or succeeds a number so +2 and 2+ will both result
+   * in +2
+   *
+   * @param str           input
+   * @param onlyUseDigits use only digits contained in string - otherwise try on the whole string
+   * @param defaultValue  default to return
+   * @return parsed integer or the default value on exception
+   */
+  public static int parseSignAndIntegerOrElse(String str, boolean onlyUseDigits, int defaultValue) {
+    try {
+      int signMultiplier = findFirstPlusMinusSignMultiplier(str, 1);
+      return signMultiplier * parseIntegerOrElse(str, onlyUseDigits, defaultValue);
+    } catch (Exception ex) {
+      // silent
+      return defaultValue;
+    }
+  }
+
+  /**
+   * M+H+2 will return the index of the last + so length -2
+   *
+   * @param str             input
+   * @param allowOnlyDigits between the end and the sign there can only be digits. Otherwise, allow
+   *                        any char
+   * @return last index of + or - or -1 if not found
+   */
+  public static int findLastPlusMinusSignIndex(String str, boolean allowOnlyDigits) {
+    for (int i = str.length() - 1; i >= 0; i--) {
+      char c = str.charAt(i);
+      if (c == '+') {
+        return i;
+      }
+      if (c == '-') {
+        return i;
+      }
+      if (allowOnlyDigits && !Character.isDigit(c)) {
+        return -1;
+      }
+    }
+    return -1;
+  }
+  /**
+   * @param str input
+   * @param allowOnlyDigits between the end and the sign there can only be digits. Otherwise, allow
+   *                        any char
+   * @return first index of + or - or -1 if not found
+   */
+  private static int findFirstPlusMinusSignIndex(final String str, boolean allowOnlyDigits) {
+    for (int i = 0; i < str.length(); i++) {
+      char c = str.charAt(i);
+      if (c == '+') {
+        return i;
+      }
+      if (c == '-') {
+        return i;
+      }
+      if (allowOnlyDigits && !Character.isDigit(c)) {
+        return -1;
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * @param str input
+   * @return the first + or - character or an empty string
+   */
+  private static String findFirstPlusMinusSign(final String str) {
+    var index = findFirstPlusMinusSignIndex(str, false);
+    return index == -1 ? "" : String.valueOf(str.charAt(index));
+  }
+
+  /**
+   * @return +1 or -1 depending on first + or - sign in string. Or defaultValue if no signs
+   */
+  private static int findFirstPlusMinusSignMultiplier(final String str, int defaultValue) {
+    for (int i = 0; i < str.length(); i++) {
+      char c = str.charAt(i);
+      if (c == '+') {
+        return 1;
+      }
+      if (c == '-') {
+        return -1;
+      }
+    }
+    return defaultValue;
+  }
+
+  /**
+   * @param str input
+   * @return the digits contained in a string
+   */
+  @NotNull
+  public static String getDigits(final String str) {
+    return str == null ? "" : org.apache.commons.lang3.StringUtils.getDigits(str);
+  }
+
+  /**
+   * @return if input is null or blank - return defaultValue otherwise retain input str
+   */
+  public static String orDefault(final String str, final String defaultValue) {
+    return str == null || str.isBlank() ? defaultValue : str;
+  }
+}

--- a/src/main/java/io/github/mzmine/util/spectraldb/entry/SpectralDBAnnotation.java
+++ b/src/main/java/io/github/mzmine/util/spectraldb/entry/SpectralDBAnnotation.java
@@ -34,6 +34,7 @@ import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.datamodel.features.compoundannotations.FeatureAnnotation;
 import io.github.mzmine.datamodel.identities.iontype.IonType;
+import io.github.mzmine.datamodel.identities.iontype.IonTypeParser;
 import io.github.mzmine.modules.io.projectload.version_3_0.CONST;
 import io.github.mzmine.util.DataPointSorter;
 import io.github.mzmine.util.ParsingUtils;
@@ -203,8 +204,8 @@ public class SpectralDBAnnotation implements FeatureAnnotation, Comparable<Spect
 
   @Override
   public @Nullable IonType getAdductType() {
-    final String adduct = entry.getOrElse(DBEntryField.SMILES, null);
-    return IonType.parseFromString(adduct);
+    final String adduct = entry.getOrElse(DBEntryField.ION_TYPE, null);
+    return IonTypeParser.parse(adduct);
   }
 
   @Override
@@ -256,7 +257,7 @@ public class SpectralDBAnnotation implements FeatureAnnotation, Comparable<Spect
     return Objects.equals(getEntry(), that.getEntry()) && Objects.equals(getSimilarity(),
         that.getSimilarity()) && Objects.equals(ccsError, that.ccsError) && Objects.equals(
         getQueryScan().getScanNumber(), that.getQueryScan().getScanNumber())
-        && getQueryScan().getDataFile().equals(that.getQueryScan().getDataFile());
+           && getQueryScan().getDataFile().equals(that.getQueryScan().getDataFile());
   }
 
   @Override
@@ -266,8 +267,7 @@ public class SpectralDBAnnotation implements FeatureAnnotation, Comparable<Spect
 
   @Override
   public String toString() {
-    return String.format("%s (%.3f)", getCompoundName(),
-        requireNonNullElse(getScore(), 0f));
+    return String.format("%s (%.3f)", getCompoundName(), requireNonNullElse(getScore(), 0f));
   }
 
   @Override
@@ -277,12 +277,15 @@ public class SpectralDBAnnotation implements FeatureAnnotation, Comparable<Spect
 
   @Override
   public int compareTo(@NotNull final SpectralDBAnnotation o) {
-    if(o.getScore()==null && getScore()==null)
+    if (o.getScore() == null && getScore() == null) {
       return 0;
-    if(o.getScore()==null)
+    }
+    if (o.getScore() == null) {
       return -1;
-    if(getScore()==null)
+    }
+    if (getScore() == null) {
       return 1;
+    }
 
     return Float.compare(this.getScore(), o.getScore());
   }

--- a/src/main/java/io/github/mzmine/util/spectraldb/parser/MonaJsonParser.java
+++ b/src/main/java/io/github/mzmine/util/spectraldb/parser/MonaJsonParser.java
@@ -278,7 +278,7 @@ public class MonaJsonParser extends SpectralDBTextParser {
           Object tmp = readMetaData(main, "retention time");
           if (tmp != null) {
             if (tmp instanceof Number) {
-              value = ((Number) tmp).doubleValue();
+              value = ((Number) tmp).floatValue();
             } else {
               try {
                 String v = (String) tmp;

--- a/src/test/java/io/github/mzmine/util/StringUtilsTest.java
+++ b/src/test/java/io/github/mzmine/util/StringUtilsTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2004-2022 The MZmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class StringUtilsTest {
+
+  @Test
+  void parseIntegerOrElse() {
+    Assertions.assertEquals(123, StringUtils.parseIntegerOrElse("+123", true, 5));
+    Assertions.assertEquals(123, StringUtils.parseIntegerOrElse("123", true, 5));
+    Assertions.assertEquals(123, StringUtils.parseIntegerOrElse("dahklwdhla123dwahjdwhakd", true, 5));
+    Assertions.assertEquals(123, StringUtils.parseIntegerOrElse("dahklwdhla-123dwahjdwhakd", true, 5));
+    Assertions.assertEquals(123, StringUtils.parseIntegerOrElse("dahk-1lwdhla23dwahjdwhakd", true, 5));
+    Assertions.assertEquals(5, StringUtils.parseIntegerOrElse("dahklwdhladwahjdwhakd", true, 5));
+    Assertions.assertEquals(5, StringUtils.parseIntegerOrElse(null, true, 5));
+  }
+
+  @Test
+  void parseIntegerPrefixOrElse() {
+    Assertions.assertEquals(123, StringUtils.parseIntegerPrefixOrElse("+123",  5));
+    Assertions.assertEquals(123, StringUtils.parseIntegerPrefixOrElse("123",  5));
+    Assertions.assertEquals(123, StringUtils.parseIntegerPrefixOrElse("123dahklwdhla123dwahjdwhakd",  5));
+    Assertions.assertEquals(-123, StringUtils.parseIntegerPrefixOrElse("-123dahklwdhla-123dwahjdwhakd",  5));
+    Assertions.assertEquals(5, StringUtils.parseIntegerPrefixOrElse("dahklwdhladwahjdwhakd",  5));
+    Assertions.assertEquals(5, StringUtils.parseIntegerPrefixOrElse(null,  5));
+  }
+
+  @Test
+  void removeIntegerPrefix() {
+  }
+
+  @Test
+  void parseSignAndIntegerOrElse() {
+    Assertions.assertEquals(123, StringUtils.parseSignAndIntegerOrElse("+123", true, 5));
+    Assertions.assertEquals(123, StringUtils.parseSignAndIntegerOrElse("123", true, 5));
+    Assertions.assertEquals(123, StringUtils.parseSignAndIntegerOrElse("dahklwdhla123dwahjdwhakd", true, 5));
+    Assertions.assertEquals(-123, StringUtils.parseSignAndIntegerOrElse("dahklwdhla-123dwahjdwhakd", true, 5));
+    Assertions.assertEquals(-123, StringUtils.parseSignAndIntegerOrElse("dahk-1lwdhla23dwahjdwhakd", true, 5));
+    Assertions.assertEquals(5, StringUtils.parseSignAndIntegerOrElse("dahklwdhladwahjdwhakd", true, 5));
+    Assertions.assertEquals(5, StringUtils.parseSignAndIntegerOrElse(null, true, 5));
+    Assertions.assertEquals(3, StringUtils.parseSignAndIntegerOrElse("+3", true, 5));
+    Assertions.assertEquals(3, StringUtils.parseSignAndIntegerOrElse("3+", true, 5));
+  }
+
+  @Test
+  void getDigits() {
+    Assertions.assertEquals("123", StringUtils.getDigits("+123"));
+    Assertions.assertEquals("123", StringUtils.getDigits("123"));
+    Assertions.assertEquals("123", StringUtils.getDigits("dahklwdhla123dwahjdwhakd"));
+    Assertions.assertEquals("123", StringUtils.getDigits("dahklwdhla-123dwahjdwhakd"));
+    Assertions.assertEquals("123", StringUtils.getDigits("dahk-1lwdhla23dwahjdwhakd"));
+    Assertions.assertEquals("", StringUtils.getDigits("dahklwdhladwahjdwhakd"));
+    Assertions.assertEquals("", StringUtils.getDigits(null));
+    Assertions.assertEquals("3", StringUtils.getDigits("+3"));
+    Assertions.assertEquals("3", StringUtils.getDigits("3+"));
+  }
+
+  @Test
+  void orDefault() {
+    Assertions.assertEquals("default", StringUtils.orDefault("", "default"));
+    Assertions.assertEquals("default", StringUtils.orDefault(" ", "default"));
+    Assertions.assertEquals("default", StringUtils.orDefault("\t", "default"));
+    Assertions.assertEquals("default", StringUtils.orDefault(null, "default"));
+    Assertions.assertEquals("value", StringUtils.orDefault("value", "default"));
+  }
+}


### PR DESCRIPTION
Added many tests and handle now many more cases for ion parsing

## will parse in this order
- find known adducts/neutral losses
- try by formula to get mass
- add as a string if nothing else matches

charge is always retained by just adding or removing electrons to make up for adduct modifications where we do not know the charge. 

M+Fe]+2  -- we do not know the charge of Fe here but we just calc the mass and then remove 2 electrons from it

