### PR TITLE
fix FragmentScanSelection in case only merged ms2s are available.

### DIFF
--- a/src/main/java/io/github/mzmine/util/scans/FragmentScanSelection.java
+++ b/src/main/java/io/github/mzmine/util/scans/FragmentScanSelection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -112,6 +112,10 @@ public record FragmentScanSelection(@NotNull MZTolerance mzTol, boolean mergeSep
     final List<Scan> noMergedScans = scans.stream().filter(
         scan -> !(scan instanceof MergedMassSpectrum merged)
             || merged.getMergingType() == MergingType.PASEF_SINGLE).toList();
+
+    if (noMergedScans.isEmpty()) {
+      return scans;
+    }
 
     Map<Float, List<Scan>> byFragmentationEnergy = ScanUtils.splitByFragmentationEnergy(
         noMergedScans);


### PR DESCRIPTION
@robinschmid what was the expected behaviour here? For tims spectra, we only retain the merged spectra after the MS2 goruping, not the individual spectra. Therefore, no "non-merged" ms2s were available and caused exceptions later on.