### PR TITLE
Add CLI argument to change files easily

### DIFF
--- a/src/main/java/io/github/mzmine/main/MZmineArgumentParser.java
+++ b/src/main/java/io/github/mzmine/main/MZmineArgumentParser.java
@@ -25,6 +25,7 @@
 
 package io.github.mzmine.main;
 
+import io.github.mzmine.modules.io.import_rawdata_all.AllSpectralDataImportModule;
 import io.github.mzmine.util.files.FileAndPathUtil;
 import java.io.File;
 import java.io.IOException;
@@ -49,7 +50,7 @@ public class MZmineArgumentParser {
   private static final Logger logger = Logger.getLogger(MZmineArgumentParser.class.getName());
 
   private File batchFile;
-  private File[] overrideDataFiles;
+  private @Nullable File[] overrideDataFiles;
   private File preferencesFile;
   private File tempDirectory;
   private boolean isKeepRunningAfterBatch = false;
@@ -65,8 +66,10 @@ public class MZmineArgumentParser {
     batch.setRequired(false);
     options.addOption(batch);
 
-    Option input = new Option("i", "input", true,
-        "input files. Either defined in a .txt text file with one file per line or ");
+    Option input = new Option("i", "input", true, """
+        input data files. Either defined in a .txt text file with one file per line
+        or by glob pattern matching. To match all .mzML files in a path: -i "D:\\Data\\*.mzML"
+        """);
     input.setRequired(false);
     options.addOption(input);
 
@@ -201,6 +204,7 @@ public class MZmineArgumentParser {
    *
    * @return true will keep objects in memory which are usually stored in memory mapped files
    */
+  @Nullable
   public KeepInMemory isKeepInMemory() {
     return isKeepInMemory;
   }
@@ -213,6 +217,13 @@ public class MZmineArgumentParser {
     return loadTsfProfile;
   }
 
+  /**
+   * Defines data files that will be used in headless mode. Those files will replace the input files
+   * in the {@link AllSpectralDataImportModule}
+   *
+   * @return data files if specified as argument else null
+   */
+  @Nullable
   public File[] getOverrideDataFiles() {
     return overrideDataFiles;
   }

--- a/src/main/java/io/github/mzmine/main/MZmineCore.java
+++ b/src/main/java/io/github/mzmine/main/MZmineCore.java
@@ -169,7 +169,7 @@ public final class MZmineCore {
         } else {
           logger.log(Level.WARNING,
               "Cannot create or access temp file directory that was set via program argument: "
-                  + tempDirectory.getAbsolutePath());
+              + tempDirectory.getAbsolutePath());
         }
       }
 
@@ -193,6 +193,7 @@ public final class MZmineCore {
 
       // batch mode defined by command line argument
       File batchFile = argsParser.getBatchFile();
+      File[] overrideDataFiles = argsParser.getOverrideDataFiles();
       boolean keepRunningInHeadless = argsParser.isKeepRunningAfterBatch();
 
       // track version use
@@ -226,7 +227,8 @@ public final class MZmineCore {
 
           // run batch file
           getInstance().batchExitCode = BatchModeModule.runBatch(
-              getInstance().projectManager.getCurrentProject(), batchFile, Instant.now());
+              getInstance().projectManager.getCurrentProject(), batchFile, overrideDataFiles,
+              Instant.now());
         }
 
         // option to keep MZmine running after the batch is finished

--- a/src/main/java/io/github/mzmine/modules/batchmode/BatchModeModule.java
+++ b/src/main/java/io/github/mzmine/modules/batchmode/BatchModeModule.java
@@ -37,13 +37,16 @@ import io.github.mzmine.util.ExitCode;
 import java.io.File;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.w3c.dom.Document;
 
 /**
@@ -63,7 +66,18 @@ public class BatchModeModule implements MZmineProcessingModule {
    */
   public static ExitCode runBatch(@NotNull MZmineProject project, File batchFile,
       @NotNull Instant moduleCallDate) {
+    return runBatch(project, batchFile, null, moduleCallDate);
+  }
 
+  /**
+   * Run from batch file (usually in headless mode)
+   *
+   * @param batchFile         local file
+   * @param overrideDataFiles change the data import to those files if not null
+   * @return exit code that reflects if the batch mode was started
+   */
+  public static ExitCode runBatch(@NotNull MZmineProject project, File batchFile,
+      @Nullable File[] overrideDataFiles, @NotNull Instant moduleCallDate) {
     if (MZmineCore.getTaskController().isTaskInstanceRunningOrQueued(BatchTask.class)) {
       MZmineCore.getDesktop().displayErrorMessage(
           "Cannot run a second batch while the current batch is not finished.");
@@ -85,6 +99,16 @@ public class BatchModeModule implements MZmineProcessingModule {
         logger.log(Level.WARNING, "Warnings during batch file import:");
         for (final String errorMessage : errorMessages) {
           logger.log(Level.WARNING, errorMessage);
+        }
+      }
+
+      if (overrideDataFiles != null) {
+        if (!newQueue.setImportFiles(overrideDataFiles)) {
+          logger.log(Level.SEVERE,
+              "Could not change the input files to " + Arrays.stream(overrideDataFiles)
+                  .map(file -> file != null ? file.getAbsolutePath() : "null")
+                  .collect(Collectors.joining("\n")));
+          return ExitCode.ERROR;
         }
       }
 

--- a/src/main/java/io/github/mzmine/modules/batchmode/BatchQueue.java
+++ b/src/main/java/io/github/mzmine/modules/batchmode/BatchQueue.java
@@ -42,6 +42,7 @@ import io.github.mzmine.util.javafx.ArrayObservableList;
 import java.io.File;
 import java.util.Collection;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.w3c.dom.Document;
@@ -235,8 +236,9 @@ public class BatchQueue extends ArrayObservableList<MZmineProcessingStep<MZmineP
    * first step in batch
    *
    * @param allFiles replaces import files
+   * @return true if success, false if not. e.g., if there was no data import step in the batch file
    */
-  public boolean setImportFiles(final File[] allFiles) {
+  public boolean setImportFiles(final File[] allFiles) throws IllegalStateException {
     MZmineProcessingStep<?> currentStep = get(0);
     ParameterSet importParameters = currentStep.getParameterSet();
     try {
@@ -245,10 +247,10 @@ public class BatchQueue extends ArrayObservableList<MZmineProcessingStep<MZmineP
       importParam.setValue(allFiles);
       return true;
     } catch (Exception ex) {
-      logger.warning(
-          "When running batch and changing the data input, the first step in the batch needs to be the all spectral data import module.");
-      throw new IllegalStateException(
-          "When running batch and changing the data input, the first step in the batch needs to be the all spectral data import module");
+      logger.log(Level.WARNING,
+          "Could not change input data files in batch. When running batch and changing the data input, the first step in the batch needs to be the all spectral data import module.",
+          ex);
+      return false;
     }
   }
 

--- a/src/main/java/io/github/mzmine/modules/batchmode/BatchQueue.java
+++ b/src/main/java/io/github/mzmine/modules/batchmode/BatchQueue.java
@@ -33,9 +33,13 @@ import io.github.mzmine.modules.MZmineProcessingStep;
 import io.github.mzmine.modules.dataprocessing.filter_rowsfilter.RowsFilterModule;
 import io.github.mzmine.modules.dataprocessing.filter_rowsfilter.RowsFilterParameters;
 import io.github.mzmine.modules.impl.MZmineProcessingStepImpl;
+import io.github.mzmine.modules.io.import_rawdata_all.AllSpectralDataImportModule;
+import io.github.mzmine.modules.io.import_rawdata_all.AllSpectralDataImportParameters;
 import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.parameters.parametertypes.filenames.FileNamesParameter;
 import io.github.mzmine.util.CollectionUtils;
 import io.github.mzmine.util.javafx.ArrayObservableList;
+import java.io.File;
 import java.util.Collection;
 import java.util.List;
 import java.util.logging.Logger;
@@ -225,4 +229,27 @@ public class BatchQueue extends ArrayObservableList<MZmineProcessingStep<MZmineP
       }
     }
   }
+
+  /**
+   * Replace all import files in the {@link AllSpectralDataImportModule} - which needs to be the
+   * first step in batch
+   *
+   * @param allFiles replaces import files
+   */
+  public boolean setImportFiles(final File[] allFiles) {
+    MZmineProcessingStep<?> currentStep = get(0);
+    ParameterSet importParameters = currentStep.getParameterSet();
+    try {
+      FileNamesParameter importParam = importParameters.getParameter(
+          AllSpectralDataImportParameters.fileNames);
+      importParam.setValue(allFiles);
+      return true;
+    } catch (Exception ex) {
+      logger.warning(
+          "When running batch and changing the data input, the first step in the batch needs to be the all spectral data import module.");
+      throw new IllegalStateException(
+          "When running batch and changing the data input, the first step in the batch needs to be the all spectral data import module");
+    }
+  }
+
 }

