### PR TITLE
revert jfreechart version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ ikonli-bootstrap = { module = "org.kordamp.ikonli:ikonli-bootstrapicons-pack", v
 graphstream-javafx = { module = "org.graphstream:gs-ui-javafx", version.ref = "graphstream" }
 graphstream-algo = { module = "org.graphstream:gs-algo", version.ref = "graphstream" }
 graphstream-core = "com.github.robinschmid:gs-core:45504f632f"
-jfree-core = "org.jfree:jfreechart:1.5.4"
+jfree-core = "org.jfree:jfreechart:1.5.3"
 jfree-fx = "org.jfree:org.jfree.chart.fx:2.0.1"
 jfree-fxgraphics = "org.jfree:org.jfree.fxgraphics2d:2.1.1"
 fxcharts = "eu.hansolo.fx:charts:21.0.7"

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/JFreeChartUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/JFreeChartUtils.java
@@ -37,7 +37,8 @@ public class JFreeChartUtils {
    * @return num datasets including null
    */
   public static int getDatasetCountNullable(XYPlot plot) {
-    return plot.getDatasets().size();
+    return plot.getDatasetCount();
+//    return plot.getDatasets().size();
   }
 
   /**

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/gui/javafx/EChartViewer.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/gui/javafx/EChartViewer.java
@@ -100,7 +100,7 @@ public class EChartViewer extends ChartViewer implements DatasetChangeListener {
   protected ZoomHistory zoomHistory;
   protected List<AxesRangeChangedListener> axesRangeListener;
   protected boolean isMouseZoomable = true;
-  protected boolean stickyZeroForRangeAxis = false;
+  protected boolean stickyZeroForRangeAxis = true;
   protected boolean standardGestures = true;
   // only for XYData (not for categoryPlots)
   protected boolean addZoomHistory = true;
@@ -111,7 +111,7 @@ public class EChartViewer extends ChartViewer implements DatasetChangeListener {
    * stickyZeroForRangeAxis = false <br> Graphics and data export menu are added
    */
   public EChartViewer() {
-    this(null, true, true, true, true, false);
+    this(null, true, true, true, true, true);
   }
 
   /**
@@ -121,7 +121,7 @@ public class EChartViewer extends ChartViewer implements DatasetChangeListener {
    * @param chart
    */
   public EChartViewer(JFreeChart chart) {
-    this(chart, true, true, true, true, false);
+    this(chart, true, true, true, true, true);
   }
 
   /**
@@ -135,7 +135,7 @@ public class EChartViewer extends ChartViewer implements DatasetChangeListener {
    */
   public EChartViewer(JFreeChart chart, boolean graphicsExportMenu, boolean dataExportMenu,
       boolean standardGestures) {
-    this(chart, graphicsExportMenu, dataExportMenu, standardGestures, false);
+    this(chart, graphicsExportMenu, dataExportMenu, standardGestures, true);
   }
 
   /**
@@ -280,19 +280,11 @@ public class EChartViewer extends ChartViewer implements DatasetChangeListener {
 
     if (chartPanel.getChart().getPlot() instanceof XYPlot) {
       // set sticky zero
-      if (stickyZeroForRangeAxis) {
-        ValueAxis rangeAxis = chartPanel.getChart().getXYPlot().getRangeAxis();
-        if (rangeAxis instanceof NumberAxis axis) {
-          axis.setAutoRangeIncludesZero(true);
-          axis.setAutoRange(true);
-          axis.setAutoRangeStickyZero(true);
-          axis.setRangeType(RangeType.POSITIVE);
-        }
-      }
+      setStickyZeroRangeAxis(this.stickyZeroForRangeAxis);
 
       Plot p = getChart().getPlot();
       if (addZoomHistory && p instanceof XYPlot && !(p instanceof CombinedDomainXYPlot
-                                                     || p instanceof CombinedRangeXYPlot)) {
+          || p instanceof CombinedRangeXYPlot)) {
         // zoom history
         zoomHistory = new ZoomHistory(this, 20);
 
@@ -339,6 +331,16 @@ public class EChartViewer extends ChartViewer implements DatasetChangeListener {
         }
       }
       //      mouseAdapter.addDebugHandler();
+    }
+  }
+
+  public void setStickyZeroRangeAxis(boolean stickyZeroForRangeAxis) {
+    ValueAxis rangeAxis = this.getChart().getXYPlot().getRangeAxis();
+    if (rangeAxis instanceof NumberAxis axis) {
+      axis.setAutoRangeIncludesZero(stickyZeroForRangeAxis);
+      axis.setAutoRangeStickyZero(stickyZeroForRangeAxis);
+      axis.setRangeType(stickyZeroForRangeAxis ? RangeType.POSITIVE : RangeType.FULL);
+      axis.setAutoRange(true);
     }
   }
 
@@ -417,8 +419,7 @@ public class EChartViewer extends ChartViewer implements DatasetChangeListener {
         XYDataset data = plot.getDataset(d);
         if (data == null) {
           continue;
-        }
-        else if (data instanceof XYZDataset xyz) {
+        } else if (data instanceof XYZDataset xyz) {
           int series = data.getSeriesCount();
           Object[][] model = new Object[series * 3][];
           for (int s = 0; s < series; s++) {

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/renderers/ColoredXYBarRenderer.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/renderers/ColoredXYBarRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -34,6 +34,7 @@ import java.awt.Paint;
 import java.awt.Shape;
 import java.awt.Stroke;
 import java.awt.geom.Rectangle2D;
+import java.util.logging.Logger;
 import org.jfree.chart.LegendItem;
 import org.jfree.chart.axis.ValueAxis;
 import org.jfree.chart.entity.EntityCollection;
@@ -56,6 +57,7 @@ public class ColoredXYBarRenderer extends XYBarRenderer {
   public static final float TRANSPARENCY = 0.8f;
   public static final AlphaComposite alphaComp =
       AlphaComposite.getInstance(AlphaComposite.SRC_OVER, TRANSPARENCY);
+  private static final Logger logger = Logger.getLogger(ColoredXYBarRenderer.class.getName());
   private static final long serialVersionUID = 1L;
 
   private boolean isTransparent;
@@ -300,4 +302,6 @@ public class ColoredXYBarRenderer extends XYBarRenderer {
     }
     return super.lookupSeriesPaint(series);
   }
+
+
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICDataSet.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICDataSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -406,14 +406,14 @@ public class TICDataSet extends AbstractTaskXYZDataset {
       processedScans++;
 
       // Refresh every REDRAW_INTERVAL ms.
-      synchronized (TICDataSet.class) {
+      /*synchronized (TICDataSet.class) {
 
         if (System.currentTimeMillis() - lastRedrawTime > REDRAW_INTERVAL) {
 
           refresh();
           lastRedrawTime = System.currentTimeMillis();
         }
-      }
+      }*/
     }
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/kendrickmassplot/KendrickMassPlotChart.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/kendrickmassplot/KendrickMassPlotChart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2023 The MZmine Development Team
+ * Copyright (c) 2004-2024 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -54,6 +54,7 @@ public class KendrickMassPlotChart extends EChartViewer {
       String colorScaleLabel, KendrickMassPlotXYZDataset dataset) {
     super(ChartFactory.createScatterPlot(title, xAxisLabel, yAxisLabel, dataset,
         PlotOrientation.VERTICAL, false, true, true));
+    setStickyZeroRangeAxis(false);
     this.colorScaleLabel = colorScaleLabel;
 
     EStandardChartTheme defaultChartTheme = MZmineCore.getConfiguration().getDefaultChartTheme();

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/scan_histogram/chart/HistogramPanel.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/scan_histogram/chart/HistogramPanel.java
@@ -27,6 +27,7 @@ package io.github.mzmine.modules.visualization.scan_histogram.chart;
 
 import io.github.mzmine.gui.chartbasics.ChartLogicsFX;
 import io.github.mzmine.gui.chartbasics.HistogramChartFactory;
+import io.github.mzmine.gui.chartbasics.JFreeChartUtils;
 import io.github.mzmine.gui.chartbasics.gui.javafx.EChartViewer;
 import io.github.mzmine.util.maths.Precision;
 import java.awt.event.ActionEvent;
@@ -84,16 +85,15 @@ public class HistogramPanel extends BorderPane {
   private final TextField txtPrecision;
   private final CheckBox cbGaussianFit;
   private final CheckBox cbKeepSameXaxis;
-
-  private EChartViewer pnHisto;
-  private String xLabel;
-  private HistogramData data;
   private final VBox boxSettings;
   private final VBox secondGaussian;
   private final HBox pnHistoSett;
   private final HBox xRanges;
   private final HBox yRanges;
   private final Executor exec;
+  private EChartViewer pnHisto;
+  private String xLabel;
+  private HistogramData data;
 
   /**
    * Create the dialog.
@@ -521,9 +521,9 @@ public class HistogramPanel extends BorderPane {
   }
 
   protected void hideGaussianCurve(XYPlot p) {
-    if (p.getDatasets().size() > 1) {
-      p.setRenderer(p.getDatasets().size() - 1, null);
-      p.setDataset(p.getDatasets().size() - 1, null);
+    if (JFreeChartUtils.getDatasetCountNullable(p) > 1) {
+      p.setRenderer(JFreeChartUtils.getDatasetCountNullable(p) - 1, null);
+      p.setDataset(JFreeChartUtils.getDatasetCountNullable(p) - 1, null);
     }
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/vankrevelendiagram/VanKrevelenDiagramChart.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/vankrevelendiagram/VanKrevelenDiagramChart.java
@@ -55,6 +55,7 @@ public class VanKrevelenDiagramChart extends EChartViewer {
   public VanKrevelenDiagramChart(String title, String xAxisLabel, String yAxisLabel, String colorScaleLabel, VanKrevelenDiagramXYZDataset dataset) {
     super(ChartFactory.createScatterPlot(title, xAxisLabel, yAxisLabel, dataset, PlotOrientation.VERTICAL, false, true, true));
     this.colorScaleLabel = colorScaleLabel;
+    setStickyZeroRangeAxis(false);
 
     EStandardChartTheme defaultChartTheme = MZmineCore.getConfiguration().getDefaultChartTheme();
     defaultChartTheme.apply(this);

--- a/mzmine-community/src/main/java/io/github/mzmine/util/dialogs/AxesSetupDialog.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/dialogs/AxesSetupDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -25,15 +25,10 @@
 
 package io.github.mzmine.util.dialogs;
 
-import java.util.logging.Logger;
-import javafx.stage.Window;
-import org.jetbrains.annotations.NotNull;
-import org.jfree.chart.axis.NumberAxis;
-import org.jfree.chart.axis.NumberTickUnit;
-import org.jfree.chart.axis.ValueAxis;
-import org.jfree.chart.plot.XYPlot;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.util.ExitCode;
+import java.util.Locale;
+import java.util.logging.Logger;
 import javafx.scene.Scene;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Button;
@@ -47,7 +42,13 @@ import javafx.scene.layout.GridPane;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
+import javafx.stage.Window;
 import javafx.util.converter.NumberStringConverter;
+import org.jetbrains.annotations.NotNull;
+import org.jfree.chart.axis.NumberAxis;
+import org.jfree.chart.axis.NumberTickUnit;
+import org.jfree.chart.axis.ValueAxis;
+import org.jfree.chart.plot.XYPlot;
 
 public class AxesSetupDialog extends Stage {
 
@@ -55,26 +56,20 @@ public class AxesSetupDialog extends Stage {
 
   private final ValueAxis xAxis;
   private final ValueAxis yAxis;
-
-  private ExitCode exitCode = ExitCode.UNKNOWN;
-
   private final DialogPane mainPane;
   private final Scene mainScene;
-
   // Buttons
   private final Button btnOK, btnApply, btnCancel;
-
   private final GridPane pnlLabelsAndFields;
   private final TextField fieldXMin;
   private final TextField fieldXMax;
   private final TextField fieldXTick;
-
   private final TextField fieldYMin;
   private final TextField fieldYMax;
   private final TextField fieldYTick;
-
   private final CheckBox checkXAutoRange, checkXAutoTick;
   private final CheckBox checkYAutoRange, checkYAutoTick;
+  private ExitCode exitCode = ExitCode.UNKNOWN;
 
   /**
    * Constructor
@@ -100,8 +95,8 @@ public class AxesSetupDialog extends Stage {
     xAxis = plot.getDomainAxis();
     yAxis = plot.getRangeAxis();
 
-    NumberStringConverter xConverter = new NumberStringConverter();
-    NumberStringConverter yConverter = new NumberStringConverter();
+    NumberStringConverter xConverter = new NumberStringConverter(Locale.US);
+    NumberStringConverter yConverter = new NumberStringConverter(Locale.US);
 
     if (xAxis instanceof NumberAxis)
       xConverter = new NumberStringConverter(((NumberAxis) xAxis).getNumberFormatOverride());


### PR DESCRIPTION
- new jfreechart version 1.5.4 caused spectra plot to glitch out
- new jfreechart version 1.5.4 caused color to change after the first label was rendered in SimpleCharts
- Range axis sticky zero behaviour was disabled by default in EChartViewer, but the sticky zero behaviour was not applied to the axis. the default jfree behaviour was to have sticky zero enabled. I set the default in EChartViewer to true and actually applied it to the plot. Disabled sticky zero for Kendrick and VanKrevelen