### PR TITLE
Add WeakListeners to decouple views automatically

### DIFF
--- a/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableContextMenu.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableContextMenu.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -40,6 +40,7 @@ import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.featuredata.IonMobilogramTimeSeries;
 import io.github.mzmine.datamodel.featuredata.IonTimeSeries;
 import io.github.mzmine.datamodel.features.Feature;
+import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.datamodel.features.compoundannotations.FeatureAnnotation;
@@ -331,7 +332,8 @@ public class FeatureTableContextMenu extends ContextMenu {
 
   private void initShowMenu() {
 
-    final MenuItem showNetworkVisualizerItem = new MenuItem("Feature network");
+    final MenuItem showNetworkVisualizerItem = new ConditionalMenuItem("Feature overview (network)",
+        () -> hasMs2(selectedRows));
     showNetworkVisualizerItem.setOnAction(e -> showNetworkVisualizer());
 
     final MenuItem showXICItem = new ConditionalMenuItem("XIC (quick)",
@@ -477,7 +479,7 @@ public class FeatureTableContextMenu extends ContextMenu {
     });
 
     final MenuItem showAllMSMSItem = new ConditionalMenuItem("All MS/MS",
-        () -> !selectedRows.isEmpty() && !selectedRows.get(0).getAllFragmentScans().isEmpty());
+        () -> hasMs2(selectedRows));
     showAllMSMSItem.setOnAction(e -> onShowAllMsMsClicked());
 
     final MenuItem showIsotopePatternItem = new ConditionalMenuItem("Isotope pattern",
@@ -515,13 +517,18 @@ public class FeatureTableContextMenu extends ContextMenu {
 
     showMenu.getItems()
         .addAll(showXICItem, showXICSetupItem, showIMSFeatureItem, showImageFeatureItem,
-            new SeparatorMenuItem(), show2DItem, show3DItem, showIntensityPlotItem,
-            showInIMSRawDataOverviewItem, showInMobilityMzVisualizerItem, new SeparatorMenuItem(),
-            showSpectrumItem, showFeatureFWHMMs1Item, showBestMobilityScanItem,
-            extractSumSpectrumFromMobScans, showMSMSItem, showMSMSMirrorItem, showAllMSMSItem,
-            showDiaIons, showDiaMirror, new SeparatorMenuItem(), showIsotopePatternItem,
-            showCompoundDBResults, showSpectralDBResults, showMatchedLipidSignals,
-            new SeparatorMenuItem(), showPeakRowSummaryItem, showNetworkVisualizerItem);
+            new SeparatorMenuItem(), showNetworkVisualizerItem, show2DItem, show3DItem,
+            showIntensityPlotItem, showInIMSRawDataOverviewItem, showInMobilityMzVisualizerItem,
+            new SeparatorMenuItem(), showSpectrumItem, showFeatureFWHMMs1Item,
+            showBestMobilityScanItem, extractSumSpectrumFromMobScans, showMSMSItem,
+            showMSMSMirrorItem, showAllMSMSItem, showDiaIons, showDiaMirror,
+            new SeparatorMenuItem(), showIsotopePatternItem, showCompoundDBResults,
+            showSpectralDBResults, showMatchedLipidSignals, new SeparatorMenuItem(),
+            showPeakRowSummaryItem);
+  }
+
+  private boolean hasMs2(final List<ModularFeatureListRow> selectedRows) {
+    return selectedRows.stream().anyMatch(FeatureListRow::hasMs2Fragmentation);
   }
 
   /**
@@ -529,7 +536,7 @@ public class FeatureTableContextMenu extends ContextMenu {
    */
   private void showNetworkVisualizer() {
     var featureList = table.getFeatureList();
-    if (selectedRows.isEmpty() || featureList==null) {
+    if (selectedRows.isEmpty() || featureList == null) {
       return;
     }
     NetworkOverviewWindow networks = new NetworkOverviewWindow(featureList, table, selectedRows);

--- a/src/main/java/io/github/mzmine/modules/visualization/network_overview/NetworkOverviewController.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/network_overview/NetworkOverviewController.java
@@ -76,7 +76,6 @@ public class NetworkOverviewController {
   private CompoundDatabaseMatchTab compoundMatchController;
   private EdgeTableController edgeTableController;
   private SpectraStackVisualizerPane allMs2Pane;
-  private boolean isClosed;
 
   public NetworkOverviewController() {
     this.focussedRows = FXCollections.observableArrayList();
@@ -153,7 +152,7 @@ public class NetworkOverviewController {
 
     var tabController = tempTab.getController();
     weak.addListChangeListener(networkController.getNetworkPane().getVisibleRows(), c -> {
-      if (isClosed) {
+      if (weak.isDisposed()) {
         return;
       }
       ObservableList<? extends FeatureListRow> visible = c.getList();
@@ -168,7 +167,7 @@ public class NetworkOverviewController {
       final @Nullable FeatureTableFX external) {
     // just apply selections in network
     weak.addListChangeListener(internal.getSelectedTableRows(), c -> {
-      if (isClosed) {
+      if (weak.isDisposed()) {
         return;
       }
       var list = c.getList().stream().map(TreeItem::getValue).toList();
@@ -178,7 +177,7 @@ public class NetworkOverviewController {
     // external directly sets new focussed rows - and then selected rows in the internal table
     if (external != null) {
       weak.addListChangeListener(external.getSelectedTableRows(), c -> {
-        if (isClosed) {
+        if (weak.isDisposed()) {
           return;
         }
         if (cbBindToExternalTable.isSelected()) {
@@ -190,7 +189,7 @@ public class NetworkOverviewController {
   }
 
   protected void handleSelectedNodesChanged(final Change<? extends Node> change) {
-    if (isClosed) {
+    if (weak.isDisposed()) {
       return;
     }
 
@@ -225,6 +224,5 @@ public class NetworkOverviewController {
   public void close() {
     // need to dispose of listeners to be garbage collected
     weak.dipose();
-    isClosed = true;
   }
 }

--- a/src/main/java/io/github/mzmine/modules/visualization/network_overview/NetworkOverviewController.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/network_overview/NetworkOverviewController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -27,7 +27,6 @@ package io.github.mzmine.modules.visualization.network_overview;
 
 import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
-import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.modules.visualization.compdb.CompoundDatabaseMatchTab;
 import io.github.mzmine.modules.visualization.featurelisttable_modular.FeatureTableFX;
 import io.github.mzmine.modules.visualization.featurelisttable_modular.FeatureTableTab;
@@ -36,6 +35,7 @@ import io.github.mzmine.modules.visualization.spectra.simplespectra.mirrorspectr
 import io.github.mzmine.modules.visualization.spectra.simplespectra.mirrorspectra.MirrorScanWindowFXML;
 import io.github.mzmine.modules.visualization.spectra.spectra_stack.SpectraStackVisualizerPane;
 import io.github.mzmine.modules.visualization.spectra.spectralmatchresults.SpectraIdentificationResultsWindowFX;
+import io.github.mzmine.util.javafx.WeakAdapter;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
@@ -43,7 +43,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javafx.collections.FXCollections;
-import javafx.collections.ListChangeListener;
 import javafx.collections.ListChangeListener.Change;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXMLLoader;
@@ -60,15 +59,8 @@ public class NetworkOverviewController {
 
   private static final Logger logger = Logger.getLogger(NetworkOverviewController.class.getName());
   private final ObservableList<FeatureListRow> focussedRows;
+  private final @NotNull WeakAdapter weak = new WeakAdapter();
   public ToggleSwitch cbBindToExternalTable;
-  private boolean setUpCalled = false;
-
-  private FeatureNetworkController networkController;
-  private FeatureTableFX internalTable;
-  private MirrorScanWindowController mirrorScanController;
-  private SpectraIdentificationResultsWindowFX spectralMatchesController;
-  private CompoundDatabaseMatchTab compoundMatchController;
-
   public BorderPane pnNetwork;
   public Tab tabAnnotations;
   public Tab tabSimilarity;
@@ -76,8 +68,15 @@ public class NetworkOverviewController {
   public Tab tabNodes;
   public Tab tabEdges;
   public GridPane gridAnnotations;
+  private boolean setUpCalled = false;
+  private FeatureNetworkController networkController;
+  private FeatureTableFX internalTable;
+  private MirrorScanWindowController mirrorScanController;
+  private SpectraIdentificationResultsWindowFX spectralMatchesController;
+  private CompoundDatabaseMatchTab compoundMatchController;
   private EdgeTableController edgeTableController;
   private SpectraStackVisualizerPane allMs2Pane;
+  private boolean isClosed;
 
   public NetworkOverviewController() {
     this.focussedRows = FXCollections.observableArrayList();
@@ -97,7 +96,6 @@ public class NetworkOverviewController {
 
     // create edge table
     createEdgeTable();
-
 
     // create internal table
     createInternalTable(featureList);
@@ -124,8 +122,8 @@ public class NetworkOverviewController {
     tabAllMs2.setContent(allMs2Pane);
 
     // add callbacks
-    networkController.getNetworkPane().getSelectedNodes()
-        .addListener(this::handleSelectedNodesChanged);
+    weak.addListChangeListener(networkController.getNetworkPane().getSelectedNodes(),
+        c -> handleSelectedNodesChanged(c));
 
     // set focussed rows last
     if (focussedRows != null) {
@@ -154,40 +152,50 @@ public class NetworkOverviewController {
     tabNodes.setContent(tempTab.getMainPane());
 
     var tabController = tempTab.getController();
-    networkController.getNetworkPane().getVisibleRows()
-        .addListener((ListChangeListener<? super FeatureListRow>) c -> {
-          ObservableList<? extends FeatureListRow> visible = c.getList();
-          tabController.getIdSearchField().setText(
-              visible.stream().map(FeatureListRow::getID).map(Object::toString)
-                  .collect(Collectors.joining(",")));
-        });
+    weak.addListChangeListener(networkController.getNetworkPane().getVisibleRows(), c -> {
+      if (isClosed) {
+        return;
+      }
+      ObservableList<? extends FeatureListRow> visible = c.getList();
+      tabController.getIdSearchField().setText(
+          visible.stream().map(FeatureListRow::getID).map(Object::toString)
+              .collect(Collectors.joining(",")));
+    });
   }
 
 
   private void linkFeatureTableSelections(final @NotNull FeatureTableFX internal,
       final @Nullable FeatureTableFX external) {
     // just apply selections in network
-    internal.getSelectedTableRows()
-        .addListener((ListChangeListener<? super TreeItem<ModularFeatureListRow>>) c -> {
-          var list = c.getList().stream().map(TreeItem::getValue).toList();
-          var networkPane = networkController.getNetworkPane();
-          networkPane.getSelectedNodes().setAll(networkPane.getNodes(list));
-        });
+    weak.addListChangeListener(internal.getSelectedTableRows(), c -> {
+      if (isClosed) {
+        return;
+      }
+      var list = c.getList().stream().map(TreeItem::getValue).toList();
+      var networkPane = networkController.getNetworkPane();
+      networkPane.getSelectedNodes().setAll(networkPane.getNodes(list));
+    });
     // external directly sets new focussed rows - and then selected rows in the internal table
     if (external != null) {
-      external.getSelectedTableRows()
-          .addListener((ListChangeListener<? super TreeItem<ModularFeatureListRow>>) c -> {
-            if (cbBindToExternalTable.isSelected()) {
-              var list = c.getList().stream().map(TreeItem::getValue).toList();
-              focussedRows.setAll(list);
-            }
-          });
+      weak.addListChangeListener(external.getSelectedTableRows(), c -> {
+        if (isClosed) {
+          return;
+        }
+        if (cbBindToExternalTable.isSelected()) {
+          var list = c.getList().stream().map(TreeItem::getValue).toList();
+          focussedRows.setAll(list);
+        }
+      });
     }
   }
 
   protected void handleSelectedNodesChanged(final Change<? extends Node> change) {
+    if (isClosed) {
+      return;
+    }
+
     var selectedRows = networkController.getNetworkPane().getRowsFromNodes(change.getList());
-      showAnnotations(selectedRows);
+    showAnnotations(selectedRows);
     showAllMs2(selectedRows);
     if (selectedRows.size() >= 2) {
       showSimilarityMirror(selectedRows.get(0), selectedRows.get(1));
@@ -212,5 +220,11 @@ public class NetworkOverviewController {
    */
   public void showSimilarityMirror(FeatureListRow a, FeatureListRow b) {
     mirrorScanController.setScans(a.getMostIntenseFragmentScan(), b.getMostIntenseFragmentScan());
+  }
+
+  public void close() {
+    // need to dispose of listeners to be garbage collected
+    weak.dipose();
+    isClosed = true;
   }
 }

--- a/src/main/java/io/github/mzmine/modules/visualization/network_overview/NetworkOverviewWindow.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/network_overview/NetworkOverviewWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -49,6 +49,11 @@ public class NetworkOverviewWindow extends Stage {
       @Nullable FeatureTableFX externalTable,
       @Nullable List<? extends FeatureListRow> selectedRows) {
     setTitle("Network overview: " + featureList.getName());
+    setOnCloseRequest(event -> {
+      if (controller != null) {
+        controller.close();
+      }
+    });
     try {
       // Load the window FXML
       FXMLLoader loader = new FXMLLoader(getClass().getResource("NetworkOverviewPane.fxml"));

--- a/src/main/java/io/github/mzmine/modules/visualization/networking/visual/FeatureNetworkController.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/networking/visual/FeatureNetworkController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -57,7 +57,6 @@ import javafx.scene.control.Tooltip;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.Pane;
 import javafx.util.Duration;
-import org.controlsfx.control.CheckComboBox;
 import org.controlsfx.control.SearchableComboBox;
 import org.controlsfx.control.ToggleSwitch;
 import org.controlsfx.control.textfield.TextFields;
@@ -79,7 +78,7 @@ public class FeatureNetworkController {
   public SearchableComboBox<EdgeAtt> comboEdgeSize;
   public SearchableComboBox<EdgeAtt> comboEdgeLabel;
   public ToggleSwitch cbCollapseIons;
-  public CheckComboBox<String> cbComboVisibleEdgeTypes;
+  //  public CheckComboBox<String> cbComboVisibleEdgeTypes;
   public Spinner<Integer> spinnerNodeNeighbors;
   public BorderPane mainPane;
   public TextField txtFilterAnnotations;
@@ -162,12 +161,12 @@ public class FeatureNetworkController {
     addComboOptions(comboNodeSize, SIZE, NodeAtt.values(), NodeAtt.LOG10_SUM_INTENSITY);
     addComboOptions(comboEdgeColor, COLOR, EdgeAtt.values(), EdgeAtt.NEIGHBOR_DISTANCE);
     addComboOptions(comboEdgeSize, SIZE, EdgeAtt.values(), EdgeAtt.SCORE);
-    addComboOptions(comboEdgeLabel, LABEL, EdgeAtt.values(), EdgeAtt.DELTA_MZ);
+    addComboOptions(comboEdgeLabel, LABEL, EdgeAtt.values(), EdgeAtt.NONE);
 
     cbCollapseIons.selectedProperty()
         .addListener((observable, oldValue, newValue) -> networkPane.collapseIonNodes(newValue));
 
-    cbComboVisibleEdgeTypes.getItems().addAll(networkPane.getUniqueEdgeTypes());
+//    cbComboVisibleEdgeTypes.getItems().addAll(networkPane.getUniqueEdgeTypes());
     // TODO check all and bind visibility
 
     // #######################################################

--- a/src/main/java/io/github/mzmine/modules/visualization/networking/visual/FeatureNetworkGenerator.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/networking/visual/FeatureNetworkGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -112,6 +112,13 @@ public class FeatureNetworkGenerator {
 
       // add gnps library matches to nodes
       addGNPSLibraryMatchesToNodes(rows);
+
+      // add missing row nodes
+      for (final FeatureListRow row : rows) {
+        if (row.hasMs2Fragmentation()) {
+          getRowNode(row, true);
+        }
+      }
 
       // add id name
       for (Node node : graph) {

--- a/src/main/java/io/github/mzmine/modules/visualization/networking/visual/FeatureNetworkPane.fxml
+++ b/src/main/java/io/github/mzmine/modules/visualization/networking/visual/FeatureNetworkPane.fxml
@@ -52,7 +52,7 @@
                   <FlowPane hgap="4.0" vgap="4.0">
                      <children>
                         <ToggleSwitch fx:id="cbCollapseIons" contentDisplay="RIGHT" graphicTextGap="0.0" nodeOrientation="RIGHT_TO_LEFT" selected="false" text="Collapse ions" />
-                        <CheckComboBox fx:id="cbComboVisibleEdgeTypes" />
+<!--                        <CheckComboBox fx:id="cbComboVisibleEdgeTypes" />-->
                         <Spinner fx:id="spinnerNodeNeighbors" prefHeight="26.0" prefWidth="71.0">
                         </Spinner>
                         <TextField fx:id="txtFilterAnnotations" prefHeight="26.0" prefWidth="194.0" promptText="Search &amp; select matches" />

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/spectra_stack/SpectraStackVisualizerPane.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/spectra_stack/SpectraStackVisualizerPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -73,6 +73,8 @@ import org.jfree.chart.axis.ValueAxis;
  */
 public class SpectraStackVisualizerPane extends BorderPane {
 
+  public static final int ROW_LIMIT = 50;
+
   private final ParameterSet parameters;
   private final ParameterSetupPane paramPane;
   private final Label lbRawIndex;
@@ -131,7 +133,6 @@ public class SpectraStackVisualizerPane extends BorderPane {
 
     pnRawControls = new FlowPane(3, 0, prevRaw, nextRaw, lbRawIndex, lbRawName);
     Pane pnTopMenu = new FlowPane(3, 3, resetZoom, pnRawControls);
-
 
     Accordion paramAccordion = new Accordion(new TitledPane("Options", paramPane));
     BorderPane wrapped = new BorderPane(paramAccordion);
@@ -296,8 +297,9 @@ public class SpectraStackVisualizerPane extends BorderPane {
   /**
    * Sort rows
    */
-  public void setData(FeatureListRow[] rows, @Nullable RawDataFile[] allRaw, @Nullable RawDataFile raw,
-      boolean createMS1, SortingProperty sorting, SortingDirection direction) {
+  public void setData(FeatureListRow[] rows, @Nullable RawDataFile[] allRaw,
+      @Nullable RawDataFile raw, boolean createMS1, SortingProperty sorting,
+      SortingDirection direction) {
     Arrays.sort(rows, new FeatureListRowSorter(sorting, direction));
     setData(rows, allRaw, raw, createMS1);
   }
@@ -309,8 +311,10 @@ public class SpectraStackVisualizerPane extends BorderPane {
     setData(rows.toArray(FeatureListRow[]::new), null, null, createMS1);
   }
 
-  public void setData(FeatureListRow[] rows, @Nullable RawDataFile[] allRaw, @Nullable RawDataFile raw,
-      boolean createMS1) {
+  public void setData(FeatureListRow[] rows, @Nullable RawDataFile[] allRaw,
+      @Nullable RawDataFile raw, boolean createMS1) {
+    rows = Arrays.stream(rows).filter(FeatureListRow::hasMs2Fragmentation).limit(ROW_LIMIT)
+        .toArray(FeatureListRow[]::new);
     if (applyMzSorting) {
       Arrays.sort(rows, FeatureListRowSorter.MZ_ASCENDING);
     }

--- a/src/main/java/io/github/mzmine/modules/visualization/spectra/spectralmatchresults/SpectraIdentificationResultsWindowFX.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/spectra/spectralmatchresults/SpectraIdentificationResultsWindowFX.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -32,6 +32,7 @@ import io.github.mzmine.modules.visualization.featurelisttable_modular.FeatureTa
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.FeatureUtils;
 import io.github.mzmine.util.javafx.TableViewUtils;
+import io.github.mzmine.util.javafx.WeakAdapter;
 import io.github.mzmine.util.spectraldb.entry.SpectralDBAnnotation;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -44,7 +45,6 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
-import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
@@ -77,6 +77,8 @@ public class SpectraIdentificationResultsWindowFX extends SimpleTab {
   private static final Logger logger = Logger.getLogger(
       SpectraIdentificationResultsWindowFX.class.getName());
 
+  private final WeakAdapter weak = new WeakAdapter();
+
   // link row selection to results
   private final Font headerFont = new Font("Dialog Bold", 16);
   private final ObservableList<SpectralDBAnnotation> totalMatches;
@@ -84,10 +86,10 @@ public class SpectraIdentificationResultsWindowFX extends SimpleTab {
 
   private final Map<SpectralDBAnnotation, SpectralMatchPanelFX> matchPanels;
   private final VBox mainBox;
-  // couple y zoom (if one is changed - change the other in a mirror plot)
-  private boolean isCouplingZoomY;
   private final Label noMatchesFound;
   private final BorderPane pnMain;
+  // couple y zoom (if one is changed - change the other in a mirror plot)
+  private boolean isCouplingZoomY;
   private int currentIndex = 0;
   private int showBestN = 15;
   private Label shownMatchesLbl;
@@ -99,6 +101,8 @@ public class SpectraIdentificationResultsWindowFX extends SimpleTab {
 
   public SpectraIdentificationResultsWindowFX(@Nullable final FeatureTableFX table) {
     super("Spectral matches", false, false);
+    setOnCloseRequest(event -> weak.dipose());
+
     addRowSelectionListener(table);
 
     totalMatches = FXCollections.observableList(Collections.synchronizedList(new ArrayList<>()));
@@ -127,15 +131,18 @@ public class SpectraIdentificationResultsWindowFX extends SimpleTab {
     if (table == null) {
       return;
     }
-    table.getSelectedTableRows()
-        .addListener((ListChangeListener<? super TreeItem<ModularFeatureListRow>>) c -> {
-          var rows = c.getList().stream().map(TreeItem::getValue).toList();
-          var allMatches = rows.stream().map(ModularFeatureListRow::getSpectralLibraryMatches)
-              .flatMap(Collection::stream).toList();
-          setMatches(allMatches);
+    weak.addListChangeListener(table.getSelectedTableRows(), c -> {
+      if (weak.isDisposed()) {
+        return;
+      }
 
-          setTitle(rows);
-        });
+      var rows = c.getList().stream().map(TreeItem::getValue).toList();
+      var allMatches = rows.stream().map(ModularFeatureListRow::getSpectralLibraryMatches)
+          .flatMap(Collection::stream).toList();
+      setMatches(allMatches);
+
+      setTitle(rows);
+    });
   }
 
 

--- a/src/main/java/io/github/mzmine/util/javafx/WeakAdapter.java
+++ b/src/main/java/io/github/mzmine/util/javafx/WeakAdapter.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2004-2023 The MZmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.util.javafx;
+
+import java.util.ArrayList;
+import java.util.List;
+import javafx.beans.InvalidationListener;
+import javafx.beans.Observable;
+import javafx.beans.WeakInvalidationListener;
+import javafx.beans.binding.BooleanExpression;
+import javafx.beans.binding.StringExpression;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.StringProperty;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
+import javafx.beans.value.WeakChangeListener;
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
+import javafx.collections.WeakListChangeListener;
+
+/**
+ * WeakChangeListeners etc need to keep a reference to the listener inside, otherwise its garbage
+ * collected too soon. Add all listeners to objects like this:
+ * <pre>
+ *   weak = new WeakAdapter();
+ *   weak.addChangeListener(myProperty, new ChangeListener<> (){});
+ * </pre>
+ * After use call dispose or remove individual listeners.
+ */
+public class WeakAdapter {
+
+  private final List<Object> listenerRefs = new ArrayList<>();
+
+  public WeakAdapter() {
+  }
+
+  public void dipose() {
+    listenerRefs.clear();
+  }
+
+  public final <T> void remove(ChangeListener<T> listener) {
+    listenerRefs.remove(listener);
+  }
+
+  public final <T> void addChangeListener(final ObservableValue observable,
+      ChangeListener<T> listener) {
+    listenerRefs.add(listener);
+    observable.addListener(new WeakChangeListener<>(listener));
+  }
+
+  public final <T> void addListChangeListener(ObservableList<T> list,
+      ListChangeListener<T> listener) {
+    list.addListener(addListChangeListener(listener));
+  }
+
+  public final <T> WeakListChangeListener<T> addListChangeListener(ListChangeListener<T> listener) {
+    listenerRefs.add(listener);
+    return new WeakListChangeListener<>(listener);
+  }
+
+  public void addInvalidationListener(final Observable listened, InvalidationListener listener) {
+    listenerRefs.add(listener);
+    listened.addListener(new WeakInvalidationListener(listener));
+  }
+
+  public final void stringBind(final StringProperty propertyToUpdate,
+      final StringExpression expressionToListen) {
+    ChangeListener<String> listener = new ChangeListener<String>() {
+      @Override
+      public void changed(ObservableValue<? extends String> ov, String t, String name) {
+        propertyToUpdate.set(name);
+      }
+    };
+    listenerRefs.add(listener);
+    expressionToListen.addListener(new WeakChangeListener<>(listener));
+    listener.changed(null, null, expressionToListen.get());
+  }
+
+  public final void booleanBind(final BooleanProperty propertyToUpdate,
+      final BooleanExpression expressionToListen) {
+    ChangeListener<Boolean> listener = new ChangeListener<Boolean>() {
+      @Override
+      public void changed(ObservableValue<? extends Boolean> ov, Boolean t, Boolean name) {
+        propertyToUpdate.set(name);
+      }
+    };
+    listenerRefs.add(listener);
+    expressionToListen.addListener(new WeakChangeListener<>(listener));
+    propertyToUpdate.set(expressionToListen.get());
+  }
+}

--- a/src/main/java/io/github/mzmine/util/javafx/WeakAdapter.java
+++ b/src/main/java/io/github/mzmine/util/javafx/WeakAdapter.java
@@ -53,12 +53,18 @@ import javafx.collections.WeakListChangeListener;
 public class WeakAdapter {
 
   private final List<Object> listenerRefs = new ArrayList<>();
+  private boolean isDisposed = false;
 
   public WeakAdapter() {
   }
 
   public void dipose() {
     listenerRefs.clear();
+    isDisposed = true;
+  }
+
+  public boolean isDisposed() {
+    return isDisposed;
   }
 
   public final <T> void remove(ChangeListener<T> listener) {


### PR DESCRIPTION
WeakAdapter holds references to all listeners between javafx interfaces and generated WeakListeners as wrappers. Once a tab or stage is closed we need to call dispose and that enables garbage collection on the listeners. 

Easy safe way to get rid of all listeners.