--- a/src/main/java/io/github/mzmine/modules/batchmode/BatchTask.java
+++ b/src/main/java/io/github/mzmine/modules/batchmode/BatchTask.java
@@ -147,10 +147,19 @@ public class BatchTask extends AbstractTask {
 
         if (allFiles.length != 0) {
           // set files to import
-          queue.setImportFiles(allFiles);
-
+          if (!queue.setImportFiles(allFiles)) {
+            if (skipOnError) {
+              processedSteps += stepsPerDataset;
+              continue;
+            } else {
+              setStatus(TaskStatus.ERROR);
+              setErrorMessage("Could not set data files in advanced batch mode. Will cancel all jobs. " + datasetName);
+              return;
+            }
+          }
           // set files to output
           setOutputFiles(parentDir, createResultsDir, datasetName);
+
         } else {
           errorDataset++;
           logger.info("No data files found in directory: " + datasetName);

--- a/src/main/java/io/github/mzmine/modules/batchmode/BatchTask.java
+++ b/src/main/java/io/github/mzmine/modules/batchmode/BatchTask.java
@@ -39,7 +39,6 @@ import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.parametertypes.EmbeddedParameterSet;
 import io.github.mzmine.parameters.parametertypes.filenames.FileNameParameter;
-import io.github.mzmine.parameters.parametertypes.filenames.FileNamesParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsSelection;
 import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesParameter;
@@ -148,7 +147,7 @@ public class BatchTask extends AbstractTask {
 
         if (allFiles.length != 0) {
           // set files to import
-          setImportFiles(allFiles);
+          queue.setImportFiles(allFiles);
 
           // set files to output
           setOutputFiles(parentDir, createResultsDir, datasetName);
@@ -230,19 +229,6 @@ public class BatchTask extends AbstractTask {
     }
   }
 
-  private void setImportFiles(final File[] allFiles) {
-    MZmineProcessingStep<?> currentStep = queue.get(0);
-    ParameterSet importParameters = currentStep.getParameterSet();
-    FileNamesParameter importParam = importParameters.getParameter(
-        AllSpectralDataImportParameters.fileNames);
-    if (importParam == null) {
-      logger.warning(
-          "When running advanced batch, the first step in the batch needs to be the all spectral data import module.");
-      throw new IllegalStateException(
-          "When running advanced batch, the first step in the batch needs to be the all spectral data import module");
-    }
-    importParam.setValue(allFiles);
-  }
 
   private void processQueueStep(int stepNumber) {
 

--- a/src/main/java/io/github/mzmine/util/files/FileAndPathUtil.java
+++ b/src/main/java/io/github/mzmine/util/files/FileAndPathUtil.java
@@ -28,16 +28,20 @@ package io.github.mzmine.util.files;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Stream;
 import javafx.stage.FileChooser.ExtensionFilter;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -575,4 +579,58 @@ public class FileAndPathUtil {
   public static String safePathEncode(String name, String replaceStr) {
     return name.replaceAll("[^a-zA-Z0-9-_()\\.\\s]", replaceStr);
   }
+
+  /**
+   * Three options:
+   * <p>
+   * 1. a string that defines all files separated by lines \n
+   * <p>
+   * 2. a .txt text file with files listed separated by newline \n
+   * <p>
+   * 3. a wildcard path/*.mzML to grab all files
+   *
+   * @return extracted list of files
+   */
+  public static File[] parseFileInputArgument(final String input) throws IOException {
+    if (input.toLowerCase().endsWith(".txt")) {
+      try (var lines = Files.lines(Paths.get(input))) {
+        return lines.map(File::new).toArray(File[]::new);
+      }
+    }
+
+    if (input.contains("*")) {
+      return searchWithGlob(input);
+    }
+
+    // try to just use the input as files separated by newline
+    // matches all new line characters
+    return Arrays.stream(input.split("\\R")).map(File::new).toArray(File[]::new);
+  }
+
+  /**
+   * @param globPath path like path/*.mzML
+   * @return all matching files
+   */
+  public static @NotNull File[] searchWithGlob(String globPath) throws IOException {
+    var path = new File(globPath);
+//    var path = Paths.get(globPath);
+    return searchWithGlob(path.getParentFile().toPath(), path.getName());
+  }
+
+  /**
+   * @param rootDir parent directory
+   * @param pattern pattern like *.mzML
+   * @return all matching files
+   */
+  public static @NotNull File[] searchWithGlob(Path rootDir, String pattern) throws IOException {
+    PathMatcher matcher = FileSystems.getDefault()
+        .getPathMatcher((pattern.startsWith("glob:") ? "" : "glob:") + pattern);
+
+    try (Stream<Path> stream = Files.walk(rootDir, 1)) {
+      return stream.filter(file -> !Files.isDirectory(file))
+          .filter(file -> matcher.matches(file.getFileName())).map(Path::toFile)
+          .toArray(File[]::new);
+    }
+  }
+
 }

--- a/src/main/java/io/github/mzmine/util/files/FileAndPathUtil.java
+++ b/src/main/java/io/github/mzmine/util/files/FileAndPathUtil.java
@@ -627,8 +627,7 @@ public class FileAndPathUtil {
         .getPathMatcher((pattern.startsWith("glob:") ? "" : "glob:") + pattern);
 
     try (Stream<Path> stream = Files.walk(rootDir, 1)) {
-      return stream.filter(file -> !Files.isDirectory(file))
-          .filter(file -> matcher.matches(file.getFileName())).map(Path::toFile)
+      return stream.filter(file -> matcher.matches(file.getFileName())).map(Path::toFile)
           .toArray(File[]::new);
     }
   }


### PR DESCRIPTION
Added arguments i: input to change the input files in batch files easily. It just replaces all the files in the AllSpectralDataImportModule.

Either provide a txt file with paths or use glob patterns
```
-b D:\Data\batch\test.xml -i D:\Data\input_files.txt
-b D:\Data\batch\test.xml -i D:\Data\*.mzML
```

