### PR TITLE
[GC-EI] ms workflow

### DIFF
--- a/license_header
+++ b/license_header
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2022 The MZmine Development Team
+Copyright (c) 2004-2024 The MZmine Development Team
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/license_header_intellij.xml
+++ b/license_header_intellij.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2004-2022 The MZmine Development Team
+  ~ Copyright (c) 2004-$today.year The MZmine Development Team
   ~
   ~ Permission is hereby granted, free of charge, to any person
   ~ obtaining a copy of this software and associated documentation
@@ -25,7 +25,7 @@
 
 <component name="CopyrightManager">
   <copyright>
-    <option name="notice" value="Copyright (c) 2004-2022 The MZmine Development Team&#10;&#10;Permission is hereby granted, free of charge, to any person&#10;obtaining a copy of this software and associated documentation&#10;files (the &quot;Software&quot;), to deal in the Software without&#10;restriction, including without limitation the rights to use,&#10;copy, modify, merge, publish, distribute, sublicense, and/or sell&#10;copies of the Software, and to permit persons to whom the&#10;Software is furnished to do so, subject to the following&#10;conditions:&#10;&#10;The above copyright notice and this permission notice shall be&#10;included in all copies or substantial portions of the Software.&#10;&#10;THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND,&#10;EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES&#10;OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND&#10;NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT&#10;HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,&#10;WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING&#10;FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR&#10;OTHER DEALINGS IN THE SOFTWARE." />
+    <option name="notice" value="Copyright (c) 2004-$today.year The MZmine Development Team&#10;&#10;Permission is hereby granted, free of charge, to any person&#10;obtaining a copy of this software and associated documentation&#10;files (the &quot;Software&quot;), to deal in the Software without&#10;restriction, including without limitation the rights to use,&#10;copy, modify, merge, publish, distribute, sublicense, and/or sell&#10;copies of the Software, and to permit persons to whom the&#10;Software is furnished to do so, subject to the following&#10;conditions:&#10;&#10;The above copyright notice and this permission notice shall be&#10;included in all copies or substantial portions of the Software.&#10;&#10;THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND,&#10;EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES&#10;OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND&#10;NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT&#10;HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,&#10;WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING&#10;FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR&#10;OTHER DEALINGS IN THE SOFTWARE." />
     <option name="myName" value="mzmine" />
   </copyright>
 </component>

--- a/src/main/java/io/github/mzmine/datamodel/features/FeatureList.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/FeatureList.java
@@ -35,6 +35,8 @@ import io.github.mzmine.datamodel.features.correlation.R2RNetworkingMaps;
 import io.github.mzmine.datamodel.features.correlation.RowsRelationship;
 import io.github.mzmine.datamodel.features.correlation.RowsRelationship.Type;
 import io.github.mzmine.datamodel.features.types.DataType;
+import io.github.mzmine.datamodel.features.types.DataTypes;
+import io.github.mzmine.datamodel.features.types.DataTypes;
 import io.github.mzmine.datamodel.features.types.LinkedGraphicalType;
 import io.github.mzmine.datamodel.features.types.numbers.RTType;
 import io.github.mzmine.modules.MZmineModule;
