### PR TITLE
Fix high priority thread pool rejection

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/multithreaded/MultiThreadPeakFinderMainTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/multithreaded/MultiThreadPeakFinderMainTask.java
@@ -40,12 +40,12 @@ import io.github.mzmine.taskcontrol.AllTasksFinishedListener;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.taskcontrol.TaskPriority;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import io.github.mzmine.taskcontrol.utils.TaskUtils;
 import io.github.mzmine.util.MemoryMapStorage;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -155,16 +155,8 @@ class MultiThreadPeakFinderMainTask extends AbstractTask {
     };
 
     // start
-    MZmineCore.getTaskController().addTasks(tasks.toArray(AbstractTask[]::new));
-
-    // wait till finish
-    while (!(isCanceled() || isFinished())) {
-      try {
-        Thread.sleep(100);
-      } catch (InterruptedException e) {
-        logger.log(Level.SEVERE, "Error in GNPS export/submit task", e);
-      }
-    }
+    var wrappedTasks = MZmineCore.getTaskController().addTasks(tasks.toArray(AbstractTask[]::new));
+    TaskUtils.waitForTasksToFinish(thistask, wrappedTasks);
   }
 
   private int getMaxThreads() {

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/multithreaded/MultiThreadPeakFinderTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/multithreaded/MultiThreadPeakFinderTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2023 The MZmine Development Team
+ * Copyright (c) 2004-2024 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -192,7 +192,7 @@ class MultiThreadPeakFinderTask extends AbstractTask {
    */
   @Override
   public TaskPriority getTaskPriority() {
-    return TaskPriority.HIGH;
+    return TaskPriority.NORMAL;
   }
 
   public double getFinishedPercentage() {

--- a/taskcontroller/src/main/java/io/github/mzmine/taskcontrol/TaskController.java
+++ b/taskcontroller/src/main/java/io/github/mzmine/taskcontrol/TaskController.java
@@ -26,7 +26,7 @@
 package io.github.mzmine.taskcontrol;
 
 import io.github.mzmine.taskcontrol.impl.WrappedTask;
-import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -46,8 +46,11 @@ public sealed interface TaskController permits TaskControllerImpl {
       t.setPriority(8); // elevated priority
       return t;
     };
-    return new ThreadPoolExecutor(0, maxNumThreads, 120L, TimeUnit.SECONDS,
-        new SynchronousQueue<>(), threadFac);
+//    var executor = Executors.newWorkStealingPool(maxNumThreads);
+    var executor = new ThreadPoolExecutor(maxNumThreads, maxNumThreads, 120L,
+        TimeUnit.SECONDS, new LinkedBlockingQueue<>(), threadFac);
+    executor.allowCoreThreadTimeOut(true);
+    return executor;
   }
 
   /**

--- a/taskcontroller/src/main/java/io/github/mzmine/taskcontrol/TaskControllerImpl.java
+++ b/taskcontroller/src/main/java/io/github/mzmine/taskcontrol/TaskControllerImpl.java
@@ -29,10 +29,12 @@ import io.github.mzmine.taskcontrol.impl.WrappedTask;
 import java.util.Arrays;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -241,10 +243,14 @@ final class TaskControllerImpl implements TaskController {
       // Create a new thread if the task is high-priority or if we
       // have less then maximum # of threads running
 
-      var usedExecutor =
-          task.getTaskPriority() == TaskPriority.NORMAL ? executor : highPriorityExecutor;
-      Future<?> future = usedExecutor.submit(task);
-      task.setFuture(future);
+      try {
+        var usedExecutor =
+            task.getTaskPriority() == TaskPriority.NORMAL ? executor : highPriorityExecutor;
+        Future<?> future = usedExecutor.submit(task);
+        task.setFuture(future);
+      } catch (RejectedExecutionException e) {
+        logger.log(Level.SEVERE, e.getMessage(), e);
+      }
     }
 
     addSubmittedTasksToView(wrappedTasks);

--- a/taskcontroller/src/main/java/io/github/mzmine/taskcontrol/listeners/MasterTaskCancelListener.java
+++ b/taskcontroller/src/main/java/io/github/mzmine/taskcontrol/listeners/MasterTaskCancelListener.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2004-2024 The MZmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.taskcontrol.listeners;
+
+import io.github.mzmine.taskcontrol.AbstractTask;
+import io.github.mzmine.taskcontrol.Task;
+import io.github.mzmine.taskcontrol.TaskStatus;
+import io.github.mzmine.taskcontrol.TaskStatusListener;
+import io.github.mzmine.taskcontrol.impl.WrappedTask;
+
+/**
+ * Listener that is added to a master thread to also cancel or error out sub tasks
+ */
+public class MasterTaskCancelListener implements TaskStatusListener {
+
+  private final WrappedTask[] subTasks;
+
+  public MasterTaskCancelListener(WrappedTask[] subTasks) {
+    this.subTasks = subTasks;
+  }
+
+  @Override
+  public void taskStatusChanged(final Task master, final TaskStatus newStatus,
+      final TaskStatus oldStatus) {
+    if (master.isCanceled()) {
+      for (final WrappedTask wrappedTask : subTasks) {
+        if (wrappedTask.isFinished()) {
+          continue;
+        }
+
+        if (wrappedTask.getActualTask() instanceof AbstractTask at) {
+          at.setStatus(newStatus);
+        } else {
+          wrappedTask.cancel();
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The high priority threadpool was supposed to be cached - so that idle threads will be terminated after a timeout. Core pool size needs to be set to the number of max threads here otherwise no new threads are started. Also the used Queue for cached blocks until a thread takes the work.

```
if fewer than corePoolSize threads are running, a new thread is created to handle the request, even if other worker threads are idle. Else if fewer than maximumPoolSize threads are running, a new thread will be created to handle the request only if the queue is full
```