### PR TITLE
fix metadata import

### DIFF
--- a/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/ProjectMetadataColumnParameters.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/ProjectMetadataColumnParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -43,13 +43,18 @@ import org.jetbrains.annotations.Nullable;
 
 public class ProjectMetadataColumnParameters extends SimpleParameterSet {
 
-  private static final Logger logger = Logger.getLogger(
-      ProjectMetadataColumnParameters.class.getName());
   public static final StringParameter title = new StringParameter("Title",
       "Title of the new parameter", "", true, true);
-
   public static final TextParameter description = new TextParameter("Description",
       "Description of the new parameter", "", false);
+  public static final ComboParameter<AvailableTypes> valueType = new ComboParameter<>("Type",
+      "Type of the new parameter", AvailableTypes.values(), AvailableTypes.values()[0]);
+  private static final Logger logger = Logger.getLogger(
+      ProjectMetadataColumnParameters.class.getName());
+
+  public ProjectMetadataColumnParameters() {
+    super(new Parameter[]{title, description, valueType});
+  }
 
   /**
    * Order represents the order of value conversion in
@@ -107,9 +112,15 @@ public class ProjectMetadataColumnParameters extends SimpleParameterSet {
      */
     public static @Nullable AvailableTypes[] tryMap(final String[] values) {
       try {
-        AvailableTypes[] types = new AvailableTypes[values.length];
-        for (int i = 0; i < values.length; i++) {
-          types[i] = AvailableTypes.valueOf(values[i]);
+        // check if this is the type row. it starts with "TYPE"
+        if (values.length == 0 || !values[0].equalsIgnoreCase("type")) {
+          return null;
+        }
+
+        // type descriptions start in column 1
+        AvailableTypes[] types = new AvailableTypes[values.length - 1];
+        for (int i = 1; i < values.length; i++) {
+          types[i - 1] = AvailableTypes.valueOf(values[i]);
         }
         return types;
       } catch (Exception e) {
@@ -146,12 +157,5 @@ public class ProjectMetadataColumnParameters extends SimpleParameterSet {
         return null;
       }
     }
-  }
-
-  public static final ComboParameter<AvailableTypes> valueType = new ComboParameter<>("Type",
-      "Type of the new parameter", AvailableTypes.values(), AvailableTypes.values()[0]);
-
-  public ProjectMetadataColumnParameters() {
-    super(new Parameter[]{title, description, valueType});
   }
 }

--- a/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/io/ProjectMetadataExporter.java
+++ b/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/io/ProjectMetadataExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2023 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -62,9 +62,9 @@ public class ProjectMetadataExporter {
   private File chooseFile() {
     FileChooser fileChooser = new FileChooser();
     fileChooser.setTitle("Please select a file containing project parameter values for files.");
-    fileChooser.getExtensionFilters().addAll(new FileChooser.ExtensionFilter("All Files", "*.*"),
+    fileChooser.getExtensionFilters().addAll(new FileChooser.ExtensionFilter("tsv", "*.tsv"),
         new FileChooser.ExtensionFilter("text", "*.txt"),
-        new FileChooser.ExtensionFilter("tsv", "*.tsv"));
+        new FileChooser.ExtensionFilter("All Files", "*.*"));
 
     // setting the initial directory
     File currentFile = currentProject.getProjectFile();

--- a/src/main/java/io/github/mzmine/util/CSVParsingUtils.java
+++ b/src/main/java/io/github/mzmine/util/CSVParsingUtils.java
@@ -251,17 +251,22 @@ public class CSVParsingUtils {
   /**
    * Read data until end
    *
-   * @param sep separator
+   * @param sep             separator
+   * @param omitFirstColumn Omits the first column when parsing the file as it may be empty due to
+   *                        column descriptions.
    * @return list of rows
    * @throws IOException if read is unsuccessful
    */
-  public static List<String[]> readData(final BufferedReader reader, final String sep)
-      throws IOException {
+  public static List<String[]> readData(final BufferedReader reader, final String sep,
+      boolean omitFirstColumn) throws IOException {
     List<String[]> data = new ArrayList<>();
     String line;
     while ((line = reader.readLine()) != null) {
       String[] split = line.split(sep);
-      if (split.length > 0 && split[0].length() > 0) {
+      if (omitFirstColumn && split.length > 0) {
+        split = Arrays.copyOfRange(split, 1, split.length);
+      }
+      if (split.length > 0 && !split[0].isEmpty()) {
         data.add(split);
       }
     }
@@ -271,13 +276,15 @@ public class CSVParsingUtils {
   /**
    * Read data until end - then map to columns
    *
-   * @param sep separator
+   * @param sep             separator
+   * @param omitFirstColumn Omits the first column when parsing the file as it may be empty due to
+   *                        column descriptions.
    * @return array of [columns][rows]
    * @throws IOException if read is unsuccessful
    */
-  public static String[][] readDataMapToColumns(final BufferedReader reader, final String sep)
-      throws IOException {
-    List<String[]> rows = readData(reader, sep);
+  public static String[][] readDataMapToColumns(final BufferedReader reader, final String sep,
+      boolean omitFirstColumn) throws IOException {
+    List<String[]> rows = readData(reader, sep, true);
     // max columns
     int cols = rows.stream().mapToInt(a -> a.length).max().orElse(0);
 


### PR DESCRIPTION
apparently someone updated the metadata import to make it more flexible but killed it in the process :D.

Now it works again. @robinschmid Do we expect only "flexible" metadata or can it also not have the first column with the data description?

```
DESC				Run start time stamp of the sample
TYPE	TEXT	NUMBER	TEXT	DATETIME
TITLE	Filename	run	plant	run_date
	20210623_11_3B_1uL.raw	2.0	3	2021-06-24T14:00:08.052628200
	20210623_14_3C_1uL.raw	3.0	3	2021-06-24T15:00:03.440886500
	20210623_09_5A_1uL.raw	1.0	5	2021-06-24T13:20:11.009363400
	20210623_08_3A_1uL.raw	1.0	3	2021-06-24T13:00:12.667116200
	20210623_12_5B_1uL.raw	2.0	5	2021-06-24T14:20:06.693571700
	20210623_13_9B_1uL.raw	2.0	9	2021-06-24T14:40:04.966900400
	20210623_15_5C_1uL.raw	3.0	5	2021-06-24T15:20:02.031823700
	20210623_10_9A_1uL.raw	1.0	9	2021-06-24T13:40:09.494080200
	20210623_16_9C_1uL.raw	3.0	9	2021-06-24T15:40:02.690457200

```