@@ -47,7 +49,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 import javafx.collections.ObservableList;
-import javafx.collections.ObservableMap;
+import javafx.collections.ObservableSet;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.w3c.dom.Element;
@@ -91,7 +93,7 @@ public interface FeatureList {
    */
   void applyRowBindings(FeatureListRow row);
 
-  ObservableMap<Class<? extends DataType>, DataType> getFeatureTypes();
+  ObservableSet<DataType> getFeatureTypes();
 
   void addFeatureType(Collection<DataType> types);
 
@@ -101,11 +103,48 @@ public interface FeatureList {
 
   void addRowType(@NotNull DataType<?>... types);
 
-  ObservableMap<Class<? extends DataType>, DataType> getRowTypes();
+  ObservableSet<DataType> getRowTypes();
 
-  boolean hasFeatureType(Class typeClass);
 
-  boolean hasRowType(Class typeClass);
+  /**
+   * Checks if typeClass was added as a FeatureType
+   *
+   * @param typeClass class of a DataType
+   * @return true if feature type is available
+   */
+  default boolean hasFeatureType(Class<? extends DataType> typeClass) {
+    return hasFeatureType(DataTypes.get(typeClass));
+  }
+
+  /**
+   * Checks if typeClass was added as a FeatureType
+   *
+   * @param type DataType
+   * @return true if feature type is available
+   */
+  default boolean hasFeatureType(DataType type) {
+    return getFeatureTypes().contains(type);
+  }
+
+  /**
+   * Checks if typeClass was added as a row type
+   *
+   * @param typeClass class of a DataType
+   * @return true if row type is available
+   */
+  default boolean hasRowType(Class<? extends DataType> typeClass) {
+    return hasRowType(DataTypes.get(typeClass));
+  }
+
+  /**
+   * Checks if typeClass was added as a row type
+   *
+   * @param type DataType
+   * @return true if row type is available
+   */
+  default boolean hasRowType(DataType type) {
+    return getRowTypes().contains(type);
+  }
 
   /**
    * Returns number of raw data files participating in the feature list

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeature.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -68,13 +68,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javafx.collections.FXCollections;
 import javafx.collections.MapChangeListener;
 import javafx.collections.ObservableMap;
-import javafx.scene.Node;
-import javafx.scene.layout.Pane;
+import javafx.collections.SetChangeListener;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -96,17 +96,23 @@ public class ModularFeature implements Feature, ModularDataModel {
   public ModularFeature(@NotNull ModularFeatureList flist) {
     this.flist = flist;
 
+    // TODO turn into weak bindings? with WeakAdapter in FeatureList
     // register listener to types map to automatically generate default properties for new DataTypes
-    flist.getFeatureTypes().addListener(
-        (MapChangeListener<? super Class<? extends DataType>, ? super DataType>) change -> {
-          if (change.wasAdded()) {
-            // do nothing for now
-          } else if (change.wasRemoved()) {
-            // remove type columns to maps
-            DataType type = change.getValueRemoved();
-            this.remove((Class) type.getClass());
-          }
-        });
+    flist.getFeatureTypes().addListener((SetChangeListener<? super DataType>) change -> {
+      if (change.wasAdded()) {
+        // do nothing for now
+      } else if (change.wasRemoved()) {
+        // remove type columns to maps
+        DataType type = change.getElementRemoved();
+        this.remove(type);
+      }
+    });
+    //
+    map.addListener((MapChangeListener<? super DataType, ? super Object>) change -> {
+      if (change.wasAdded()) {
+        flist.addFeatureType(change.getKey());
+      }
+    });
   }
 
   // NOT TESTED
@@ -194,10 +200,11 @@ public class ModularFeature implements Feature, ModularDataModel {
   /**
    * Creates a new feature.
    *
-   * @param flist         The feature list.
-   * @param dataFile      The raw data file of this feature.
+   * @param flist    The feature list.
+   * @param dataFile The raw data file of this feature.
    */
-  public ModularFeature(ModularFeatureList flist, RawDataFile dataFile, FeatureStatus featureStatus) {
+  public ModularFeature(ModularFeatureList flist, RawDataFile dataFile,
+      FeatureStatus featureStatus) {
     this(flist);
     assert dataFile != null;
 
@@ -284,7 +291,7 @@ public class ModularFeature implements Feature, ModularDataModel {
   }
 
   @Override
-  public ObservableMap<Class<? extends DataType>, DataType> getTypes() {
+  public Set<DataType> getTypes() {
     return flist.getFeatureTypes();
   }
 

--- a/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureListRow.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureListRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -77,14 +77,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 import javafx.collections.FXCollections;
 import javafx.collections.MapChangeListener;
 import javafx.collections.ObservableList;
 import javafx.collections.ObservableMap;
-import javafx.scene.Node;
-import javafx.scene.layout.Pane;
+import javafx.collections.SetChangeListener;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -120,16 +120,21 @@ public class ModularFeatureListRow implements FeatureListRow {
     this.flist = flist;
 
     // register listener to types map to automatically generate default properties for new DataTypes
-    flist.getRowTypes().addListener(
-        (MapChangeListener<? super Class<? extends DataType>, ? super DataType>) change -> {
-          if (change.wasAdded()) {
-            // do nothing for now
-          } else if (change.wasRemoved()) {
-            // remove type columns to maps
-            DataType type = change.getValueRemoved();
-            this.remove((Class) type.getClass());
-          }
-        });
+    flist.getRowTypes().addListener((SetChangeListener<? super DataType>) change -> {
+      if (change.wasAdded()) {
+        // do nothing for now
+      } else if (change.wasRemoved()) {
+        // remove type columns to maps
+        DataType type = change.getElementRemoved();
+        this.remove(type);
+      }
+    });
+    //
+    map.addListener((MapChangeListener<? super DataType, ? super Object>) change -> {
+      if (change.wasAdded()) {
+        flist.addRowType(change.getKey());
+      }
+    });
 
     // features
     List<RawDataFile> raws = flist.getRawDataFiles();
@@ -199,7 +204,7 @@ public class ModularFeatureListRow implements FeatureListRow {
   }
 
   @Override
-  public ObservableMap<Class<? extends DataType>, DataType> getTypes() {
+  public Set<DataType> getTypes() {
     return flist.getRowTypes();
   }
 

--- a/src/main/java/io/github/mzmine/datamodel/features/SimpleModularDataModel.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/SimpleModularDataModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -27,7 +27,6 @@ package io.github.mzmine.datamodel.features;
 
 import io.github.mzmine.datamodel.features.types.DataType;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableMap;
 
@@ -38,14 +37,6 @@ import javafx.collections.ObservableMap;
 public class SimpleModularDataModel implements ModularDataModel {
 
   private final ObservableMap<DataType, Object> map = FXCollections.observableMap(new HashMap<>());
-
-  private final ObservableMap<Class<? extends DataType>, DataType> types = FXCollections.observableMap(
-      new LinkedHashMap<>());
-
-  @Override
-  public ObservableMap<Class<? extends DataType>, DataType> getTypes() {
-    return types;
-  }
 
   @Override
   public ObservableMap<DataType, Object> getMap() {

--- a/src/main/java/io/github/mzmine/datamodel/features/types/DataTypes.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/DataTypes.java
@@ -91,9 +91,14 @@ public class DataTypes {
 
   private static final Logger logger = Logger.getLogger(DataTypes.class.getName());
 
-  // map class to instance
-  private static final HashMap<Class<? extends DataType>, DataType> TYPES = new HashMap<>();
-  // map unique ID to instance
+  /**
+   * map class.name to instance. Cannot use class as key as this leads to memory leaks trhough class
+   * loader
+   */
+  private static final HashMap<String, DataType> TYPES = new HashMap<>();
+  /**
+   * map unique ID to instance
+   */
   private static final HashMap<String, DataType<?>> map = new HashMap<>();
 
   static {
@@ -110,7 +115,7 @@ public class DataTypes {
                       "FATAL: Multiple data types with unique ID " + dt.getUniqueID() + "\n"
                       + value.getClass().getName() + "\n" + dt.getClass().getName());
                 }
-                TYPES.put(dt.getClass(), dt);
+                TYPES.put(dt.getClass().getName(), dt);
               }
             } catch (InstantiationException | IllegalAccessException | InvocationTargetException |
                      NoSuchMethodException e) {
@@ -131,12 +136,16 @@ public class DataTypes {
     return map.get(uniqueId);
   }
 
-  public static <T> DataType<T> get(DataType<T> instance) {
-    return get((Class) instance.getClass());
+  public static <T extends DataType<?>> T get(T instance) {
+    return (T) get(instance.getClass().getName());
   }
 
-  public static <T> DataType<T> get(Class<? extends DataType<T>> clazz) {
-    return TYPES.get(clazz);
+  public static <T extends DataType<?>> T get(Class<T> clazz) {
+    return (T) TYPES.get(clazz.getName());
+  }
+
+  public static DataType get(String className) {
+    return TYPES.get(className);
   }
 
   /**
@@ -144,7 +153,7 @@ public class DataTypes {
    */
   @SafeVarargs
   public static List<DataType> getAll(final Class<? extends DataType<?>>... classes) {
-    return Arrays.stream(classes).map(c -> TYPES.get(c)).toList();
+    return Arrays.stream(classes).map(c -> TYPES.get(c.getName())).toList();
   }
 
   /**
@@ -154,7 +163,7 @@ public class DataTypes {
     return TYPES.values();
   }
 
-  public static Collection<Class<? extends DataType>> getClasses() {
+  public static Collection<String> getClasses() {
     return TYPES.keySet();
   }
 
@@ -194,5 +203,20 @@ public class DataTypes {
       prioMap.put(DataTypes.get(aClass), i++);
     }
     return prioMap;
+  }
+
+  /**
+   * Check if type of clazz is contained in a collection of types
+   *
+   * @param types collection of types
+   * @param clazz type class
+   * @param <T>   data value type
+   * @return the data type if it is contained. otherwise null
+   */
+  @Nullable
+  public static <T> DataType<T> getOrNull(final Collection<? extends DataType> types,
+      final Class<? extends DataType<T>> clazz) {
+    DataType<T> type = DataTypes.get(clazz);
+    return types.contains(type) ? type : null;
   }
 }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/abstr/SimpleSubColumnsType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/abstr/SimpleSubColumnsType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -116,7 +116,7 @@ public abstract class SimpleSubColumnsType<T extends ModularDataRecord> extends
     // create column per name
     for (int index = 0; index < subTypes.size(); index++) {
       DataType type = subTypes.get(index);
-      if (this.getClass().isInstance(type)) {
+      if (this.equals(type)) {
         // create a special column for this type that actually represents the list of data
         cols.add(DataType.createStandardColumn(type, raw, this, index));
       } else {

--- a/src/main/java/io/github/mzmine/datamodel/features/types/annotations/CompoundDatabaseMatchesType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/annotations/CompoundDatabaseMatchesType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -49,7 +49,6 @@ import io.github.mzmine.datamodel.features.types.numbers.scores.IsotopePatternSc
 import io.github.mzmine.modules.io.projectload.version_3_0.CONST;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
 import java.util.logging.Logger;
 import javax.xml.stream.XMLStreamException;
@@ -69,23 +68,12 @@ public class CompoundDatabaseMatchesType extends ListWithSubsType<CompoundDBAnno
 
   private static final Logger logger = Logger.getLogger(
       CompoundDatabaseMatchesType.class.getName());
-  private static final Map<Class<? extends DataType>, Function<CompoundDBAnnotation, Object>> mapper = Map.ofEntries(
-      //
-      createEntry(CompoundDatabaseMatchesType.class, CompoundDBAnnotation::getCompoundName), //
-      createEntry(CompoundNameType.class, CompoundDBAnnotation::getCompoundName), //
-      createEntry(CompoundAnnotationScoreType.class, CompoundDBAnnotation::getScore),
-      createEntry(FormulaType.class, CompoundDBAnnotation::getFormula), //
-      createEntry(IonTypeType.class, CompoundDBAnnotation::getAdductType), //
-      createEntry(SmilesStructureType.class, CompoundDBAnnotation::getSmiles), //
-      createEntry(InChIStructureType.class, match -> match.get(new InChIStructureType())), //
-      createEntry(PrecursorMZType.class, CompoundDBAnnotation::getPrecursorMZ), //
-      createEntry(MzPpmDifferenceType.class, match -> match.get(MzPpmDifferenceType.class)), //
-      createEntry(NeutralMassType.class, match -> match.get(new NeutralMassType())), //
-      createEntry(RTType.class, match -> match.get(new RTType())), //
-      createEntry(CCSType.class, CompoundDBAnnotation::getCCS),
-      createEntry(DatabaseMatchInfoType.class, match -> match.get(DatabaseMatchInfoType.class)),
-      createEntry(CommentType.class, match -> match.get(CommentType.class)),
-      createEntry(IsotopePatternScoreType.class, match -> match.get(IsotopePatternScoreType.class)));
+
+  @Override
+  protected <K> @Nullable K map(@NotNull final DataType<K> subType,
+      final CompoundDBAnnotation item) {
+    return item.get(subType);
+  }
 
   public CompoundDatabaseMatchesType() {
   }
@@ -111,11 +99,6 @@ public class CompoundDatabaseMatchesType extends ListWithSubsType<CompoundDBAnno
   }
 
   @Override
-  protected Map<Class<? extends DataType>, Function<CompoundDBAnnotation, Object>> getMapper() {
-    return mapper;
-  }
-
-  @Override
   public void saveToXML(@NotNull XMLStreamWriter writer, @Nullable Object value,
       @NotNull ModularFeatureList flist, @NotNull ModularFeatureListRow row,
       @Nullable ModularFeature feature, @Nullable RawDataFile file) throws XMLStreamException {
@@ -126,7 +109,7 @@ public class CompoundDatabaseMatchesType extends ListWithSubsType<CompoundDBAnno
     if (!(value instanceof List<?> list)) {
       throw new IllegalArgumentException(
           "Wrong value type for data type: " + this.getClass().getName() + " value class: "
-              + value.getClass());
+          + value.getClass());
     }
 
     for (Object o : list) {
@@ -142,7 +125,7 @@ public class CompoundDatabaseMatchesType extends ListWithSubsType<CompoundDBAnno
       @NotNull ModularFeatureList flist, @NotNull ModularFeatureListRow row,
       @Nullable ModularFeature feature, @Nullable RawDataFile file) throws XMLStreamException {
     if (!(reader.isStartElement() && reader.getLocalName().equals(CONST.XML_DATA_TYPE_ELEMENT)
-        && reader.getAttributeValue(null, CONST.XML_DATA_TYPE_ID_ATTR).equals(getUniqueID()))) {
+          && reader.getAttributeValue(null, CONST.XML_DATA_TYPE_ID_ATTR).equals(getUniqueID()))) {
       throw new IllegalStateException("Wrong element");
     }
 

--- a/src/main/java/io/github/mzmine/datamodel/features/types/annotations/GNPSSpectralLibraryMatchesType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/annotations/GNPSSpectralLibraryMatchesType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -34,9 +34,8 @@ import io.github.mzmine.datamodel.features.types.numbers.scores.CosineScoreType;
 import io.github.mzmine.modules.dataprocessing.id_gnpsresultsimport.GNPSLibraryMatch;
 import io.github.mzmine.modules.dataprocessing.id_gnpsresultsimport.GNPSLibraryMatch.ATT;
 import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * This type has multiple sub columns
@@ -48,40 +47,33 @@ public class GNPSSpectralLibraryMatchesType extends ListWithSubsType<GNPSLibrary
 
   // Unmodifiable list of all subtypes
   private static final List<DataType> subTypes = List.of(new GNPSSpectralLibraryMatchesType(),
-      new CompoundNameType(), new IonAdductType(),
-      new SmilesStructureType(), new InChIStructureType(),
-      new CosineScoreType(), new MatchingSignalsType(), new GNPSLibraryUrlType(),
-      new GNPSClusterUrlType(), new GNPSNetworkUrlType());
+      new CompoundNameType(), new IonAdductType(), new SmilesStructureType(),
+      new InChIStructureType(), new CosineScoreType(), new MatchingSignalsType(),
+      new GNPSLibraryUrlType(), new GNPSClusterUrlType(), new GNPSNetworkUrlType());
 
-  private static final Map<Class<? extends DataType>, Function<GNPSLibraryMatch, Object>> mapper =
-      Map.ofEntries(
-          createEntry(GNPSSpectralLibraryMatchesType.class, match -> match),
-          createEntry(CompoundNameType.class,
-              match -> match.getResultOr(ATT.COMPOUND_NAME, "NONAME")),
-          createEntry(IonAdductType.class, match -> match.getResultOr(ATT.ADDUCT, "")),
-          createEntry(SmilesStructureType.class, match -> match.getResultOr(ATT.SMILES, "")),
-          createEntry(InChIStructureType.class, match -> match.getResultOr(ATT.INCHI, "")),
-          createEntry(CosineScoreType.class,
-              match -> match.getResultOr(ATT.LIBRARY_MATCH_SCORE, null)),
-          createEntry(MatchingSignalsType.class,
-              match -> match.getResultOr(ATT.SHARED_SIGNALS, null)),
-          createEntry(GNPSLibraryUrlType.class,
-              match -> match.getResultOr(ATT.GNPS_LIBRARY_URL, null)),
-          createEntry(GNPSClusterUrlType.class,
-              match -> match.getResultOr(ATT.GNPS_CLUSTER_URL, null)),
-          createEntry(GNPSNetworkUrlType.class,
-              match -> match.getResultOr(ATT.GNPS_NETWORK_URL, null))
-      );
-
-  @Override
-  protected Map<Class<? extends DataType>, Function<GNPSLibraryMatch, Object>> getMapper() {
-    return mapper;
-  }
 
   @NotNull
   @Override
   public List<DataType> getSubDataTypes() {
     return subTypes;
+  }
+
+  @Override
+  protected <K> @Nullable K map(@NotNull final DataType<K> subType, final GNPSLibraryMatch match) {
+    return (K) switch (subType) {
+      case GNPSSpectralLibraryMatchesType __ -> match;
+      case CompoundNameType __ -> match.getResultOr(ATT.COMPOUND_NAME, "NONAME");
+      case IonAdductType __ -> match.getResultOr(ATT.ADDUCT, "");
+      case SmilesStructureType __ -> match.getResultOr(ATT.SMILES, "");
+      case InChIStructureType __ -> match.getResultOr(ATT.INCHI, "");
+      case CosineScoreType __ -> match.getResultOr(ATT.LIBRARY_MATCH_SCORE, null);
+      case MatchingSignalsType __ -> match.getResultOr(ATT.SHARED_SIGNALS, null);
+      case GNPSLibraryUrlType __ -> match.getResultOr(ATT.GNPS_LIBRARY_URL, null);
+      case GNPSClusterUrlType __ -> match.getResultOr(ATT.GNPS_CLUSTER_URL, null);
+      case GNPSNetworkUrlType __ -> match.getResultOr(ATT.GNPS_NETWORK_URL, null);
+      default -> throw new UnsupportedOperationException(
+          "DataType %s is not covered in map".formatted(subType.toString()));
+    };
   }
 
 

--- a/src/main/java/io/github/mzmine/datamodel/features/types/annotations/ManualAnnotationType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/annotations/ManualAnnotationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -110,7 +110,9 @@ public class ManualAnnotationType extends DataType<ManualAnnotation> implements 
     }
 
     final ManualAnnotation manual = new ManualAnnotation();
-    model.getTypes().values().forEach(type -> manual.set(type, model.get(type)));
+    for (DataType type : model.getTypes()) {
+      manual.set(type, model.get(type));
+    }
     return manual;
   }
 
@@ -129,7 +131,7 @@ public class ManualAnnotationType extends DataType<ManualAnnotation> implements 
     // create column per name
     for (int index = 0; index < getNumberOfSubColumns(); index++) {
       DataType type = subTypes.get(index);
-      if (this.getClass().isInstance(type)) {
+      if (this.equals(type)) {
         // create a special column for this type that actually represents the list of data
         cols.add(DataType.createStandardColumn(type, raw, this, index));
       } else {

--- a/src/main/java/io/github/mzmine/datamodel/features/types/annotations/SpectralLibraryMatchesType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/annotations/SpectralLibraryMatchesType.java
@@ -47,10 +47,9 @@ import io.github.mzmine.modules.io.projectload.version_3_0.CONST;
 import io.github.mzmine.util.spectraldb.entry.DBEntryField;
 import io.github.mzmine.util.spectraldb.entry.SpectralDBAnnotation;
 import io.github.mzmine.util.spectraldb.entry.SpectralDBFeatureIdentity;
+import io.github.mzmine.util.spectraldb.entry.SpectralLibraryEntry;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
@@ -65,36 +64,11 @@ import org.jetbrains.annotations.Nullable;
 public class SpectralLibraryMatchesType extends ListWithSubsType<SpectralDBAnnotation> implements
     AnnotationType {
 
-  private static final Map<Class<? extends DataType>, Function<SpectralDBAnnotation, Object>> mapper = Map.ofEntries(
-      createEntry(SpectralLibraryMatchesType.class, match -> match),
-      createEntry(CompoundNameType.class,
-          match -> match.getEntry().getField(DBEntryField.NAME).orElse("").toString()),
-      createEntry(FormulaType.class,
-          match -> match.getEntry().getField(DBEntryField.FORMULA).orElse("").toString()),
-      createEntry(IonAdductType.class,
-          match -> match.getEntry().getField(DBEntryField.ION_TYPE).orElse("").toString()),
-      createEntry(SmilesStructureType.class,
-          match -> match.getEntry().getField(DBEntryField.SMILES).orElse("").toString()),
-      createEntry(InChIStructureType.class,
-          match -> match.getEntry().getField(DBEntryField.INCHI).orElse("").toString()),
-      createEntry(CosineScoreType.class, match -> (float) match.getSimilarity().getScore()),
-      createEntry(MatchingSignalsType.class, match -> match.getSimilarity().getOverlap()),
-      createEntry(PrecursorMZType.class,
-          match -> match.getEntry().getField(DBEntryField.PRECURSOR_MZ).orElse(null)),
-      createEntry(NeutralMassType.class,
-          match -> match.getEntry().getField(DBEntryField.EXACT_MASS).orElse(null)),
-      createEntry(CCSType.class, match -> match.getEntry().getOrElse(DBEntryField.CCS, null)),
-      createEntry(CCSRelativeErrorType.class, SpectralDBAnnotation::getCCSError));
   // Unmodifiable list of all subtypes
   private static final List<DataType> subTypes = List.of(new SpectralLibraryMatchesType(),
       new CompoundNameType(), new IonAdductType(), new FormulaType(), new SmilesStructureType(),
       new InChIStructureType(), new PrecursorMZType(), new NeutralMassType(), new CosineScoreType(),
       new MatchingSignalsType(), new CCSType(), new CCSRelativeErrorType());
-
-  @Override
-  protected Map<Class<? extends DataType>, Function<SpectralDBAnnotation, Object>> getMapper() {
-    return mapper;
-  }
 
   @NotNull
   @Override
@@ -107,6 +81,28 @@ public class SpectralLibraryMatchesType extends ListWithSubsType<SpectralDBAnnot
   @Override
   public List<DataType> getSubDataTypes() {
     return subTypes;
+  }
+
+  @Override
+  protected <K> @Nullable K map(@NotNull final DataType<K> subType,
+      final SpectralDBAnnotation match) {
+    final SpectralLibraryEntry entry = match.getEntry();
+    return (K) switch (subType) {
+      case SpectralLibraryMatchesType __ -> match;
+      case CompoundNameType __ -> entry.getField(DBEntryField.NAME).orElse("").toString();
+      case FormulaType __ -> entry.getField(DBEntryField.FORMULA).orElse("").toString();
+      case IonAdductType __ -> entry.getField(DBEntryField.ION_TYPE).orElse("").toString();
+      case SmilesStructureType __ -> entry.getField(DBEntryField.SMILES).orElse("").toString();
+      case InChIStructureType __ -> entry.getField(DBEntryField.INCHI).orElse("").toString();
+      case CosineScoreType __ -> (float) match.getSimilarity().getScore();
+      case MatchingSignalsType __ -> match.getSimilarity().getOverlap();
+      case PrecursorMZType __ -> entry.getField(DBEntryField.PRECURSOR_MZ).orElse(null);
+      case NeutralMassType __ -> entry.getField(DBEntryField.EXACT_MASS).orElse(null);
+      case CCSType __ -> entry.getOrElse(DBEntryField.CCS, null);
+      case CCSRelativeErrorType __ -> match.getCCSError();
+      default -> throw new UnsupportedOperationException(
+          "DataType %s is not covered in map".formatted(subType.toString()));
+    };
   }
 
   @NotNull

--- a/src/main/java/io/github/mzmine/datamodel/features/types/annotations/formula/FormulaListType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/annotations/formula/FormulaListType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -43,8 +43,6 @@ import io.github.mzmine.modules.dataprocessing.id_formulaprediction.ResultFormul
 import io.github.mzmine.modules.io.projectload.version_3_0.CONST;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
@@ -52,15 +50,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * A collection of annotation types related to a list of molecular formulas stored in the {@link
- * SimpleFormulaListType}. Includes scores, neutral mass, etc.
+ * A collection of annotation types related to a list of molecular formulas stored in the
+ * {@link SimpleFormulaListType}. Includes scores, neutral mass, etc.
  */
 public class FormulaListType extends ListWithSubsType<ResultFormula> implements AnnotationType {
-
-  @Override
-  public boolean getDefaultVisibility() {
-    return true;
-  }
 
   // Unmodifiable list of all subtypes
   private static final List<DataType> subTypes = List.of(new FormulaListType(),
@@ -68,15 +61,10 @@ public class FormulaListType extends ListWithSubsType<ResultFormula> implements 
       new MzAbsoluteDifferenceType(), new IsotopePatternScoreType(), new MsMsScoreType(),
       new CombinedScoreType());
 
-  private static final Map<Class<? extends DataType>, Function<ResultFormula, Object>> mapper = Map.ofEntries(
-      createEntry(FormulaListType.class, formula -> formula),
-      createEntry(FormulaMassType.class, formula -> formula.getExactMass()),
-      createEntry(RdbeType.class, formula -> formula.getRDBE()),
-      createEntry(MzPpmDifferenceType.class, formula -> formula.getPpmDiff()),
-      createEntry(MzAbsoluteDifferenceType.class, formula -> formula.getAbsoluteMzDiff()),
-      createEntry(IsotopePatternScoreType.class, formula -> formula.getIsotopeScore()),
-      createEntry(MsMsScoreType.class, formula -> formula.getMSMSScore()),
-      createEntry(CombinedScoreType.class, formula -> formula.getScore(10, 3, 1)));
+  @Override
+  public boolean getDefaultVisibility() {
+    return true;
+  }
 
   @NotNull
   @Override
@@ -85,8 +73,19 @@ public class FormulaListType extends ListWithSubsType<ResultFormula> implements 
   }
 
   @Override
-  protected Map<Class<? extends DataType>, Function<ResultFormula, Object>> getMapper() {
-    return mapper;
+  protected <K> @Nullable K map(@NotNull final DataType<K> subType, final ResultFormula formula) {
+    return (K) switch (subType) {
+      case FormulaListType __ -> formula;
+      case FormulaMassType __ -> formula.getExactMass();
+      case RdbeType __ -> formula.getRDBE();
+      case MzPpmDifferenceType __ -> formula.getPpmDiff();
+      case MzAbsoluteDifferenceType __ -> formula.getAbsoluteMzDiff();
+      case IsotopePatternScoreType __ -> formula.getIsotopeScore();
+      case MsMsScoreType __ -> formula.getMSMSScore();
+      case CombinedScoreType __ -> formula.getScore(10, 3, 1);
+      default -> throw new UnsupportedOperationException(
+          "DataType %s is not covered in map".formatted(subType.toString()));
+    };
   }
 
   @NotNull
@@ -130,7 +129,7 @@ public class FormulaListType extends ListWithSubsType<ResultFormula> implements 
       @NotNull ModularFeatureList flist, @NotNull ModularFeatureListRow row,
       @Nullable ModularFeature feature, @Nullable RawDataFile file) throws XMLStreamException {
     if (!(reader.isStartElement() && reader.getLocalName().equals(CONST.XML_DATA_TYPE_ELEMENT)
-        && reader.getAttributeValue(null, CONST.XML_DATA_TYPE_ID_ATTR).equals(getUniqueID()))) {
+          && reader.getAttributeValue(null, CONST.XML_DATA_TYPE_ID_ATTR).equals(getUniqueID()))) {
       throw new IllegalStateException("Wrong element");
     }
 
@@ -142,7 +141,7 @@ public class FormulaListType extends ListWithSubsType<ResultFormula> implements 
         continue;
       }
 
-      if(reader.getLocalName().equals(ResultFormula.XML_ELEMENT)) {
+      if (reader.getLocalName().equals(ResultFormula.XML_ELEMENT)) {
         final ResultFormula formula = ResultFormula.loadFromXML(reader);
         formulas.add(formula);
       }

--- a/src/main/java/io/github/mzmine/datamodel/features/types/numbers/SimpleStatisticsType.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/numbers/SimpleStatisticsType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -44,7 +44,6 @@ import io.github.mzmine.main.MZmineCore;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.control.TreeTableColumn;
@@ -245,11 +244,6 @@ public abstract class SimpleStatisticsType extends NumberType<SimpleStatistics> 
     return new SimpleStatistics(model.getNonNullElse(MinimumType.class, 0d),
         model.getNonNullElse(MeanType.class, 0d), model.getNonNullElse(MaximumType.class, 0d),
         model.getNonNullElse(ClassificationType.class, ""));
-  }
-
-  private static <T> T getOrDefault(final Map<Class<? extends DataType>, Object> values,
-      T defaultValue) {
-    return (T) values.getOrDefault(MinimumType.class, defaultValue);
   }
 
 }

--- a/src/main/java/io/github/mzmine/datamodel/identities/iontype/IonIdentity.java
+++ b/src/main/java/io/github/mzmine/datamodel/identities/iontype/IonIdentity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -40,6 +40,7 @@ import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -401,8 +402,8 @@ public class IonIdentity implements Comparable<IonIdentity> {
    *
    * @return
    */
-  public ResultFormula getBestMolFormula() {
-    return molFormulas == null || molFormulas.isEmpty() ? null : molFormulas.get(0);
+  public Optional<ResultFormula> getBestMolFormula() {
+    return molFormulas.isEmpty() ? Optional.empty() : Optional.of(molFormulas.get(0));
   }
 
 

--- a/src/main/java/io/github/mzmine/main/MZmineCore.java
+++ b/src/main/java/io/github/mzmine/main/MZmineCore.java
@@ -63,7 +63,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Hashtable;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -91,7 +91,7 @@ public final class MZmineCore {
   private final Desktop defaultHeadlessDesktop = new HeadLessDesktop();
   private final List<MemoryMapStorage> storageList = Collections.synchronizedList(
       new ArrayList<>());
-  private final Map<Class<?>, MZmineModule> initializedModules = new Hashtable<>();
+  private final Map<String, MZmineModule> initializedModules = new HashMap<>();
   private TaskControllerImpl taskController;
   private MZmineConfiguration configuration;
   private Desktop desktop;
@@ -336,8 +336,11 @@ public final class MZmineCore {
   @SuppressWarnings("unchecked")
   public synchronized static <ModuleType extends MZmineModule> ModuleType getModuleInstance(
       Class<ModuleType> moduleClass) {
+    if (moduleClass == null) {
+      return null;
+    }
 
-    ModuleType module = (ModuleType) getInstance().initializedModules.get(moduleClass);
+    ModuleType module = (ModuleType) getInstance().initializedModules.get(moduleClass.getName());
 
     if (module == null) {
 
@@ -349,7 +352,7 @@ public final class MZmineCore {
         module = moduleClass.getDeclaredConstructor().newInstance();
 
         // Add to the module list
-        getInstance().initializedModules.put(moduleClass, module);
+        getInstance().initializedModules.put(moduleClass.getName(), module);
 
       } catch (Throwable e) {
         logger.log(Level.SEVERE, "Could not start module " + moduleClass, e);

--- a/src/main/java/io/github/mzmine/main/impl/MZmineConfigurationImpl.java
+++ b/src/main/java/io/github/mzmine/main/impl/MZmineConfigurationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -80,12 +80,15 @@ public class MZmineConfigurationImpl implements MZmineConfiguration {
 
   private final EncryptionKeyParameter globalEncrypter;
 
-  private final Map<Class<? extends MZmineModule>, ParameterSet> moduleParameters;
+  /**
+   * class.getName is used as keys. Classes should not be used as keys in maps
+   */
+  private final Map<String, ParameterSet> moduleParameters;
 
   private final EStandardChartTheme standardChartTheme;
 
   public MZmineConfigurationImpl() {
-    moduleParameters = new Hashtable<Class<? extends MZmineModule>, ParameterSet>();
+    moduleParameters = new Hashtable<>();
     preferences = new MZminePreferences();
     lastProjects = new FileNameListSilentParameter("Last projects");
     globalEncrypter = new EncryptionKeyParameter();
@@ -105,7 +108,11 @@ public class MZmineConfigurationImpl implements MZmineConfiguration {
    */
   @Override
   public @Nullable ParameterSet getModuleParameters(Class<? extends MZmineModule> moduleClass) {
-    ParameterSet parameters = moduleParameters.get(moduleClass);
+    if (moduleClass == null) {
+      return null;
+    }
+
+    ParameterSet parameters = moduleParameters.get(moduleClass.getName());
     if (parameters == null) {
       // Create an instance of parameter set
       try {
@@ -125,21 +132,21 @@ public class MZmineConfigurationImpl implements MZmineConfiguration {
         try {
           parameters = parameterSetClass.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
-          e.printStackTrace();
           logger.log(Level.SEVERE,
-              "Could not create an instance of parameter set class " + parameterSetClass, e);
+              "Could not create an instance of parameter set class " + parameterSetClass + " "
+              + e.getMessage(), e);
           return null;
         }
       } catch (NoClassDefFoundError | Exception e) {
-        e.printStackTrace();
         logger.log(Level.WARNING,
-            "Could not find the module or parameter class " + moduleClass.toString(), e);
+            "Could not find the module or parameter class " + moduleClass.toString() + " "
+            + e.getMessage(), e);
         return null;
       }
 
       // Add the parameter set to the configuration
       parameters.setModuleNameAttribute(MZmineCore.getModuleInstance(moduleClass).getName());
-      moduleParameters.put(moduleClass, parameters);
+      moduleParameters.put(moduleClass.getName(), parameters);
 
     }
     return parameters;
@@ -160,7 +167,7 @@ public class MZmineConfigurationImpl implements MZmineConfiguration {
           "Given parameter set is an instance of " + parameters.getClass() + " instead of "
           + parametersClass);
     }
-    moduleParameters.put(moduleClass, parameters);
+    moduleParameters.put(moduleClass.getName(), parameters);
 
   }
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/adap_hierarchicalclustering/ADAP3DecompositionV1_5Parameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/adap_hierarchicalclustering/ADAP3DecompositionV1_5Parameters.java
@@ -24,8 +24,6 @@
  */
 package io.github.mzmine.modules.dataprocessing.adap_hierarchicalclustering;
 
-import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
-import java.text.NumberFormat;
 import dulab.adap.workflow.TwoStepDecompositionParameters;
 import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
@@ -33,9 +31,12 @@ import io.github.mzmine.parameters.parametertypes.BooleanParameter;
 import io.github.mzmine.parameters.parametertypes.ComboParameter;
 import io.github.mzmine.parameters.parametertypes.DoubleParameter;
 import io.github.mzmine.parameters.parametertypes.IntegerParameter;
+import io.github.mzmine.parameters.parametertypes.OriginalFeatureListHandlingParameter;
 import io.github.mzmine.parameters.parametertypes.StringParameter;
 import io.github.mzmine.parameters.parametertypes.ranges.ListDoubleRangeParameter;
+import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
 import io.github.mzmine.util.ExitCode;
+import java.text.NumberFormat;
 import javafx.collections.FXCollections;
 
 /**
@@ -109,15 +110,14 @@ public class ADAP3DecompositionV1_5Parameters extends SimpleParameterSet {
   public static final StringParameter SUFFIX = new StringParameter("Suffix",
       "This string is added to feature list name as suffix", "ADAP-GC 3 Peak Decomposition");
 
-  public static final BooleanParameter AUTO_REMOVE = new BooleanParameter(
-      "Remove original feature list",
-      "If checked, original chromatogram will be removed and only the deconvolved version remains");
+  public static final OriginalFeatureListHandlingParameter handleOriginal = //
+      new OriginalFeatureListHandlingParameter(false);
 
   public ADAP3DecompositionV1_5Parameters() {
     super(
-        new Parameter[] {PEAK_LISTS, MIN_CLUSTER_DISTANCE, MIN_CLUSTER_SIZE, MIN_CLUSTER_INTENSITY,
+        new Parameter[]{PEAK_LISTS, MIN_CLUSTER_DISTANCE, MIN_CLUSTER_SIZE, MIN_CLUSTER_INTENSITY,
             USE_ISSHARED, EDGE_TO_HEIGHT_RATIO, DELTA_TO_HEIGHT_RATIO, MIN_MODEL_SHARPNESS,
-            SHAPE_SIM_THRESHOLD, MODEL_PEAK_CHOICE, MZ_VALUES, SUFFIX, AUTO_REMOVE},
+            SHAPE_SIM_THRESHOLD, MODEL_PEAK_CHOICE, MZ_VALUES, SUFFIX, handleOriginal},
         "https://mzmine.github.io/mzmine_documentation/module_docs/featdet_hierarch_clustering/featdet_hierarch_clustering.html");
   }
 
@@ -125,7 +125,7 @@ public class ADAP3DecompositionV1_5Parameters extends SimpleParameterSet {
   public ExitCode showSetupDialog(boolean valueCheckRequired) {
     String message = "<html>Module Disclaimer:"
         + "<br> If you use this Spectral Deconvolution Module, please cite the "
-        + "<a href=\"https://bmcbioinformatics.biomedcentral.com/articles/10.1186/1471-2105-11-395\">MZmine2 paper</a> and the following article:"
+        + "<a href=\"https://doi.org/10.1038/s41587-023-01690-2\">MZmine 3 paper</a> and the following article:"
         + "<br><a href=\"http://pubs.acs.org/doi/10.1021/acs.jproteome.7b00633\"> Smirnov A, Jia W, Walker D, Jones D, Du X: ADAP-GC 3.2: Graphical Software Tool for "
         + "<br>Efficient Spectral Deconvolution of Gas Cromatography&mdash;High-Resolution Mass Spectrometry "
         + "<br>Metabolomics Data. J. Proteome Res 2017, DOI: 10.1021/acs.jproteome.7b00633</a>"
@@ -136,5 +136,10 @@ public class ADAP3DecompositionV1_5Parameters extends SimpleParameterSet {
 
     dialog.showAndWait();
     return dialog.getExitCode();
+  }
+
+  @Override
+  public int getVersion() {
+    return 2;
   }
 }

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/adap_mcr/ADAP3DecompositionV2Parameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/adap_mcr/ADAP3DecompositionV2Parameters.java
@@ -29,7 +29,6 @@ import io.github.mzmine.parameters.impl.SimpleParameterSet;
 import io.github.mzmine.parameters.parametertypes.BooleanParameter;
 import io.github.mzmine.parameters.parametertypes.DoubleParameter;
 import io.github.mzmine.parameters.parametertypes.IntegerParameter;
-import io.github.mzmine.parameters.parametertypes.OptionalParameter;
 import io.github.mzmine.parameters.parametertypes.OriginalFeatureListHandlingParameter;
 import io.github.mzmine.parameters.parametertypes.StringParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
@@ -43,8 +42,8 @@ public class ADAP3DecompositionV2Parameters extends SimpleParameterSet {
   public static final FeatureListsParameter PEAK_LISTS = new FeatureListsParameter("Features", 1,
       Integer.MAX_VALUE);
 
-  public static final OptionalParameter<FeatureListsParameter> CHROMATOGRAM_LISTS = new OptionalParameter<>(
-      new FeatureListsParameter("Chromatograms", 0, Integer.MAX_VALUE), false);
+  public static final FeatureListsParameter CHROMATOGRAM_LISTS =
+      new FeatureListsParameter("Chromatograms", 0, Integer.MAX_VALUE);
 
   // ------------------------------------------------------------------------
   // ----- First-phase parameters -------------------------------------------

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/adap_mcr/ADAP3DecompositionV2SetupDialog.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/adap_mcr/ADAP3DecompositionV2SetupDialog.java
@@ -26,37 +26,35 @@
 package io.github.mzmine.modules.dataprocessing.adap_mcr;
 
 
+import com.google.common.collect.Sets;
+import dulab.adap.datamodel.BetterComponent;
+import dulab.adap.datamodel.BetterPeak;
+import dulab.adap.workflow.decomposition.ComponentSelector;
+import dulab.adap.workflow.decomposition.RetTimeClusterer;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
+import io.github.mzmine.parameters.Parameter;
+import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.parameters.dialogs.ParameterSetupDialog;
 import io.github.mzmine.util.RangeUtils;
-
-import java.awt.*;
+import java.awt.Dimension;
+import java.awt.Font;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import javafx.geometry.NodeOrientation;
 import javafx.geometry.Pos;
-import javafx.scene.layout.*;
-import org.jetbrains.annotations.NotNull;
-import com.google.common.collect.Sets;
-import dulab.adap.datamodel.BetterComponent;
-import dulab.adap.datamodel.BetterPeak;
-import dulab.adap.workflow.decomposition.ComponentSelector;
-import dulab.adap.workflow.decomposition.RetTimeClusterer;
-import io.github.mzmine.parameters.Parameter;
-import io.github.mzmine.parameters.ParameterSet;
-import io.github.mzmine.parameters.dialogs.ParameterSetupDialog;
-import javafx.geometry.Orientation;
 import javafx.scene.Cursor;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.Separator;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.VBox;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * @author Du-Lab Team <dulab.binf@gmail.com>
@@ -86,12 +84,12 @@ public class ADAP3DecompositionV2SetupDialog extends ParameterSetupDialog {
   private BorderPane pnlUIElements;
   private VBox pnlComboBoxes;
   private VBox pnlPlots;
-  private CheckBox chkPreview;
-  private ComboBox<ChromatogramPeakPair> cboPeakLists;
-  private ComboBox<RetTimeClusterer.Cluster> cboClusters;
-  private Button btnRefresh;
-  private SimpleScatterPlot retTimeMZPlot;
-  private EICPlot retTimeIntensityPlot;
+  private final CheckBox chkPreview;
+  private final ComboBox<ChromatogramPeakPair> cboPeakLists;
+  private final ComboBox<RetTimeClusterer.Cluster> cboClusters;
+  private final Button btnRefresh;
+  private final SimpleScatterPlot retTimeMZPlot;
+  private final EICPlot retTimeIntensityPlot;
 
   /**
    * Current values of the parameters
@@ -262,10 +260,10 @@ public class ADAP3DecompositionV2SetupDialog extends ParameterSetupDialog {
     if (chromatogramPeakPair == null)
       return;
 
-    FeatureList chromatogramList = chromatogramPeakPair.chromatograms;
-    FeatureList peakList = chromatogramPeakPair.peaks;
-    if (chromatogramList == null || peakList == null)
-      return;
+    FeatureList chromatogramList = chromatogramPeakPair.chromatograms();
+    FeatureList peakList = chromatogramPeakPair.peaks();
+//    if (chromatogramList == null)
+//      return;
 
     Double minDistance =
         parameterSet.getParameter(ADAP3DecompositionV2Parameters.PREF_WINDOW_WIDTH).getValue();
@@ -314,10 +312,10 @@ public class ADAP3DecompositionV2SetupDialog extends ParameterSetupDialog {
     if (chromatogramPeakPair == null)
       return;
 
-    FeatureList chromatogramList = chromatogramPeakPair.chromatograms;
-    FeatureList peakList = chromatogramPeakPair.peaks;
-    if (chromatogramList == null || peakList == null)
-      return;
+    FeatureList chromatogramList = chromatogramPeakPair.chromatograms();
+    FeatureList peakList = chromatogramPeakPair.peaks();
+//    if (chromatogramList == null)
+//      return;
 
     final RetTimeClusterer.Cluster cluster = cboClusters.getSelectionModel().getSelectedItem();
     if (cluster == null)
@@ -368,7 +366,7 @@ public class ADAP3DecompositionV2SetupDialog extends ParameterSetupDialog {
       Object oldValue = currentParameters[i];
       Object newValue = newValues[i].getValue();
 
-      if (newValue != null && oldValue != null && oldValue.equals(newValue))
+      if (oldValue != null && oldValue.equals(newValue))
         continue;
 
       changedIndices.add(i);

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/adap_mcr/ADAP3DecompositionV2Task.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/adap_mcr/ADAP3DecompositionV2Task.java
@@ -32,12 +32,13 @@ import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.FeatureStatus;
 import io.github.mzmine.datamodel.IsotopePattern;
 import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.PseudoSpectrum;
+import io.github.mzmine.datamodel.PseudoSpectrumType;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.featuredata.IonTimeSeries;
 import io.github.mzmine.datamodel.featuredata.impl.SimpleIonTimeSeries;
 import io.github.mzmine.datamodel.features.Feature;
-import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
@@ -46,10 +47,12 @@ import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
 import io.github.mzmine.datamodel.features.types.FeatureShapeType;
 import io.github.mzmine.datamodel.impl.SimpleDataPoint;
 import io.github.mzmine.datamodel.impl.SimpleIsotopePattern;
+import io.github.mzmine.datamodel.impl.SimplePseudoSpectrum;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.parametertypes.OriginalFeatureListHandlingParameter.OriginalFeatureListOption;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import io.github.mzmine.util.DataPointUtils;
 import io.github.mzmine.util.DataTypeUtils;
 import io.github.mzmine.util.MemoryMapStorage;
 import java.time.Instant;
@@ -57,6 +60,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -113,8 +117,9 @@ public class ADAP3DecompositionV2Task extends AbstractTask {
       logger.info("Started ADAP Peak Decomposition on " + originalLists);
 
       // Check raw data files.
-      if (originalLists.chromatograms.getNumberOfRawDataFiles() > 1
-          && originalLists.peaks.getNumberOfRawDataFiles() > 1) {
+      @Nullable var chromatograms = originalLists.chromatograms();
+      @NotNull var peaks = originalLists.peaks();
+      if ((chromatograms!=null && chromatograms.getNumberOfRawDataFiles() > 1) || peaks.getNumberOfRawDataFiles() > 1) {
         setStatus(TaskStatus.ERROR);
         setErrorMessage(
             "Peak Decomposition can only be performed on feature lists with a single raw data file");
@@ -130,8 +135,10 @@ public class ADAP3DecompositionV2Task extends AbstractTask {
             project.addFeatureList(newPeakList);
             // Remove the original peaklist if requested.
             if (parameters.getParameter(ADAP3DecompositionV2Parameters.HANDLE_ORIGINAL).getValue() == OriginalFeatureListOption.REMOVE) {
-              project.removeFeatureList(originalLists.chromatograms);
-              project.removeFeatureList(originalLists.peaks);
+              project.removeFeatureList(peaks);
+              if (chromatograms != null) {
+                project.removeFeatureList(chromatograms);
+              }
             }
 
             setStatus(TaskStatus.FINISHED);
@@ -165,17 +172,17 @@ public class ADAP3DecompositionV2Task extends AbstractTask {
   }
 
   private ModularFeatureList decomposePeaks(@NotNull ChromatogramPeakPair lists) {
-    RawDataFile dataFile = lists.chromatograms.getRawDataFile(0);
+    RawDataFile dataFile = lists.peaks().getRawDataFile(0);
 
     // Create new feature list.
     ModularFeatureList resolvedPeakList = new ModularFeatureList(dataFile + " " + suffix,
         getMemoryMapStorage(), dataFile);
     DataTypeUtils.addDefaultChromatographicTypeColumns(resolvedPeakList);
 
-    resolvedPeakList.setSelectedScans(dataFile, lists.chromatograms.getSeletedScans(dataFile));
+    resolvedPeakList.setSelectedScans(dataFile, lists.peaks().getSeletedScans(dataFile));
 
     // Load previous applied methods.
-    for (final FeatureList.FeatureListAppliedMethod method : lists.peaks.getAppliedMethods()) {
+    for (var method : lists.peaks().getAppliedMethods()) {
       resolvedPeakList.addDescriptionOfAppliedTask(method);
     }
 
@@ -185,13 +192,14 @@ public class ADAP3DecompositionV2Task extends AbstractTask {
             ADAPMultivariateCurveResolutionModule.class, parameters, getModuleCallDate()));
 
     // Collect peak information
-    List<BetterPeak> chromatograms = utils.getPeaks(lists.chromatograms);
-    List<BetterPeak> peaks = utils.getPeaks(lists.peaks);
+    var chromLists = lists.chromatograms();
+    List<BetterPeak> chromatograms = chromLists!=null? utils.getPeaks(chromLists) : List.of();
+    List<BetterPeak> peaks = utils.getPeaks(lists.peaks());
 
     // Find components (a.k.a. clusters of peaks with fragmentation spectra)
     List<BetterComponent> components = getComponents(chromatograms, peaks);
 
-    // Create PeakListRow for each components
+    // Create PeakListRow for each component
     List<FeatureListRow> newPeakListRows = new ArrayList<>();
 
     int rowID = 0;
@@ -217,11 +225,19 @@ public class ADAP3DecompositionV2Task extends AbstractTask {
       if (dataPoints.size() < 5) {
         continue;
       }
+      dataPoints.sort(Comparator.comparingDouble(DataPoint::getMZ));
 
-      // todo: replace this with it's own data type?
-      refPeak.setIsotopePattern(
-          new SimpleIsotopePattern(dataPoints.toArray(new DataPoint[dataPoints.size()]), -1,
-              IsotopePattern.IsotopePatternStatus.PREDICTED, "Spectrum"));
+      // todo: keep for legacy, should be removed if no other modules rely on this
+      refPeak.setIsotopePattern(new SimpleIsotopePattern(dataPoints.toArray(new DataPoint[0]), -1,
+          IsotopePattern.IsotopePatternStatus.PREDICTED, "EI Pseudo MS1 Spectrum"));
+
+      var data = DataPointUtils.getDataPointsAsDoubleArray(dataPoints);
+      double[] mz = data[0];
+      double[] intensities = data[1];
+      PseudoSpectrum pseudoMs1 = new SimplePseudoSpectrum(dataFile, 1, refPeak.getRT(), null, mz,
+          intensities, Objects.requireNonNull(refPeak.getRepresentativeScan()).getPolarity(),
+          "Pseudo Spectrum", PseudoSpectrumType.GC_EI);
+      refPeak.setAllMS2FragmentScans(new ArrayList<>(List.of(pseudoMs1)));
 
       final ModularFeatureListRow row = new ModularFeatureListRow(resolvedPeakList, ++rowID);
 
@@ -295,7 +311,7 @@ public class ADAP3DecompositionV2Task extends AbstractTask {
         mzs, chromatogram.ys, scans);
 
     // calculations done in the constructor by FeatureDataUtils
-    return new ModularFeature(resolvedFeatureList, dataFile, series, FeatureStatus.MANUAL);
+    return new ModularFeature(resolvedFeatureList, dataFile, series, FeatureStatus.DETECTED);
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/adap_mcr/ADAPMultivariateCurveResolutionModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/adap_mcr/ADAPMultivariateCurveResolutionModule.java
@@ -28,8 +28,6 @@ import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.MZmineProcessingModule;
-import io.github.mzmine.modules.dataprocessing.featdet_adapchromatogrambuilder.ADAPChromatogramBuilderParameters;
-import io.github.mzmine.modules.dataprocessing.featdet_adapchromatogrambuilder.ModularADAPChromatogramBuilderTask;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/adap_mcr/ChromatogramPeakPair.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/adap_mcr/ChromatogramPeakPair.java
@@ -34,38 +34,32 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
+ * Might not have chromatograms
  * @author Du-Lab Team dulab.binf@gmail.com
  */
-public class ChromatogramPeakPair {
-
-  public final FeatureList chromatograms;
-  public final FeatureList peaks;
-
-  private ChromatogramPeakPair(@NotNull FeatureList chromatograms, @NotNull FeatureList peaks) {
-    this.chromatograms = chromatograms;
-    this.peaks = peaks;
-  }
+public record ChromatogramPeakPair(@NotNull FeatureList peaks, @Nullable FeatureList chromatograms) {
 
   @Override
   public String toString() {
-    return chromatograms.getName() + " / " + peaks.getName();
+    return chromatograms==null? peaks.getName() : chromatograms.getName() + " / " + peaks.getName();
   }
 
   public static Map<RawDataFile, ChromatogramPeakPair> fromParameterSet(
       @NotNull ParameterSet parameterSet) {
     Map<RawDataFile, ChromatogramPeakPair> pairs = new HashMap<>();
 
-    var optionalChromatograms = parameterSet.getParameter(
-        ADAP3DecompositionV2Parameters.CHROMATOGRAM_LISTS);
-    var useChromatograms = optionalChromatograms.getValue();
-    FeatureList[] chromatograms =
-        useChromatograms ? optionalChromatograms.getEmbeddedParameter().getValue()
-            .getMatchingFeatureLists() : null;
+    FeatureList[] chromatograms = parameterSet.getParameter(
+        ADAP3DecompositionV2Parameters.CHROMATOGRAM_LISTS).getValue().getMatchingFeatureLists();
     FeatureList[] peaks = parameterSet.getParameter(ADAP3DecompositionV2Parameters.PEAK_LISTS)
         .getValue().getMatchingFeatureLists();
     if (chromatograms == null || chromatograms.length == 0 || peaks == null || peaks.length == 0) {
+      assert peaks != null;
+      for (final FeatureList flist : peaks) {
+        pairs.put(flist.getRawDataFile(0), new ChromatogramPeakPair(flist, null));
+      }
       return pairs;
     }
 
@@ -83,7 +77,7 @@ public class ChromatogramPeakPair {
       FeatureList peak = Arrays.stream(peaks).filter(c -> c.getRawDataFile(0) == dataFile)
           .findFirst().orElse(null);
       if (chromatogram != null && peak != null) {
-        pairs.put(dataFile, new ChromatogramPeakPair(chromatogram, peak));
+        pairs.put(dataFile, new ChromatogramPeakPair(peak, chromatogram));
       }
     }
 

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_append_rows/MergeAlignerTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_append_rows/MergeAlignerTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -38,7 +38,6 @@ import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.MemoryMapStorage;
 import java.time.Instant;
-import java.util.Date;
 import java.util.List;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -51,14 +50,13 @@ public class MergeAlignerTask extends AbstractTask {
   private static final Logger logger = Logger.getLogger(MergeAlignerTask.class.getName());
 
   private final MZmineProject project;
-  private ModularFeatureList[] featureLists;
-  private ModularFeatureList alignedFeatureList;
+  private final ModularFeatureList[] featureLists;
 
   // Processed rows counter
   private int processedRows, totalRows;
 
-  private String featureListName;
-  private ParameterSet parameters;
+  private final String featureListName;
+  private final ParameterSet parameters;
 
   public MergeAlignerTask(MZmineProject project, ParameterSet parameters,
       @Nullable MemoryMapStorage storage, @NotNull Instant moduleCallDate) {
@@ -67,8 +65,7 @@ public class MergeAlignerTask extends AbstractTask {
     this.project = project;
     this.parameters = parameters;
 
-    featureLists = parameters.getParameter(
-        MergeAlignerParameters.featureLists).getValue()
+    featureLists = parameters.getParameter(MergeAlignerParameters.featureLists).getValue()
         .getMatchingFeatureLists();
 
     featureListName = parameters.getParameter(
@@ -111,8 +108,8 @@ public class MergeAlignerTask extends AbstractTask {
         .flatMap(flist -> flist.getRawDataFiles().stream()).distinct().collect(Collectors.toList());
 
     // create copy of first feature list as base and renumber IDs
-    alignedFeatureList = featureLists[0]
-        .createCopy(featureListName, getMemoryMapStorage(), allDataFiles, true);
+    ModularFeatureList alignedFeatureList = featureLists[0].createCopy(featureListName,
+        getMemoryMapStorage(), allDataFiles, true);
 
     // next row will have this id
     int newRowID = alignedFeatureList.getNumberOfRows() + 1;
@@ -123,9 +120,8 @@ public class MergeAlignerTask extends AbstractTask {
       ModularFeatureList featureList = featureLists[i];
 
       // copy all types
-      featureList.getRowTypes().values().forEach(type -> alignedFeatureList.addRowType(type));
-      featureList.getFeatureTypes().values()
-          .forEach(type -> alignedFeatureList.addFeatureType(type));
+      alignedFeatureList.addRowType(featureList.getRowTypes());
+      alignedFeatureList.addFeatureType(featureList.getFeatureTypes());
 
       // selected scans during chromatogram creation needs to be the same list for the same data file
       for (RawDataFile file : featureList.getRawDataFiles()) {

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_join/JoinAlignerModule.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_join/JoinAlignerModule.java
@@ -41,7 +41,7 @@ public class JoinAlignerModule implements MZmineProcessingModule {
   private static final String MODULE_NAME = "Join aligner";
   private static final String MODULE_DESCRIPTION =
       "This method aligns detected peaks using a match score. This score is calculated based on"
-          + " the mass and retention time of each peak using preset tolerance.";
+          + " the mass and retention time of each feature using preset tolerance.";
 
   @Override
   public @NotNull String getName() {

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_lcimage/LcImageAlignerParameters.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_lcimage/LcImageAlignerParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -80,9 +80,9 @@ public class LcImageAlignerParameters extends SimpleParameterSet {
     final ModularFeatureList[] matchingFeatureLists = getValue(
         LcImageAlignerParameters.flists).getMatchingFeatureLists();
     final var imageList = Arrays.stream(matchingFeatureLists)
-        .filter(flist -> flist.getFeatureTypes().containsValue(new ImageType())).toList();
+        .filter(flist -> flist.hasFeatureType(ImageType.class)).toList();
     final var baseLists = Arrays.stream(matchingFeatureLists)
-        .filter(flist -> !flist.getFeatureTypes().containsValue(new ImageType())).toList();
+        .filter(flist -> !flist.hasFeatureType(ImageType.class)).toList();
 
     if (imageList.isEmpty()) {
       errorMessages.add("No feature list with images selected.");

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/align_lcimage/LcImageAlignerTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/align_lcimage/LcImageAlignerTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -94,11 +94,11 @@ public class LcImageAlignerTask extends AbstractTask {
 
     // checked in setup dialog
     imageLists = Arrays.stream(matchingFeatureLists)
-        .filter(flist -> flist.getFeatureTypes().containsValue(new ImageType()))
+        .filter(flist -> flist.hasFeatureType(ImageType.class))
         .map(list -> (FeatureList) list).toList();
 
     final List<FeatureList> featureLists = Arrays.stream(matchingFeatureLists)
-        .filter(flist -> !flist.getFeatureTypes().containsValue(new ImageType()))
+        .filter(flist -> !flist.hasFeatureType(ImageType.class))
         .map(list -> (FeatureList) list).toList();
     if (featureLists.size() > 1) {
       logger.warning(

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_blanksubtraction/FeatureListBlankSubtractionTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_blanksubtraction/FeatureListBlankSubtractionTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -26,7 +26,6 @@
 package io.github.mzmine.modules.dataprocessing.filter_blanksubtraction;
 
 import io.github.mzmine.datamodel.AbundanceMeasure;
-import io.github.mzmine.datamodel.FeatureInformation;
 import io.github.mzmine.datamodel.FeatureStatus;
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.datamodel.RawDataFile;
@@ -153,7 +152,7 @@ public class FeatureListBlankSubtractionTask extends AbstractTask {
         originalFeatureList.getName() + " " + suffix, getMemoryMapStorage(),
         keepBackgroundFeatures == BlankSubtractionOptions.KEEP
             ? originalFeatureList.getRawDataFiles() : nonBlankRaws);
-    originalFeatureList.getRowTypes().values()
+    originalFeatureList.getRowTypes()
         .forEach(notBackgroundAlignedFeaturesList::addRowType);
 
     // use all samples that are not defined as blanks
@@ -171,7 +170,7 @@ public class FeatureListBlankSubtractionTask extends AbstractTask {
     final ModularFeatureList backgroundAlignedFeaturesList = new ModularFeatureList(
         originalFeatureList.getName() + " subtractedBackground", getMemoryMapStorage(),
         originalFeatureList.getRawDataFiles());
-    originalFeatureList.getRowTypes().values().forEach(backgroundAlignedFeaturesList::addRowType);
+    originalFeatureList.getRowTypes().forEach(backgroundAlignedFeaturesList::addRowType);
     originalFeatureList.getRawDataFiles().forEach(
         f -> backgroundAlignedFeaturesList.setSelectedScans(f,
             originalFeatureList.getSeletedScans(f)));

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_clearannotations/ClearFeatureAnnotationsTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_clearannotations/ClearFeatureAnnotationsTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -71,8 +71,9 @@ public class ClearFeatureAnnotationsTask extends AbstractTask {
     final Map<DataType<?>, Boolean> annotationTypes = parameterSet.getValue(
         ClearFeatureAnnotationsParameters.clear);
 
+    final var types = list.getRowTypes();
     typesToClear = (List) annotationTypes.entrySet().stream().filter(Entry::getValue)
-        .map(Entry::getKey).filter(t -> list.getRowTypes().containsValue(t)).toList();
+        .map(Entry::getKey).filter(t -> types.contains(t)).toList();
   }
 
   @Override
@@ -96,7 +97,7 @@ public class ClearFeatureAnnotationsTask extends AbstractTask {
       totalRows = origFeatureList.getRows().size() * typesToClear.size();
 
       for (DataType<?> dataType : typesToClear) {
-        if (!origFeatureList.getRowTypes().containsKey(dataType.getClass())) {
+        if (!origFeatureList.getRowTypes().contains(dataType)) {
           continue;
         }
         // Filter the feature list.

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/filter_isotopefinder/IsotopeFinderTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/filter_isotopefinder/IsotopeFinderTask.java
@@ -349,9 +349,10 @@ class IsotopeFinderTask extends AbstractTask {
 
   @Nullable
   private MobilityScanDataAccess initMobilityScanDataAccess(RawDataFile raw) {
-    return raw instanceof IMSRawDataFile imsFile && featureList.getFeatureTypes()
-        .containsKey(MobilityUnitType.class) ? new MobilityScanDataAccess(imsFile,
-        MobilityScanDataType.MASS_LIST, (List<Frame>) featureList.getSeletedScans(imsFile)) : null;
+    return
+        raw instanceof IMSRawDataFile imsFile && featureList.hasFeatureType(MobilityUnitType.class)
+            ? new MobilityScanDataAccess(imsFile, MobilityScanDataType.MASS_LIST,
+            (List<Frame>) featureList.getSeletedScans(imsFile)) : null;
   }
 
   private void checkCandidatesInScan(ScanDataAccess scans, List<MergedDataPoint> candidates,

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_lipididentification/lipids/customlipidclass/CustomLipidClassFragmentationRulesChoiceComponent.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_lipididentification/lipids/customlipidclass/CustomLipidClassFragmentationRulesChoiceComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -221,7 +221,7 @@ public class CustomLipidClassFragmentationRulesChoiceComponent extends BorderPan
 
     private static final StringParameter formula = new StringParameter("Molecular formula",
         "Enter a molecular formula, if it is involved in the fragmentation rule. E.g. a head group fragment needs to be specified by its molecular formula.",
-        null, false, false);
+        "", false, false);
 
     private AddLipidFragmentationRuleParameters() {
       super(new Parameter[]{polarity, ionizationMethod, lipidFragmentationRuleType,

--- a/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularTask.java
@@ -224,11 +224,11 @@ public class CSVExportModularTask extends AbstractTask implements ProcessedItems
         .sorted(FeatureListRowSorter.DEFAULT_ID).toList();
     List<RawDataFile> rawDataFiles = flist.getRawDataFiles();
 
-    List<DataType> rowTypes = flist.getRowTypes().values().stream().filter(this::filterType)
+    List<DataType> rowTypes = flist.getRowTypes().stream().filter(this::filterType)
         .filter(type -> !removeEmptyCols || typeContainData(type, rows, false, -1))
         .collect(Collectors.toList());
 
-    List<DataType> featureTypes = flist.getFeatureTypes().values().stream().filter(this::filterType)
+    List<DataType> featureTypes = flist.getFeatureTypes().stream().filter(this::filterType)
         .filter(type -> !removeEmptyCols || typeContainData(type, rows, true, -1))
         .collect(Collectors.toList());
 

--- a/src/main/java/io/github/mzmine/modules/io/export_features_csv_legacy/LegacyCSVExportTask.java
+++ b/src/main/java/io/github/mzmine/modules/io/export_features_csv_legacy/LegacyCSVExportTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -27,12 +27,12 @@ package io.github.mzmine.modules.io.export_features_csv_legacy;
 
 import com.google.common.collect.Lists;
 import io.github.mzmine.datamodel.FeatureStatus;
-import io.github.mzmine.datamodel.MobilityType;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.datamodel.features.types.MobilityUnitType;
+import io.github.mzmine.datamodel.features.types.numbers.MobilityType;
 import io.github.mzmine.datamodel.identities.iontype.IonIdentity;
 import io.github.mzmine.gui.preferences.NumberFormats;
 import io.github.mzmine.main.MZmineCore;
@@ -427,7 +427,7 @@ public class LegacyCSVExportTask extends AbstractTask implements ProcessedItemsC
           line.append(mobility == null ? "" : mobility).append(fieldSeparator);
           break;
         case ROW_ION_MOBILITY_UNIT:
-          final MobilityType unit = featureListRow.get(MobilityUnitType.class);
+          final var unit = featureListRow.get(MobilityUnitType.class);
           line.append(unit == null ? "" : unit).append(fieldSeparator);
           break;
         case ROW_CCS:

--- a/src/main/java/io/github/mzmine/modules/io/spectraldbsubmit/param/GnpsLibrarySubmitParameters.java
+++ b/src/main/java/io/github/mzmine/modules/io/spectraldbsubmit/param/GnpsLibrarySubmitParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -37,7 +37,6 @@
 
 package io.github.mzmine.modules.io.spectraldbsubmit.param;
 
-import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
 import io.github.mzmine.parameters.parametertypes.PasswordParameter;
 import io.github.mzmine.parameters.parametertypes.StringParameter;
@@ -49,11 +48,11 @@ import io.github.mzmine.parameters.parametertypes.StringParameter;
  */
 public class GnpsLibrarySubmitParameters extends SimpleParameterSet {
 
-  public static StringParameter user =
-      new StringParameter("Username", "GNPS username", null, true, true);
+  public static StringParameter user = new StringParameter("Username", "GNPS username", "", true,
+      true);
   public static PasswordParameter pass = new PasswordParameter("Password", "GNPS password");
 
   public GnpsLibrarySubmitParameters() {
-    super(new Parameter[] {user, pass});
+    super(user, pass);
   }
 }

--- a/src/main/java/io/github/mzmine/modules/io/spectraldbsubmit/view/MSMSLibrarySubmissionWindow.java
+++ b/src/main/java/io/github/mzmine/modules/io/spectraldbsubmit/view/MSMSLibrarySubmissionWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -583,7 +583,7 @@ public class MSMSLibrarySubmissionWindow extends Stage {
           .setValue(precursorMZ == 0d ? null : precursorMZ);
     } else {
       // MS1
-      ionParam.getParameter(LibrarySubmitIonParameters.ADDUCT).setValue(null);
+      ionParam.getParameter(LibrarySubmitIonParameters.ADDUCT).setValue("");
       ionParam.getParameter(LibrarySubmitIonParameters.CHARGE).setValue(null);
       ionParam.getParameter(LibrarySubmitIonParameters.MZ).setValue(null);
     }

--- a/src/main/java/io/github/mzmine/modules/tools/batchwizard/builders/BaseWizardBatchBuilder.java
+++ b/src/main/java/io/github/mzmine/modules/tools/batchwizard/builders/BaseWizardBatchBuilder.java
@@ -97,6 +97,8 @@ import io.github.mzmine.modules.dataprocessing.id_spectral_library_match.Spectra
 import io.github.mzmine.modules.dataprocessing.id_spectral_library_match.SpectralLibrarySearchParameters.ScanMatchingSelection;
 import io.github.mzmine.modules.dataprocessing.id_spectral_library_match.library_to_featurelist.SpectralLibraryToFeatureListModule;
 import io.github.mzmine.modules.dataprocessing.id_spectral_library_match.library_to_featurelist.SpectralLibraryToFeatureListParameters;
+import io.github.mzmine.modules.dataprocessing.norm_rtcalibration.RTCalibrationModule;
+import io.github.mzmine.modules.dataprocessing.norm_rtcalibration.RTCalibrationParameters;
 import io.github.mzmine.modules.impl.MZmineProcessingStepImpl;
 import io.github.mzmine.modules.io.export_compoundAnnotations_csv.CompoundAnnotationsCSVExportModule;
 import io.github.mzmine.modules.io.export_compoundAnnotations_csv.CompoundAnnotationsCSVExportParameters;
@@ -909,8 +911,13 @@ public abstract class BaseWizardBatchBuilder extends WizardBatchBuilder {
     param.setParameter(MassDetectionParameters.dataFiles,
         new RawDataFilesSelection(RawDataFilesSelectionType.BATCH_LAST_FILES));
     // if MS level 0 then apply to all scans
-    param.getParameter(MassDetectionParameters.scanSelection)
-        .setValue(true, new ScanSelection(MsLevelFilter.of(msLevel, true)));
+    if (msLevel != 0) {
+      param.getParameter(MassDetectionParameters.scanSelection)
+          .setValue(true, new ScanSelection(MsLevelFilter.of(msLevel, true)));
+    } else {
+      param.getParameter(MassDetectionParameters.scanSelection)
+          .setValue(true, new ScanSelection(MsLevelFilter.ALL_LEVELS));
+    }
     param.setParameter(MassDetectionParameters.scanTypes, scanTypes);
     param.setParameter(MassDetectionParameters.massDetector,
         new MZmineProcessingStepImpl<>(MZmineCore.getModuleInstance(massDetectorClass),
@@ -989,6 +996,25 @@ public abstract class BaseWizardBatchBuilder extends WizardBatchBuilder {
 
     MZmineProcessingStep<MZmineProcessingModule> step = new MZmineProcessingStepImpl<>(
         MZmineCore.getModuleInstance(SmoothingModule.class), param);
+    q.add(step);
+  }
+
+  protected void makeAndAddRetentionTimeCalibration(BatchQueue q, MZTolerance mzTolInterSample,
+      RTTolerance interSampleRtTol,
+      OriginalFeatureListOption handleOriginalFeatureLists) {
+
+    final ParameterSet param = MZmineCore.getConfiguration()
+        .getModuleParameters(RTCalibrationModule.class).cloneParameterSet();
+    param.setParameter(RTCalibrationParameters.featureLists,
+        new FeatureListsSelection(FeatureListsSelectionType.BATCH_LAST_FEATURELISTS));
+    param.setParameter(RTCalibrationParameters.MZTolerance, mzTolInterSample);
+    param.setParameter(RTCalibrationParameters.RTTolerance, interSampleRtTol);
+    param.setParameter(RTCalibrationParameters.minHeight, minFeatureHeight);
+    param.setParameter(RTCalibrationParameters.handleOriginal, handleOriginalFeatureLists);
+    param.setParameter(RTCalibrationParameters.suffix, "rt_cal");
+
+    MZmineProcessingStep<MZmineProcessingModule> step = new MZmineProcessingStepImpl<>(
+        MZmineCore.getModuleInstance(RTCalibrationModule.class), param);
     q.add(step);
   }
 

--- a/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/IonInterfaceGcElectronImpactWizardParameters.java
+++ b/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/IonInterfaceGcElectronImpactWizardParameters.java
@@ -30,42 +30,42 @@ import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.tools.batchwizard.WizardPart;
 import io.github.mzmine.modules.tools.batchwizard.subparameters.factories.IonInterfaceWizardParameterFactory;
 import io.github.mzmine.parameters.parametertypes.BooleanParameter;
-import io.github.mzmine.parameters.parametertypes.DoubleParameter;
 import io.github.mzmine.parameters.parametertypes.IntegerParameter;
 import io.github.mzmine.parameters.parametertypes.ranges.DoubleRangeParameter;
 import io.github.mzmine.parameters.parametertypes.ranges.RTRangeParameter;
 import io.github.mzmine.parameters.parametertypes.tolerances.RTTolerance;
 import io.github.mzmine.parameters.parametertypes.tolerances.RTTolerance.Unit;
 import io.github.mzmine.parameters.parametertypes.tolerances.RTToleranceParameter;
-import java.text.NumberFormat;
+import javafx.collections.FXCollections;
 
 public final class IonInterfaceGcElectronImpactWizardParameters extends
     IonInterfaceWizardParameters {
 
   public static final RTRangeParameter cropRtRange = new RTRangeParameter("Crop retention time",
       "Crops the RT range of chromatograms. Used to exclude time before the flow time\n"
-      + "and after the separation, where in many runs cleaning and re-equilibration starts.", true,
-      Range.closed(0.5, 30d));
+          + "and after the separation, where in many runs cleaning and re-equilibration starts.",
+      true, Range.closed(0.5, 30d));
   public static final RTToleranceParameter approximateChromatographicFWHM = new RTToleranceParameter(
       "Approximate feature FWHM",
       "The approximate feature width (chromatograpic peak width) in retention time (full-width-at-half-maximum, FWHM). ",
-      new RTTolerance(0.05f, Unit.MINUTES));
+      new RTTolerance(0.05f, Unit.MINUTES),
+      FXCollections.observableArrayList(Unit.MINUTES, Unit.SECONDS));
   public static final RTToleranceParameter intraSampleRTTolerance = new RTToleranceParameter(
       "RT tolerance (intra-sample)",
       "Retention time tolerance for multiple signals of the same compound in the same "
-      + "sample.\nUsed to detect isotopes or multimers/adducts of the same compound.",
-      new RTTolerance(0.04f, Unit.MINUTES));
+          + "sample.\nUsed to detect isotopes or multimers/adducts of the same compound.",
+      new RTTolerance(0.04f, Unit.MINUTES),
+      FXCollections.observableArrayList(Unit.MINUTES, Unit.SECONDS));
   public static final RTToleranceParameter interSampleRTTolerance = new RTToleranceParameter(
       "RT tolerance (sample-to-sample)",
       "Retention time tolerance for the same compound in different samples.\n"
-      + "Used to align multiple measurements of the same sample or a batch run.",
-      new RTTolerance(0.1f, Unit.MINUTES));
+          + "Used to align multiple measurements of the same sample or a batch run.",
+      new RTTolerance(0.1f, Unit.MINUTES),
+      FXCollections.observableArrayList(Unit.MINUTES, Unit.SECONDS));
   public static final IntegerParameter minNumberOfDataPoints = new IntegerParameter(
       "Minimum consecutive scans",
       "Minimum number of consecutive scans with detected data points as used in chromatogram building and feature resolving.",
       4, 1, Integer.MAX_VALUE);
-  public static final DoubleParameter SN_THRESHOLD = new DoubleParameter("Signal/noise threshold",
-      "Signal to noise ratio threshold", NumberFormat.getNumberInstance(), 5d, 0.0, null);
   public static final DoubleRangeParameter RT_FOR_CWT_SCALES_DURATION = new DoubleRangeParameter(
       "Min/max feature width",
       "Upper and lower bounds of retention times to be used for setting the wavelet scales. Choose a range that that simmilar to the range of peak widths expected to be found from the data.",
@@ -74,32 +74,38 @@ public final class IonInterfaceGcElectronImpactWizardParameters extends
   public static final BooleanParameter smoothing = new BooleanParameter("Smoothing",
       "Apply smoothing in the retention time dimension, usually only needed if the peak shapes are spiky.",
       false);
+  public static final BooleanParameter RECALIBRATE_RETENTION_TIMES = new BooleanParameter(
+      "Recalibrate retention times",
+      "Searches for common features in all samples and recalibrates the retention times.",
+      false);
 
   public IonInterfaceGcElectronImpactWizardParameters(
       final IonInterfaceWizardParameterFactory preset) {
     super(WizardPart.ION_INTERFACE, preset,
         // actual parameters
-        smoothing, cropRtRange, minNumberOfDataPoints, SN_THRESHOLD, RT_FOR_CWT_SCALES_DURATION,
+        smoothing, RECALIBRATE_RETENTION_TIMES, cropRtRange, minNumberOfDataPoints,
+        RT_FOR_CWT_SCALES_DURATION,
         // tolerances
         approximateChromatographicFWHM, intraSampleRTTolerance, interSampleRTTolerance);
   }
 
   public IonInterfaceGcElectronImpactWizardParameters(
       final IonInterfaceWizardParameterFactory preset, final boolean smoothingActive,
+      final boolean recalibrateRetentionTime,
       final Range<Double> cropRt, final RTTolerance fwhm, final RTTolerance intraSampleTolerance,
-      final RTTolerance interSampleTolerance, final int minDataPoints, final Double snThreshold,
+      final RTTolerance interSampleTolerance, final int minDataPoints,
       final Range<Double> rtforCWT) {
 
     this(preset);
 
     // defaults - others override those values
     setParameter(smoothing, smoothingActive);
+    setParameter(RECALIBRATE_RETENTION_TIMES, recalibrateRetentionTime);
     setParameter(cropRtRange, cropRt);
     setParameter(approximateChromatographicFWHM, fwhm);
     setParameter(intraSampleRTTolerance, intraSampleTolerance);
     setParameter(interSampleRTTolerance, interSampleTolerance);
     setParameter(minNumberOfDataPoints, minDataPoints);
-    setParameter(SN_THRESHOLD, snThreshold);
     setParameter(RT_FOR_CWT_SCALES_DURATION, rtforCWT);
   }
 

--- a/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/IonInterfaceHplcWizardParameters.java
+++ b/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/IonInterfaceHplcWizardParameters.java
@@ -32,23 +32,28 @@ import io.github.mzmine.parameters.parametertypes.BooleanParameter;
 import io.github.mzmine.parameters.parametertypes.IntegerParameter;
 import io.github.mzmine.parameters.parametertypes.ranges.RTRangeParameter;
 import io.github.mzmine.parameters.parametertypes.tolerances.RTTolerance;
+import io.github.mzmine.parameters.parametertypes.tolerances.RTTolerance.Unit;
 import io.github.mzmine.parameters.parametertypes.tolerances.RTToleranceParameter;
+import javafx.collections.FXCollections;
 
 public final class IonInterfaceHplcWizardParameters extends IonInterfaceWizardParameters {
 
   public static final RTToleranceParameter approximateChromatographicFWHM = new RTToleranceParameter(
       "Approximate feature FWHM",
-      "The approximate feature width (chromatograpic peak width) in retention time (full-width-at-half-maximum, FWHM). ");
+      "The approximate feature width (chromatograpic peak width) in retention time (full-width-at-half-maximum, FWHM). ",
+      FXCollections.observableArrayList(Unit.MINUTES, Unit.SECONDS));
 
   public static final RTToleranceParameter intraSampleRTTolerance = new RTToleranceParameter(
       "RT tolerance (intra-sample)",
       "Retention time tolerance for multiple signals of the same compound in the same "
-          + "sample.\nUsed to detect isotopes or multimers/adducts of the same compound.");
+          + "sample.\nUsed to detect isotopes or multimers/adducts of the same compound.",
+      FXCollections.observableArrayList(Unit.MINUTES, Unit.SECONDS));
 
   public static final RTToleranceParameter interSampleRTTolerance = new RTToleranceParameter(
       "RT tolerance (sample-to-sample)",
       "Retention time tolerance for the same compound in different samples.\n"
-          + "Used to align multiple measurements of the same sample or a batch run.");
+          + "Used to align multiple measurements of the same sample or a batch run.",
+      FXCollections.observableArrayList(Unit.MINUTES, Unit.SECONDS));
 
   public static final IntegerParameter minNumberOfDataPoints = new IntegerParameter(
       "Minimum consecutive scans",

--- a/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/WorkflowGcElectronImpactWizardParameters.java
+++ b/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/WorkflowGcElectronImpactWizardParameters.java
@@ -27,12 +27,17 @@ package io.github.mzmine.modules.tools.batchwizard.subparameters;
 
 import io.github.mzmine.modules.tools.batchwizard.subparameters.factories.WorkflowWizardParameterFactory;
 import io.github.mzmine.parameters.parametertypes.BooleanParameter;
+import io.github.mzmine.parameters.parametertypes.IntegerParameter;
 import io.github.mzmine.parameters.parametertypes.OptionalParameter;
 import io.github.mzmine.parameters.parametertypes.filenames.FileNameParameter;
 import io.github.mzmine.parameters.parametertypes.filenames.FileSelectionType;
 import java.io.File;
 
 public final class WorkflowGcElectronImpactWizardParameters extends WorkflowWizardParameters {
+
+  public static final IntegerParameter MIN_NUMBER_OF_SIGNALS_IN_DECON_SPECTRA =
+      new IntegerParameter("Min number of signals in deconvoluted spectrum",
+          "Min number of signals in deconvoluted spectrum", 8, true);
 
   public static final BooleanParameter exportGnps = new BooleanParameter(
       "Export for GNPS GC-EI FBMN", "Export to Feature-based Molecular Networking (FBMN) on GNPS",
@@ -54,7 +59,8 @@ public final class WorkflowGcElectronImpactWizardParameters extends WorkflowWiza
   public WorkflowGcElectronImpactWizardParameters() {
     super(WorkflowWizardParameterFactory.DECONVOLUTION,
         // actual parameters
-        exportPath, exportGnps, exportMsp, exportAnnotationGraphics);
+        MIN_NUMBER_OF_SIGNALS_IN_DECON_SPECTRA, exportPath, exportGnps, exportMsp,
+        exportAnnotationGraphics);
   }
 
 

--- a/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/factories/IonInterfaceWizardParameterFactory.java
+++ b/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/factories/IonInterfaceWizardParameterFactory.java
@@ -101,9 +101,10 @@ public enum IonInterfaceWizardParameterFactory implements WizardParameterFactory
           new RTTolerance(0.1f, Unit.MINUTES));
       // different workflow for GC-EI
       case GC_EI ->
-          new IonInterfaceGcElectronImpactWizardParameters(this, false, Range.closed(0.3, 30d),
+          new IonInterfaceGcElectronImpactWizardParameters(this, false, true,
+              Range.closed(0.3, 30d),
               new RTTolerance(0.05f, Unit.MINUTES), new RTTolerance(0.04f, Unit.MINUTES),
-              new RTTolerance(0.1f, Unit.MINUTES), 4, 5.0, Range.closed(0.001, 0.06));
+              new RTTolerance(0.1f, Unit.MINUTES), 4, Range.closed(0.001, 0.06));
       // parameters for imaging
       case MALDI, LDI, DESI, SIMS -> new IonInterfaceImagingWizardParameters(this, 25, false);
       //

--- a/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICPlot.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICPlot.java
@@ -415,6 +415,16 @@ public class TICPlot extends EChartViewer implements LabelColorMatch {
     return addDataSetAndRenderer(dataSet, renderer);
   }
 
+  public synchronized int addFeatureDataSetRandomColor(final FeatureDataSet dataSet) {
+    final FeatureTICRenderer renderer = new FeatureTICRenderer();
+    Color nextColorAWT = MZmineCore.getConfiguration().getDefaultColorPalette().getNextColorAWT();
+    renderer.setSeriesPaint(0, nextColorAWT);
+    renderer.setSeriesFillPaint(0, nextColorAWT);
+    renderer.setDefaultToolTipGenerator(new TICToolTipGenerator());
+    return addDataSetAndRenderer(dataSet, renderer);
+  }
+
+
   public synchronized void addFeatureDataSets(Collection<FeatureDataSet> dataSets) {
     final boolean oldNotify = plot.isNotify();
     plot.setNotify(false);
@@ -424,7 +434,6 @@ public class TICPlot extends EChartViewer implements LabelColorMatch {
       chart.fireChartChanged();
     }
   }
-
 
   public synchronized void addFeatureDataSet(final FeatureDataSet dataSet,
       final FeatureTICRenderer renderer) {

--- a/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFX.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFX.java
@@ -507,7 +507,7 @@ public class FeatureTableFX extends TreeTableView<ModularFeatureListRow> impleme
     rowCol.setGraphic(headerLabel);
 
     // add row types
-    featureList.getRowTypes().values().stream().filter(t -> !(t instanceof FeaturesType))
+    featureList.getRowTypes().stream().filter(t -> !(t instanceof FeaturesType))
         .forEach(dataType -> addColumn(rowCol, dataType));
 
     sortColumn(rowCol);
@@ -516,8 +516,8 @@ public class FeatureTableFX extends TreeTableView<ModularFeatureListRow> impleme
     this.getColumns().add(rowCol);
 
     // add features
-    if (featureList.getRowTypes().containsKey(FeaturesType.class)) {
-      addColumn(rowCol, featureList.getRowTypes().get(FeaturesType.class));
+    if (featureList.hasRowType(FeaturesType.class)) {
+      addColumn(rowCol, DataTypes.get(FeaturesType.class));
     }
 
   }
@@ -578,9 +578,10 @@ public class FeatureTableFX extends TreeTableView<ModularFeatureListRow> impleme
 
   private Entry<TreeTableColumn<ModularFeatureListRow, ?>, ColumnID> getMainColumnEntry(
       Class<? extends DataType> dtClass) {
+    DataType type = DataTypes.get(dtClass);
     for (var col : newColumnMap.entrySet()) {
       var colID = col.getValue();
-      if (colID.getDataType().getClass().equals(dtClass) && colID.getSubColIndex() == -1
+      if (type.equals(colID.getDataType()) && colID.getSubColIndex() == -1
           && colID.getType() == ColumnType.ROW_TYPE) {
         return col;
       }
@@ -743,7 +744,7 @@ public class FeatureTableFX extends TreeTableView<ModularFeatureListRow> impleme
       sampleCol.setGraphic(headerLabel);
 
       // Add sub columns of feature
-      for (DataType ftype : getFeatureList().getFeatureTypes().values()) {
+      for (DataType ftype : getFeatureList().getFeatureTypes()) {
         if (ftype instanceof ImageType && !(dataFile instanceof ImagingRawDataFile)) {
           // non-imaging files don't need a image column
           continue;
@@ -833,8 +834,7 @@ public class FeatureTableFX extends TreeTableView<ModularFeatureListRow> impleme
             cellValue));
         if (runnable != null) {
           MZmineCore.getTaskController().addTask(
-              new FeatureTableDoubleClickTask(runnable, getFeatureList(),
-                  (DataType<?>) userData));
+              new FeatureTableDoubleClickTask(runnable, getFeatureList(), (DataType<?>) userData));
         }
       }
     }

--- a/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFXMLTabAnchorPaneController.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFXMLTabAnchorPaneController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -124,7 +124,7 @@ public class FeatureTableFXMLTabAnchorPaneController {
 
     typeComboBox.valueProperty().addListener((observable, oldValue, newValue) -> filterRows());
     featureTable.featureListProperty().addListener(((observable, oldValue, newValue) -> {
-      typeComboBox.setItems(FXCollections.observableArrayList(newValue.getRowTypes().values()));
+      typeComboBox.setItems(FXCollections.observableArrayList(newValue.getRowTypes()));
       if (!typeComboBox.getItems().isEmpty()) {
         typeComboBox.setValue(typeComboBox.getItems().get(0));
       }

--- a/src/main/java/io/github/mzmine/modules/visualization/pseudospectrumvisualizer/PseudoSpectrumFeatureDataSetCalculationTask.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/pseudospectrumvisualizer/PseudoSpectrumFeatureDataSetCalculationTask.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2004-2023 The MZmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.visualization.pseudospectrumvisualizer;
+
+import com.google.common.collect.Range;
+import io.github.mzmine.datamodel.FeatureStatus;
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.datamodel.data_access.EfficientDataAccess;
+import io.github.mzmine.datamodel.data_access.EfficientDataAccess.ScanDataType;
+import io.github.mzmine.datamodel.data_access.ScanDataAccess;
+import io.github.mzmine.datamodel.featuredata.IonTimeSeries;
+import io.github.mzmine.datamodel.featuredata.IonTimeSeriesUtils;
+import io.github.mzmine.datamodel.features.ModularFeature;
+import io.github.mzmine.datamodel.features.ModularFeatureList;
+import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.modules.visualization.chromatogram.FeatureDataSet;
+import io.github.mzmine.modules.visualization.chromatogram.TICPlot;
+import io.github.mzmine.parameters.parametertypes.selectors.ScanSelection;
+import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
+import io.github.mzmine.taskcontrol.AbstractTask;
+import io.github.mzmine.taskcontrol.TaskStatus;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+class PseudoSpectrumFeatureDataSetCalculationTask extends AbstractTask {
+
+  private final RawDataFile rawDataFile;
+  private final List<FeatureDataSet> features;
+  private final TICPlot chromPlot;
+  private final Scan pseudoScan;
+  private final ModularFeature feature;
+  private final MZTolerance mzTolerance;
+  private final AtomicInteger processedFeatures = new AtomicInteger(0);
+
+  PseudoSpectrumFeatureDataSetCalculationTask(RawDataFile rawDataFile, TICPlot chromPlot,
+      Scan pseudoScan, ModularFeature feature, MZTolerance mzTolerance) {
+    super(null, Instant.now());
+    this.rawDataFile = rawDataFile;
+    this.chromPlot = chromPlot;
+    this.pseudoScan = pseudoScan;
+    this.feature = feature;
+    this.mzTolerance = mzTolerance;
+    this.features = new ArrayList<>();
+  }
+
+  @Override
+  public String getTaskDescription() {
+    return "Calculate feature datasets";
+  }
+
+  @Override
+  public double getFinishedPercentage() {
+    return processedFeatures.get() / (double) pseudoScan.getNumberOfDataPoints();
+  }
+
+
+  @Override
+  public void run() {
+    setStatus(TaskStatus.PROCESSING);
+
+    ModularFeatureList newFeatureList = new ModularFeatureList("Feature list " + this.hashCode(),
+        null, rawDataFile);
+
+    if (getStatus() == TaskStatus.CANCELED) {
+      return;
+    }
+
+    Range<Float> dataRTRange = Range.closed(feature.getRawDataPointsRTRange().lowerEndpoint(),
+        feature.getRawDataPointsRTRange().upperEndpoint());
+
+    final ScanSelection selection = new ScanSelection(pseudoScan.getMSLevel(),
+        feature.getRawDataPointsRTRange());
+    final ScanDataAccess access = EfficientDataAccess.of(rawDataFile, ScanDataType.MASS_LIST,
+        selection);
+    for (int i = 0; i < pseudoScan.getNumberOfDataPoints(); i++) {
+      final IonTimeSeries<Scan> series = IonTimeSeriesUtils.extractIonTimeSeries(access,
+          mzTolerance.getToleranceRange(pseudoScan.getMzValue(i)), dataRTRange, null);
+      final ModularFeature f = new ModularFeature(newFeatureList, rawDataFile, series,
+          FeatureStatus.DETECTED);
+      features.add(new FeatureDataSet(f));
+      processedFeatures.getAndIncrement();
+    }
+
+    MZmineCore.runLater(() -> {
+      if (getStatus() == TaskStatus.CANCELED) {
+        return;
+      }
+      chromPlot.removeAllFeatureDataSets(false);
+      for (FeatureDataSet featureDataSet : features) {
+        chromPlot.addFeatureDataSetRandomColor(featureDataSet);
+      }
+    });
+
+    setStatus(TaskStatus.FINISHED);
+  }
+}

--- a/src/main/java/io/github/mzmine/modules/visualization/pseudospectrumvisualizer/PseudoSpectrumVisualizerPane.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/pseudospectrumvisualizer/PseudoSpectrumVisualizerPane.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2004-2023 The MZmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.visualization.pseudospectrumvisualizer;
+
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.datamodel.features.FeatureList.FeatureListAppliedMethod;
+import io.github.mzmine.datamodel.features.ModularFeature;
+import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.modules.dataprocessing.featdet_adapchromatogrambuilder.ADAPChromatogramBuilderParameters;
+import io.github.mzmine.modules.dataprocessing.filter_diams2.DiaMs2CorrParameters;
+import io.github.mzmine.modules.visualization.chromatogram.TICPlot;
+import io.github.mzmine.modules.visualization.chromatogram.TICPlotType;
+import io.github.mzmine.modules.visualization.chromatogram.TICVisualizerTab;
+import io.github.mzmine.modules.visualization.spectra.simplespectra.SpectraPlot;
+import io.github.mzmine.modules.visualization.spectra.simplespectra.SpectraVisualizerTab;
+import io.github.mzmine.parameters.ParameterUtils;
+import io.github.mzmine.parameters.parametertypes.selectors.ScanSelection;
+import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
+import io.github.mzmine.taskcontrol.TaskStatus;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javafx.geometry.Orientation;
+import javafx.scene.control.SplitPane;
+import javafx.scene.layout.BorderPane;
+
+public class PseudoSpectrumVisualizerPane extends SplitPane {
+
+  private static final Logger LOGGER = Logger.getLogger(
+      PseudoSpectrumVisualizerPane.class.getName());
+  private ModularFeature selectedFeature;
+  private Scan pseudoScan;
+  private RawDataFile rawDataFile;
+  private SpectraPlot spectraPlot;
+  private TICPlot ticPlot;
+
+
+  public PseudoSpectrumVisualizerPane(ModularFeature selectedFeature) {
+    super();
+    setOrientation(Orientation.VERTICAL);
+    this.selectedFeature = selectedFeature;
+    this.pseudoScan = selectedFeature.getMostIntenseFragmentScan();
+    this.rawDataFile = selectedFeature.getRawDataFile();
+    ticPlot = new TICPlot();
+    spectraPlot = new SpectraPlot();
+    init();
+  }
+
+  private void init() {
+    MZTolerance mzTolerance = extractMzToleranceFromPreviousMethods();
+    SpectraVisualizerTab spectraVisualizerTab = new SpectraVisualizerTab(rawDataFile, pseudoScan,
+        false);
+    spectraVisualizerTab.loadRawData(pseudoScan);
+    spectraPlot = spectraVisualizerTab.getSpectrumPlot();
+
+    TICVisualizerTab ticVisualizerTab = new TICVisualizerTab(new RawDataFile[]{rawDataFile},
+        TICPlotType.BASEPEAK, new ScanSelection(pseudoScan.getMSLevel()),
+        mzTolerance.getToleranceRange(selectedFeature.getMZ()), null, null);
+
+    ticPlot = ticVisualizerTab.getTICPlot();
+    ticPlot.removeAllDataSets();
+    ticPlot.setLegendVisible(false);
+    PseudoSpectrumFeatureDataSetCalculationTask task = new PseudoSpectrumFeatureDataSetCalculationTask(
+        rawDataFile, ticPlot,
+        pseudoScan, selectedFeature, mzTolerance);
+    MZmineCore.getTaskController().addTask(task);
+    BorderPane pnWrapSpectrum = new BorderPane();
+    BorderPane pnWrapChrom = new BorderPane();
+    task.addTaskStatusListener((task1, newStatus, oldStatus) -> {
+      if (newStatus.equals(TaskStatus.FINISHED)) {
+        MZmineCore.runLater(() -> {
+          pnWrapChrom.setCenter(ticPlot);
+          pnWrapSpectrum.setCenter(spectraPlot);
+          getItems().addAll(pnWrapSpectrum, pnWrapChrom);
+        });
+      }
+    });
+  }
+
+  /*
+   *  Extract mz tolerance from DIA correlation or GC clustering module
+   * */
+  private MZTolerance extractMzToleranceFromPreviousMethods() {
+
+    try {
+      Collection<FeatureListAppliedMethod> appliedMethods = Objects.requireNonNull(
+          selectedFeature.getFeatureList()).getAppliedMethods();
+        if (pseudoScan.getMSLevel() > 1) {
+
+          // for DIA correlation
+          return ParameterUtils.getValueFromAppliedMethods(appliedMethods,
+                  DiaMs2CorrParameters.class, DiaMs2CorrParameters.ms2ScanToScanAccuracy)
+              .orElse(new MZTolerance(0.005, 15));
+        } else {
+
+          // for GC-EI workflow use tolerance of chromatogram building, because deconvolution does
+          // not use mz tol parameter
+          boolean hasChromatograms = appliedMethods.stream().anyMatch(
+              appliedMethod -> appliedMethod.getParameters().getClass()
+                  .equals(ADAPChromatogramBuilderParameters.class));
+          if (hasChromatograms) {
+            return ParameterUtils.getValueFromAppliedMethods(appliedMethods,
+                ADAPChromatogramBuilderParameters.class,
+                ADAPChromatogramBuilderParameters.mzTolerance).orElse(new MZTolerance(0.005, 15));
+          }
+        }
+    } catch (Exception e) {
+      LOGGER.log(Level.WARNING,
+          " Could not extract previously used mz tolerance, will apply default settings. "
+              + e.getMessage());
+    }
+    return new MZTolerance(0.005, 15);
+  }
+
+}

--- a/src/main/java/io/github/mzmine/parameters/ParameterUtils.java
+++ b/src/main/java/io/github/mzmine/parameters/ParameterUtils.java
@@ -25,15 +25,19 @@
 
 package io.github.mzmine.parameters;
 
+import io.github.mzmine.datamodel.features.FeatureList.FeatureListAppliedMethod;
 import io.github.mzmine.parameters.parametertypes.EmbeddedParameter;
 import io.github.mzmine.parameters.parametertypes.EmbeddedParameterSet;
 import io.github.mzmine.parameters.parametertypes.filenames.FileNamesParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesParameter;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
 
 public class ParameterUtils {
 
@@ -161,5 +165,15 @@ public class ParameterUtils {
     }
 
     return true;
+  }
+
+  @NotNull
+  public static <T> Optional<T> getValueFromAppliedMethods(
+      Collection<FeatureListAppliedMethod> appliedMethods,
+      Class<? extends ParameterSet> parameterClass, Parameter<T> mzTolParameter) {
+    return appliedMethods.stream()
+        .filter(appliedMethod -> appliedMethod.getParameters().getClass().equals(parameterClass))
+        .findFirst().map(FeatureListAppliedMethod::getParameters)
+        .map(parameterSet -> parameterSet.getValue(mzTolParameter));
   }
 }

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/FormulaParameter.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/FormulaParameter.java
@@ -32,7 +32,7 @@ public class FormulaParameter extends StringParameter {
   private static final String formulaPattern = "^([A-Z][a-z]?[0-9]*)+$";
 
   public FormulaParameter() {
-    super("Formula", "The chemical formula in its neutral form, e.g. C6H12O6", null);
+    super("Formula", "The chemical formula in its neutral form, e.g. C6H12O6", "");
   }
 
   @Override
@@ -40,12 +40,8 @@ public class FormulaParameter extends StringParameter {
     boolean superCheck = super.checkValue(errorMessages);
 
     String value = getValue();
-    if (value == null) {
-      return superCheck;
-    }
-    value = value.trim();
 
-    if ((value != null) && (!value.matches(formulaPattern))) {
+    if (!value.trim().matches(formulaPattern)) {
       errorMessages.add("\"" + value + "\" is not a valid chemical formula");
       return false;
     }

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/StringParameter.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/StringParameter.java
@@ -29,23 +29,26 @@ import static java.util.Objects.requireNonNullElse;
 
 import io.github.mzmine.parameters.UserParameter;
 import java.util.Collection;
+import java.util.Objects;
 import javafx.scene.control.TextField;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.w3c.dom.Element;
 
 public class StringParameter implements UserParameter<String, TextField> {
 
-  protected String name, description, value;
+  protected final boolean sensitive;
+  protected String name, description;
+  protected @NotNull String value;
   protected int inputsize = 20;
   protected boolean valueRequired = true;
-  protected final boolean sensitive;
 
   public StringParameter(String name, String description) {
-    this(name, description, null);
+    this(name, description, "");
   }
 
   public StringParameter(String name, String description, boolean isSensitive) {
-    this(name, description, null, true, isSensitive);
+    this(name, description, "", true, isSensitive);
   }
 
   public StringParameter(String name, String description, int inputsize) {
@@ -55,16 +58,16 @@ public class StringParameter implements UserParameter<String, TextField> {
     this.sensitive = false;
   }
 
-  public StringParameter(String name, String description, String defaultValue) {
+  public StringParameter(String name, String description, @NotNull String defaultValue) {
     this(name, description, defaultValue, true, false);
   }
 
-  public StringParameter(String name, String description, String defaultValue,
+  public StringParameter(String name, String description, @NotNull String defaultValue,
       boolean valueRequired) {
     this(name, description, defaultValue, valueRequired, false);
   }
 
-  public StringParameter(String name, String description, String defaultValue,
+  public StringParameter(String name, String description, @NotNull String defaultValue,
       boolean valueRequired, boolean isSensitive) {
     this.name = name;
     this.description = description;
@@ -96,7 +99,7 @@ public class StringParameter implements UserParameter<String, TextField> {
   }
 
   @Override
-  public void setValue(String value) {
+  public void setValue(@NotNull String value) {
     this.value = value;
   }
 
@@ -126,14 +129,11 @@ public class StringParameter implements UserParameter<String, TextField> {
 
   @Override
   public void loadValueFromXML(Element xmlElement) {
-    value = xmlElement.getTextContent();
+    value = Objects.requireNonNullElse(xmlElement.getTextContent(), "");
   }
 
   @Override
   public void saveValueToXML(Element xmlElement) {
-    if (value == null) {
-      return;
-    }
     xmlElement.setTextContent(value);
   }
 
@@ -142,7 +142,7 @@ public class StringParameter implements UserParameter<String, TextField> {
     if (!valueRequired) {
       return true;
     }
-    if ((value == null) || (value.trim().length() == 0)) {
+    if (value.isBlank()) {
       errorMessages.add(name + " is not set properly");
       return false;
     }

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/StringParameter.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/StringParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -29,7 +29,6 @@ import static java.util.Objects.requireNonNullElse;
 
 import io.github.mzmine.parameters.UserParameter;
 import java.util.Collection;
-import java.util.Objects;
 import javafx.scene.control.TextField;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -39,7 +38,7 @@ public class StringParameter implements UserParameter<String, TextField> {
 
   protected final boolean sensitive;
   protected String name, description;
-  protected @NotNull String value;
+  protected @NotNull String value = "";
   protected int inputsize = 20;
   protected boolean valueRequired = true;
 
@@ -94,13 +93,13 @@ public class StringParameter implements UserParameter<String, TextField> {
   }
 
   @Override
-  public String getValue() {
+  public @NotNull String getValue() {
     return value;
   }
 
   @Override
-  public void setValue(@NotNull String value) {
-    this.value = value;
+  public void setValue(String value) {
+    this.value = requireNonNullElse(value, "");
   }
 
   @Override
@@ -129,7 +128,7 @@ public class StringParameter implements UserParameter<String, TextField> {
 
   @Override
   public void loadValueFromXML(Element xmlElement) {
-    value = Objects.requireNonNullElse(xmlElement.getTextContent(), "");
+    value = requireNonNullElse(xmlElement.getTextContent(), "");
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/SumformulaParameter.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/SumformulaParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -28,6 +28,7 @@ package io.github.mzmine.parameters.parametertypes;
 
 import io.github.msdk.MSDKRuntimeException;
 import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.interfaces.IMolecularFormula;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
@@ -44,18 +45,18 @@ public class SumformulaParameter extends StringParameter {
   private final IChemObjectBuilder builder = SilentChemObjectBuilder.getInstance();
 
   public SumformulaParameter(String name, String description) {
-    this(name, description, null);
+    this(name, description, "");
   }
 
   public SumformulaParameter(String name, String description, int inputsize) {
     super(name, description, inputsize);
   }
 
-  public SumformulaParameter(String name, String description, String defaultValue) {
+  public SumformulaParameter(String name, String description, @NotNull String defaultValue) {
     super(name, description, defaultValue);
   }
 
-  public SumformulaParameter(String name, String description, String defaultValue,
+  public SumformulaParameter(String name, String description, @NotNull String defaultValue,
       boolean valueRequired) {
     super(name, description, defaultValue, valueRequired);
   }
@@ -66,7 +67,7 @@ public class SumformulaParameter extends StringParameter {
   }
 
   public String getNameWithoutCharge() {
-    if (value == null || value.isEmpty()) {
+    if (value.isBlank()) {
       return "";
     }
 
@@ -80,7 +81,6 @@ public class SumformulaParameter extends StringParameter {
 
   /**
    * Full name with charge
-   *
    */
   public String getFullName() {
     return name;
@@ -88,7 +88,7 @@ public class SumformulaParameter extends StringParameter {
 
 
   public int getCharge() {
-    if (value == null || value.isEmpty()) {
+    if (value.isBlank()) {
       return 0;
     }
     // cutoff first -
@@ -114,16 +114,16 @@ public class SumformulaParameter extends StringParameter {
 
   /**
    * Monoisotopic mass of sum formula (not mass to charge!). Mass of electrons is subtracted/added
-   *
    */
   public double getMonoisotopicMass() {
-    if (value != null && !value.isEmpty()) {
-        double mz = MolecularFormulaManipulator.getMass(getFormula(), MolecularFormulaManipulator.MonoIsotopic);
-        mz -= getCharge() * ELECTRON_MASS;
-        if (value.startsWith("-")) {
-          mz = -mz;
-        }
-        return mz;
+    if (!value.isBlank()) {
+      double mz = MolecularFormulaManipulator.getMass(getFormula(),
+          MolecularFormulaManipulator.MonoIsotopic);
+      mz -= getCharge() * ELECTRON_MASS;
+      if (value.startsWith("-")) {
+        mz = -mz;
+      }
+      return mz;
     } else if (valueRequired) {
       throw new IllegalArgumentException("Could not set up formula. Invalid input.");
     }
@@ -131,31 +131,32 @@ public class SumformulaParameter extends StringParameter {
   }
 
   public IMolecularFormula getFormula() {
-    if (value != null && !value.isEmpty()) {
-      try {
-        String formString = this.value;
-        // cutoff first - (negative mz)
-        if (formString.startsWith("-")) {
-          formString = formString.substring(1);
-        }
-
-        //
-        int l = Math.max(formString.lastIndexOf('+'), formString.lastIndexOf('-'));
-        if (l == -1) {
-          return MolecularFormulaManipulator.getMajorIsotopeMolecularFormula(formString, builder);
-        } else {
-          String f = formString.substring(0, l);
-          String charge = formString.substring(l);
-          return MolecularFormulaManipulator.getMajorIsotopeMolecularFormula("[" + f + "]" + charge,
-              builder);
-        }
-      } catch (Exception e) {
+    if (value.isBlank()) {
+      if (valueRequired) {
         throw new MSDKRuntimeException("Could not set up formula. Invalid input.");
       }
-    } else if (valueRequired) {
+      return null;
+    }
+    try {
+      String formString = this.value;
+      // cutoff first - (negative mz)
+      if (formString.startsWith("-")) {
+        formString = formString.substring(1);
+      }
+
+      //
+      int l = Math.max(formString.lastIndexOf('+'), formString.lastIndexOf('-'));
+      if (l == -1) {
+        return MolecularFormulaManipulator.getMajorIsotopeMolecularFormula(formString, builder);
+      } else {
+        String f = formString.substring(0, l);
+        String charge = formString.substring(l);
+        return MolecularFormulaManipulator.getMajorIsotopeMolecularFormula("[" + f + "]" + charge,
+            builder);
+      }
+    } catch (Exception e) {
       throw new MSDKRuntimeException("Could not set up formula. Invalid input.");
     }
-    return null;
   }
 
   public boolean checkValue() {
@@ -167,7 +168,7 @@ public class SumformulaParameter extends StringParameter {
     if (!valueRequired) {
       return true;
     }
-    if ((value == null) || (value.trim().isEmpty())) {
+    if (value.isBlank()) {
       if (errorMessages != null) {
         errorMessages.add(name + " is not set properly");
       }

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/SumformulaParameter.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/SumformulaParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2023 The MZmine Development Team
+ * Copyright (c) 2004-2024 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -62,7 +62,7 @@ public class SumformulaParameter extends StringParameter {
   }
 
   @Override
-  public String getValue() {
+  public @NotNull String getValue() {
     return getNameWithoutCharge();
   }
 

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/FeatureSelectionComponent.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/FeatureSelectionComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -71,8 +71,8 @@ public class FeatureSelectionComponent extends BorderPane {
           new IntRangeParameter("ID", "Range of included peak IDs", false, null);
       final MZRangeParameter mzParameter = new MZRangeParameter(false);
       final RTRangeParameter rtParameter = new RTRangeParameter(false);
-      final StringParameter nameParameter =
-          new StringParameter("Name", "Peak identity name", null, false);
+      final StringParameter nameParameter = new StringParameter("Name", "Peak identity name", "",
+          false);
       SimpleParameterSet paramSet = new SimpleParameterSet(
           new Parameter[] {idParameter, mzParameter, rtParameter, nameParameter});
       ExitCode exitCode = paramSet.showSetupDialog(true);

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/ScanSelectionFiltersParameters.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/ScanSelectionFiltersParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -59,8 +59,8 @@ public class ScanSelectionFiltersParameters extends SimpleParameterSet {
 
   public static final StringParameter scanDefinitionParameter = new StringParameter(
       "Scan definition",
-      "Include only scans that match this scan definition. You can use wild cards, e.g. *FTMS*",
-      null, false);
+      "Include only scans that match this scan definition. You can use wild cards, e.g. *FTMS*", "",
+      false);
 
   public static final ComboParameter<PolarityType> polarityParameter = new ComboParameter<>(
       "Polarity", "Include only scans of this polarity",

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/tolerances/RTTolerance.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/tolerances/RTTolerance.java
@@ -44,6 +44,7 @@ public class RTTolerance {
   }
 
   // old constructor for compatibility with other mzmine branches and pull requests
+  @Deprecated
   public RTTolerance(final boolean isAbsolute, final float rtTolerance) {
     this(rtTolerance, isAbsolute ? Unit.MINUTES : Unit.PERCENT);
   }
@@ -63,19 +64,11 @@ public class RTTolerance {
 
   public Range<Float> getToleranceRange(final float rtValue) {
     // rtValue is given in minutes
-    float absoluteTolerance;
-    switch (unit) {
-      case SECONDS:
-        absoluteTolerance = tolerance / 60;
-        break;
-      case PERCENT:
-        absoluteTolerance = rtValue * (tolerance / 100);
-        break;
-      case MINUTES:
-      default:
-        absoluteTolerance = tolerance;
-        break;
-    }
+    float absoluteTolerance = switch (unit) {
+      case MINUTES -> tolerance;
+      case SECONDS -> tolerance / 60;
+      case PERCENT -> rtValue * (tolerance / 100);
+    };
     return Range.closed(rtValue - absoluteTolerance, rtValue + absoluteTolerance);
   }
 
@@ -107,16 +100,11 @@ public class RTTolerance {
 
     @Override
     public String toString() {
-      switch (this) {
-        case SECONDS:
-          return "seconds";
-        case MINUTES:
-          return "minutes";
-        case PERCENT:
-          return "%";
-        default:
-          throw new IllegalArgumentException();
-      }
+      return switch (this) {
+        case SECONDS -> "seconds";
+        case MINUTES -> "minutes";
+        case PERCENT -> "%";
+      };
     }
   }
 

--- a/src/main/java/io/github/mzmine/parameters/parametertypes/tolerances/RTToleranceParameter.java
+++ b/src/main/java/io/github/mzmine/parameters/parametertypes/tolerances/RTToleranceParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -26,12 +26,16 @@
 package io.github.mzmine.parameters.parametertypes.tolerances;
 
 import io.github.mzmine.parameters.UserParameter;
+import io.github.mzmine.parameters.parametertypes.tolerances.RTTolerance.Unit;
 import java.util.Collection;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import org.jetbrains.annotations.Nullable;
 import org.w3c.dom.Element;
 
 public class RTToleranceParameter implements UserParameter<RTTolerance, RTToleranceComponent> {
 
+  private final ObservableList<Unit> toleranceTypes;
   private String name, description;
   private RTTolerance value;
 
@@ -41,14 +45,29 @@ public class RTToleranceParameter implements UserParameter<RTTolerance, RTTolera
   }
 
   public RTToleranceParameter(String name, String description) {
+    this(name, description, FXCollections.observableArrayList(RTTolerance.Unit.values()));
+  }
+
+  public RTToleranceParameter(String name, String description,
+      ObservableList<Unit> toleranceTypes) {
     this.name = name;
     this.description = description;
+    this.toleranceTypes = toleranceTypes;
   }
 
   public RTToleranceParameter(String name, String description, RTTolerance defaultValue) {
     this.name = name;
     this.description = description;
     this.value = defaultValue;
+    this.toleranceTypes = FXCollections.observableArrayList(RTTolerance.Unit.values());
+  }
+
+  public RTToleranceParameter(String name, String description, RTTolerance defaultValue,
+      ObservableList<Unit> toleranceTypes) {
+    this.name = name;
+    this.description = description;
+    this.value = defaultValue;
+    this.toleranceTypes = toleranceTypes;
   }
 
   /**
@@ -69,12 +88,12 @@ public class RTToleranceParameter implements UserParameter<RTTolerance, RTTolera
 
   @Override
   public RTToleranceComponent createEditingComponent() {
-    return new RTToleranceComponent();
+    return new RTToleranceComponent(toleranceTypes);
   }
 
   @Override
   public RTToleranceParameter cloneParameter() {
-    RTToleranceParameter copy = new RTToleranceParameter(name, description);
+    RTToleranceParameter copy = new RTToleranceParameter(name, description, toleranceTypes);
     copy.setValue(this.getValue());
     return copy;
   }

--- a/src/main/java/io/github/mzmine/util/DataTypeUtils.java
+++ b/src/main/java/io/github/mzmine/util/DataTypeUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -127,10 +127,10 @@ public class DataTypeUtils {
   public static void copyTypes(FeatureList source, FeatureList target, boolean featureTypes,
       boolean rowTypes) {
     if (featureTypes) {
-      target.addFeatureType(source.getFeatureTypes().values());
+      target.addFeatureType(source.getFeatureTypes());
     }
     if (rowTypes) {
-      target.addRowType(source.getRowTypes().values());
+      target.addRowType(source.getRowTypes());
     }
   }
 

--- a/src/main/java/io/github/mzmine/util/FeatureListUtils.java
+++ b/src/main/java/io/github/mzmine/util/FeatureListUtils.java
@@ -460,11 +460,8 @@ public class FeatureListUtils {
   public static void transferRowTypes(FeatureList targetFlist,
       Collection<FeatureList> sourceFlists) {
     for (FeatureList sourceFlist : sourceFlists) {
-      for (Class<? extends DataType> value : sourceFlist.getRowTypes().keySet()) {
-        if (!targetFlist.hasRowType(value)) {
-          targetFlist.addRowType(sourceFlist.getRowTypes().get(value));
-        }
-      }
+      // uses a set so okay to use addAll
+      targetFlist.addRowType(sourceFlist.getRowTypes());
     }
   }
 

--- a/src/main/java/io/github/mzmine/util/FeatureUtils.java
+++ b/src/main/java/io/github/mzmine/util/FeatureUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -58,10 +58,10 @@ import io.github.mzmine.util.spectraldb.entry.SpectralDBAnnotation;
 import java.text.Format;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -489,7 +489,7 @@ public class FeatureUtils {
   public static List<CompoundDBAnnotation> extractAllCompoundAnnotations(
       FeatureListRow selectedRow) {
     final List<CompoundDBAnnotation> compoundAnnotations = new ArrayList<>();
-    final Collection<DataType> dataTypes = selectedRow.getTypes().values();
+    final Set<DataType> dataTypes = selectedRow.getTypes();
     for (DataType dataType : dataTypes) {
       if (dataType instanceof ListWithSubsType<?> listType && dataType instanceof AnnotationType) {
         final List<?> list = selectedRow.get(listType);
@@ -564,7 +564,7 @@ public class FeatureUtils {
     final Map<K, V> result = new HashMap<>();
 
     // get ALL DataTypes from the feature list
-    final Collection<DataType> dataTypes = featureListRow.getTypes().values();
+    final Set<DataType> dataTypes = featureListRow.getTypes();
 
     for (DataType<?> type : dataTypes) {
 

--- a/src/main/java/io/github/mzmine/util/ManualFeatureUtils.java
+++ b/src/main/java/io/github/mzmine/util/ManualFeatureUtils.java
@@ -46,10 +46,15 @@ public class ManualFeatureUtils {
    */
   public static ManualFeature pickFeatureManually(RawDataFile dataFile, Range<Float> rtRange,
       Range<Double> mzRange) {
+    return pickFeatureManually(dataFile, rtRange, mzRange, 1);
+  }
+
+  public static ManualFeature pickFeatureManually(RawDataFile dataFile, Range<Float> rtRange,
+      Range<Double> mzRange, int msLevel) {
     ManualFeature newFeature = new ManualFeature(dataFile);
     boolean dataPointFound = false;
 
-    Scan[] scanNumbers = dataFile.getScanNumbers(1, rtRange);
+    Scan[] scanNumbers = dataFile.getScanNumbers(msLevel, rtRange);
 
     for (Scan scan : scanNumbers) {
       // Find most intense m/z feature

--- a/src/main/java/io/github/mzmine/util/adap/ADAPInterface.java
+++ b/src/main/java/io/github/mzmine/util/adap/ADAPInterface.java
@@ -24,22 +24,23 @@
  */
 package io.github.mzmine.util.adap;
 
-import com.google.common.collect.Range;
 import dulab.adap.datamodel.BetterPeak;
 import dulab.adap.datamodel.Chromatogram;
 import dulab.adap.datamodel.Component;
 import dulab.adap.datamodel.Peak;
 import dulab.adap.datamodel.PeakInfo;
 import io.github.mzmine.datamodel.DataPoint;
-import io.github.mzmine.datamodel.FeatureStatus;
 import io.github.mzmine.datamodel.IsotopePattern;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.Scan;
-import io.github.mzmine.datamodel.featuredata.IonTimeSeries;
+import io.github.mzmine.datamodel.featuredata.FeatureDataUtils;
 import io.github.mzmine.datamodel.featuredata.impl.SimpleIonTimeSeries;
-import io.github.mzmine.datamodel.features.*;
-import io.github.mzmine.datamodel.impl.SimpleDataPoint;
-
+import io.github.mzmine.datamodel.features.Feature;
+import io.github.mzmine.datamodel.features.FeatureList;
+import io.github.mzmine.datamodel.features.FeatureListRow;
+import io.github.mzmine.datamodel.features.ModularFeature;
+import io.github.mzmine.datamodel.features.ModularFeatureList;
+import io.github.mzmine.datamodel.features.types.FeatureDataType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
@@ -88,8 +89,9 @@ public class ADAPInterface {
   }
 
   @NotNull
-  public static ModularFeature peakToFeature(@NotNull ModularFeatureList alignedFeatureList, FeatureList originalFeatureList,
-                                             @NotNull RawDataFile file, @NotNull BetterPeak peak) {
+  public static ModularFeature peakToFeature(@NotNull ModularFeatureList alignedFeatureList,
+      FeatureList originalFeatureList,
+      @NotNull RawDataFile file, @NotNull BetterPeak peak, FeatureListRow row) {
 
     Chromatogram chromatogram = peak.chromatogram;
 
@@ -111,14 +113,6 @@ public class ADAPInterface {
         break;
     }
 
-    // Calculate peak area
-    double area = 0.0;
-    for (int i = 1; i < chromatogram.length; ++i) {
-      double base = (chromatogram.xs[i] - chromatogram.xs[i - 1]) * 60d;
-      double height = 0.5 * (chromatogram.ys[i] + chromatogram.ys[i - 1]);
-      area += base * height;
-    }
-
     //Get mzs values from peak and intensities from chromatogram
     final double[] newMzs = new double[scanNumbers.size()];
     final double[] newIntensities = new double[scanNumbers.size()];
@@ -127,15 +121,18 @@ public class ADAPInterface {
       newIntensities[i] = chromatogram.ys[i];
     }
 
-    SimpleIonTimeSeries simpleIonTimeSeries = new SimpleIonTimeSeries(null, newMzs, newIntensities, scanNumbers);
-
-    return new ModularFeature(alignedFeatureList, file, simpleIonTimeSeries, FeatureStatus.ESTIMATED);
-
+    SimpleIonTimeSeries simpleIonTimeSeries = new SimpleIonTimeSeries(null, newMzs, newIntensities,
+        scanNumbers);
+    ModularFeature feature = new ModularFeature(alignedFeatureList, row.getFeature(file));
+    feature.set(FeatureDataType.class, simpleIonTimeSeries);
+    FeatureDataUtils.recalculateIonSeriesDependingTypes(feature);
+    return feature;
   }
 
   @NotNull
-  public static Feature peakToFeature(@NotNull ModularFeatureList featureList,FeatureList originalFeatureList,
-                                      @NotNull RawDataFile file, @NotNull Peak peak) {
+  public static Feature peakToFeature(@NotNull ModularFeatureList featureList,
+      FeatureList originalFeatureList,
+      @NotNull RawDataFile file, @NotNull Peak peak, FeatureListRow row) {
 
     NavigableMap<Double, Double> chromatogram = peak.getChromatogram();
 
@@ -151,6 +148,6 @@ public class ADAPInterface {
     BetterPeak betterPeak = new BetterPeak(peak.getInfo().peakID,
             new Chromatogram(retTimes, intensities), peak.getInfo());
 
-    return peakToFeature(featureList, originalFeatureList,file, betterPeak);
+    return peakToFeature(featureList, originalFeatureList, file, betterPeak, row);
   }
 }

--- a/src/main/java/io/github/mzmine/util/spectraldb/entry/SpectralLibrary.java
+++ b/src/main/java/io/github/mzmine/util/spectraldb/entry/SpectralLibrary.java
@@ -32,11 +32,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.stream.Stream;
 import javafx.collections.FXCollections;
-import javafx.collections.ObservableMap;
+import javafx.collections.ObservableSet;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -53,8 +53,7 @@ public class SpectralLibrary {
   // internals
   @Nullable
   private final MemoryMapStorage storage;
-  private final ObservableMap<Class<? extends DataType>, DataType> types = FXCollections.observableMap(
-      new LinkedHashMap<>());
+  private final ObservableSet<DataType> types = FXCollections.observableSet(new LinkedHashSet<>());
 
   public SpectralLibrary(@Nullable MemoryMapStorage storage, @NotNull File path) {
     this(storage, path.getName(), path);
@@ -100,18 +99,12 @@ public class SpectralLibrary {
     return getName();
   }
 
-  public MemoryMapStorage getStorage() {
+  public @Nullable MemoryMapStorage getStorage() {
     return storage;
   }
 
   public void addType(Collection<DataType> newTypes) {
-    for (DataType<?> type : newTypes) {
-      if (!types.containsKey(type.getClass())) {
-        // add row type - all rows will automatically generate a default property for this type in
-        // their data map
-        types.put(type.getClass(), type);
-      }
-    }
+    types.addAll(newTypes);
   }
 
   public void addType(@NotNull DataType<?>... types) {

--- a/src/test/java/IonIdentityTest.java
+++ b/src/test/java/IonIdentityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -149,16 +149,16 @@ public class IonIdentityTest {
       when(formula.getRDBE()).thenReturn(4.5f);
       IonIdentity ion = rowProtonated.getBestIonIdentity();
       ion.addMolFormula(formula);
-      assertEquals(0.9f, ion.getBestMolFormula().getIsotopeScore());
-      assertEquals(4.5f, ion.getBestMolFormula().getRDBE());
+      ResultFormula best = ion.getBestMolFormula().get();
+      assertEquals(0.9f, best.getIsotopeScore());
+      assertEquals(4.5f, best.getRDBE());
 
       // setting the formula should have updated the sub properties
       // test properties in ion identity
-      assertEquals(4.5f,
-          rowProtonated.get(IonIdentityListType.class).get(0).getBestMolFormula().getRDBE(),
+      best = rowProtonated.get(IonIdentityListType.class).get(0).getBestMolFormula().get();
+      assertEquals(4.5f, best.getRDBE(),
           "Cannot access formula specific types from sub types of IonIdentityModularType.class");
-      assertEquals(0.9f,
-          rowProtonated.get(IonIdentityListType.class).get(0).getBestMolFormula().getIsotopeScore(),
+      assertEquals(0.9f, best.getIsotopeScore(),
           "Cannot access formula specific types from sub types of IonIdentityModularType.class");
 
   }

--- a/src/test/java/io/github/mzmine/util/FeatureListUtilsTest.java
+++ b/src/test/java/io/github/mzmine/util/FeatureListUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -44,22 +44,34 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 
 @ExtendWith(MockitoExtension.class)
 class FeatureListUtilsTest {
 
-  @Mock
   RawDataFile raw;
 
   ModularFeatureList flist;
 
   List<FeatureListRow> rows;
 
+  private static AutoCloseable closeable;
+//
+//  @BeforeAll
+//  public static void openMocks() {
+//    closeable = MockitoAnnotations.openMocks(FeatureListUtilsTest.class);
+//  }
+//
+//  @AfterAll
+//  public static void releaseMocks() throws Exception {
+//    closeable.close();
+//  }
+
   @BeforeEach
   void setUp() {
+    raw = Mockito.mock(RawDataFile.class);
     flist = new ModularFeatureList("List", null, raw);
     rows = new ArrayList<>();
     rows.add(getRow(9f));


### PR DESCRIPTION
- Spectral decon algorithms now write results to pseudo spectrum.
- Spectra Matching now uses Pseudo Spectrum when set to MS1 (if pseudo spectrum is present)
- DIA ion shape context menu renamed to Show Pseudo spectrum. It now shows grouped EICs (MS1 or MSMS)
- Added optional steps to GC batch wizard: smoothing and rt calibration
- Now use local minimum resolver for GCMS workflow in wizard -> much faster
- Made EICs mandatory for curve resolution GC algorithm, because it is always required. Made sure in batch creation EIC feature list cannot be deleted and is picked via name pattern.